### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Claude Trading Skills
 
+[![Run in Smithery](https://smithery.ai/badge/skills/tradermonty)](https://smithery.ai/skills?ns=tradermonty&utm_source=github&utm_medium=badge)
+
+
 Curated Claude skills for equity investors and traders. Each skill bundles prompts, knowledge, and optional helper scripts so Claude can assist with systematic backtesting, market analysis, technical charting, economic calendar monitoring, and US stock research. The repository packages skills for both Claude's web app and Claude Code workflows.
 
 日本語版READMEは[`README.ja.md`](README.ja.md)をご覧ください。


### PR DESCRIPTION
## Add skill discoverability badge

Your 18 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/tradermonty)](https://smithery.ai/skills?ns=tradermonty&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.