### PR TITLE
Improve backtest-expert skill (score 88 -> 100)

### DIFF
--- a/skills/backtest-expert/references/methodology.md
+++ b/skills/backtest-expert/references/methodology.md
@@ -92,6 +92,16 @@ Create 2D heat maps varying two parameters simultaneously:
 - Frequent need to re-optimize parameters
 - Parameters that change dramatically between periods
 
+### Profit Factor Scoring in Evaluation Script
+
+The evaluation script scores profit factor (PF) as one component of the Risk Management dimension (0-8 points out of 20). The mapping uses continuous linear interpolation with integer truncation:
+
+- PF < 1.0 → 0 points (unprofitable)
+- PF 1.0 to 3.0 → linear 0 to 8 points: `int((PF - 1.0) / 2.0 * 8)`
+- PF >= 3.0 → 8 points (capped)
+
+The `int()` truncation creates discrete 1-point steps (e.g., PF 1.25→1 pt, PF 1.50→2 pt). This is intentional — integer scoring avoids false precision from fractional differences in profit factor.
+
 ## 4. Slippage and Friction Modeling
 
 ### Realistic Slippage Assumptions
@@ -186,7 +196,7 @@ Use 1.5-2x typical slippage estimates for stress testing:
 ### Curve-Fitting (Over-Optimization)
 
 **Warning signs**:
-- Too many parameters (>5-7)
+- Too many parameters (>=7 triggers over-optimization flag; <=4 is ideal, 5-6 acceptable)
 - Highly specific parameter values (e.g., RSI = 37.3)
 - Perfect backtest results
 - Large performance drop in validation period

--- a/skills/backtest-expert/scripts/evaluate_backtest.py
+++ b/skills/backtest-expert/scripts/evaluate_backtest.py
@@ -276,6 +276,8 @@ def validate_inputs(
     avg_win_pct: float,
     avg_loss_pct: float,
     max_drawdown_pct: float,
+    years_tested: int,
+    num_parameters: int,
 ) -> None:
     """Validate evaluation inputs at system boundary. Raises ValueError."""
     if total_trades < 0:
@@ -288,6 +290,10 @@ def validate_inputs(
         raise ValueError("avg_loss_pct must be >= 0")
     if max_drawdown_pct < 0:
         raise ValueError("max_drawdown_pct must be >= 0")
+    if years_tested < 0:
+        raise ValueError("years_tested must be >= 0")
+    if num_parameters < 0:
+        raise ValueError("num_parameters must be >= 0")
 
 
 def evaluate(
@@ -301,7 +307,7 @@ def evaluate(
     slippage_tested: bool,
 ) -> dict:
     """Run full 5-dimension evaluation and return structured result."""
-    validate_inputs(total_trades, win_rate, avg_win_pct, avg_loss_pct, max_drawdown_pct)
+    validate_inputs(total_trades, win_rate, avg_win_pct, avg_loss_pct, max_drawdown_pct, years_tested, num_parameters)
     d1 = score_sample_size(total_trades)
     d2 = score_expectancy(win_rate, avg_win_pct, avg_loss_pct)
     d3 = score_risk_management(max_drawdown_pct, win_rate, avg_win_pct, avg_loss_pct)

--- a/skills/backtest-expert/scripts/tests/test_evaluate_backtest.py
+++ b/skills/backtest-expert/scripts/tests/test_evaluate_backtest.py
@@ -67,6 +67,24 @@ class TestInputValidation:
                 num_parameters=3, slippage_tested=True,
             )
 
+    def test_negative_years_tested(self, evaluator_module):
+        """Negative years_tested raises ValueError."""
+        with pytest.raises(ValueError, match="years_tested"):
+            evaluator_module.evaluate(
+                total_trades=100, win_rate=60, avg_win_pct=2.0,
+                avg_loss_pct=1.0, max_drawdown_pct=15, years_tested=-1,
+                num_parameters=3, slippage_tested=True,
+            )
+
+    def test_negative_num_parameters(self, evaluator_module):
+        """Negative num_parameters raises ValueError."""
+        with pytest.raises(ValueError, match="num_parameters"):
+            evaluator_module.evaluate(
+                total_trades=100, win_rate=60, avg_win_pct=2.0,
+                avg_loss_pct=1.0, max_drawdown_pct=15, years_tested=5,
+                num_parameters=-2, slippage_tested=True,
+            )
+
     def test_boundary_win_rate_zero(self, evaluator_module):
         """win_rate=0 is valid (all losses)."""
         result = evaluator_module.evaluate(


### PR DESCRIPTION
## Summary
- Skill: `backtest-expert`
- Score: 88 → 100
- Generated by skill self-improvement loop

## Improvements
- Added profit factor scoring documentation to methodology reference
- Clarified over-optimization parameter thresholds (>=7 triggers flag)
- Added input validation for `years_tested` and `num_parameters` (negative value checks)
- Added corresponding test cases for new validation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)