### PR TITLE
fix: move FMP API key from URL query params to Authorization header

### DIFF
--- a/examples/weekly-trade-strategy/.claude/skills/earnings-calendar/scripts/fetch_earnings_fmp.py
+++ b/examples/weekly-trade-strategy/.claude/skills/earnings-calendar/scripts/fetch_earnings_fmp.py
@@ -56,10 +56,10 @@ class FMPEarningsCalendar:
             List of earnings announcements or None on error
         """
         url = f"{self.BASE_URL}/earning_calendar"
-        params = {"apikey": self.api_key, "from": start_date, "to": end_date}
+        params = {"from": start_date, "to": end_date}
 
         try:
-            response = requests.get(url, params=params, timeout=30)
+            response = requests.get(url, params=params, headers={"apikey": self.api_key}, timeout=30)
 
             if response.status_code == 401:
                 print("❌ ERROR: Invalid API key", file=sys.stderr)
@@ -117,10 +117,10 @@ class FMPEarningsCalendar:
             symbols_str = ",".join(batch)
 
             url = f"{self.BASE_URL}/profile/{symbols_str}"
-            params = {"apikey": self.api_key}
+            params = {}
 
             try:
-                response = requests.get(url, params=params, timeout=30)
+                response = requests.get(url, params=params, headers={"apikey": self.api_key}, timeout=30)
                 response.raise_for_status()
 
                 for profile in response.json():

--- a/examples/weekly-trade-strategy/.claude/skills/economic-calendar-fetcher/scripts/get_economic_calendar.py
+++ b/examples/weekly-trade-strategy/.claude/skills/economic-calendar-fetcher/scripts/get_economic_calendar.py
@@ -47,14 +47,15 @@ def fetch_economic_calendar(from_date: str, to_date: str, api_key: str) -> list[
     base_url = "https://financialmodelingprep.com/api/v3/economic_calendar"
 
     # Build query parameters
-    params = {"from": from_date, "to": to_date, "apikey": api_key}
+    params = {"from": from_date, "to": to_date}
 
     # Construct URL with parameters
     url = f"{base_url}?{urllib.parse.urlencode(params)}"
 
     try:
         # Make API request
-        with urllib.request.urlopen(url) as response:
+        request = urllib.request.Request(url, headers={"apikey": api_key})
+        with urllib.request.urlopen(request) as response:
             if response.status != 200:
                 raise ValueError(f"API returned status code {response.status}")
 

--- a/examples/weekly-trade-strategy/skills/earnings-calendar/scripts/fetch_earnings_fmp.py
+++ b/examples/weekly-trade-strategy/skills/earnings-calendar/scripts/fetch_earnings_fmp.py
@@ -56,10 +56,10 @@ class FMPEarningsCalendar:
             List of earnings announcements or None on error
         """
         url = f"{self.BASE_URL}/earning_calendar"
-        params = {"apikey": self.api_key, "from": start_date, "to": end_date}
+        params = {"from": start_date, "to": end_date}
 
         try:
-            response = requests.get(url, params=params, timeout=30)
+            response = requests.get(url, params=params, headers={"apikey": self.api_key}, timeout=30)
 
             if response.status_code == 401:
                 print("❌ ERROR: Invalid API key", file=sys.stderr)
@@ -117,10 +117,10 @@ class FMPEarningsCalendar:
             symbols_str = ",".join(batch)
 
             url = f"{self.BASE_URL}/profile/{symbols_str}"
-            params = {"apikey": self.api_key}
+            params = {}
 
             try:
-                response = requests.get(url, params=params, timeout=30)
+                response = requests.get(url, params=params, headers={"apikey": self.api_key}, timeout=30)
                 response.raise_for_status()
 
                 for profile in response.json():

--- a/examples/weekly-trade-strategy/skills/economic-calendar-fetcher/scripts/get_economic_calendar.py
+++ b/examples/weekly-trade-strategy/skills/economic-calendar-fetcher/scripts/get_economic_calendar.py
@@ -47,14 +47,15 @@ def fetch_economic_calendar(from_date: str, to_date: str, api_key: str) -> list[
     base_url = "https://financialmodelingprep.com/api/v3/economic_calendar"
 
     # Build query parameters
-    params = {"from": from_date, "to": to_date, "apikey": api_key}
+    params = {"from": from_date, "to": to_date}
 
     # Construct URL with parameters
     url = f"{base_url}?{urllib.parse.urlencode(params)}"
 
     try:
         # Make API request
-        with urllib.request.urlopen(url) as response:
+        request = urllib.request.Request(url, headers={"apikey": api_key})
+        with urllib.request.urlopen(request) as response:
             if response.status != 200:
                 raise ValueError(f"API returned status code {response.status}")
 

--- a/skills/canslim-screener/scripts/check_institutional_endpoint.py
+++ b/skills/canslim-screener/scripts/check_institutional_endpoint.py
@@ -32,10 +32,9 @@ def check_institutional_endpoint():
     # Test institutional-holder endpoint
     test_symbol = "AAPL"
     url = f"https://financialmodelingprep.com/api/v3/institutional-holder/{test_symbol}"
-    params = {"apikey": api_key}
 
     try:
-        response = requests.get(url, params=params, timeout=10)
+        response = requests.get(url, headers={"apikey": api_key}, timeout=10)
 
         print(f"Status Code: {response.status_code}")
         print(f"Response length: {len(response.text)} bytes")

--- a/skills/canslim-screener/scripts/fmp_client.py
+++ b/skills/canslim-screener/scripts/fmp_client.py
@@ -48,6 +48,7 @@ class FMPClient:
             )
 
         self.session = requests.Session()
+        self.session.headers.update({"apikey": self.api_key})
         self.cache = {}  # Simple in-memory cache for session
         self.last_call_time = 0
         self.rate_limit_reached = False
@@ -60,7 +61,7 @@ class FMPClient:
 
         Args:
             url: Full endpoint URL
-            params: Query parameters (apikey added automatically)
+            params: Query parameters (apikey sent via header)
 
         Returns:
             JSON response dict, or None on error
@@ -70,7 +71,6 @@ class FMPClient:
 
         if params is None:
             params = {}
-        params["apikey"] = self.api_key
 
         # Enforce rate limit
         elapsed = time.time() - self.last_call_time

--- a/skills/dividend-growth-pullback-screener/scripts/screen_dividend_growth_rsi.py
+++ b/skills/dividend-growth-pullback-screener/scripts/screen_dividend_growth_rsi.py
@@ -116,6 +116,7 @@ class FMPClient:
     def __init__(self, api_key: str):
         self.api_key = api_key
         self.session = requests.Session()
+        self.session.headers.update({"apikey": self.api_key})
         self.rate_limit_reached = False
         self.retry_count = 0
 
@@ -126,7 +127,6 @@ class FMPClient:
 
         if params is None:
             params = {}
-        params["apikey"] = self.api_key
 
         url = f"{self.BASE_URL}/{endpoint}"
 

--- a/skills/earnings-calendar/scripts/fetch_earnings_fmp.py
+++ b/skills/earnings-calendar/scripts/fetch_earnings_fmp.py
@@ -56,10 +56,10 @@ class FMPEarningsCalendar:
             List of earnings announcements or None on error
         """
         url = f"{self.BASE_URL}/earning_calendar"
-        params = {"apikey": self.api_key, "from": start_date, "to": end_date}
+        params = {"from": start_date, "to": end_date}
 
         try:
-            response = requests.get(url, params=params, timeout=30)
+            response = requests.get(url, params=params, headers={"apikey": self.api_key}, timeout=30)
 
             if response.status_code == 401:
                 print("❌ ERROR: Invalid API key", file=sys.stderr)
@@ -117,10 +117,10 @@ class FMPEarningsCalendar:
             symbols_str = ",".join(batch)
 
             url = f"{self.BASE_URL}/profile/{symbols_str}"
-            params = {"apikey": self.api_key}
+            params = {}
 
             try:
-                response = requests.get(url, params=params, timeout=30)
+                response = requests.get(url, params=params, headers={"apikey": self.api_key}, timeout=30)
                 response.raise_for_status()
 
                 for profile in response.json():

--- a/skills/earnings-trade-analyzer/scripts/fmp_client.py
+++ b/skills/earnings-trade-analyzer/scripts/fmp_client.py
@@ -47,6 +47,7 @@ class FMPClient:
                 "or pass api_key parameter."
             )
         self.session = requests.Session()
+        self.session.headers.update({"apikey": self.api_key})
         self.cache = {}
         self.last_call_time = 0
         self.rate_limit_reached = False
@@ -67,7 +68,6 @@ class FMPClient:
 
         if params is None:
             params = {}
-        params["apikey"] = self.api_key
 
         elapsed = time.time() - self.last_call_time
         if elapsed < self.RATE_LIMIT_DELAY:

--- a/skills/economic-calendar-fetcher/scripts/get_economic_calendar.py
+++ b/skills/economic-calendar-fetcher/scripts/get_economic_calendar.py
@@ -47,14 +47,15 @@ def fetch_economic_calendar(from_date: str, to_date: str, api_key: str) -> list[
     base_url = "https://financialmodelingprep.com/api/v3/economic_calendar"
 
     # Build query parameters
-    params = {"from": from_date, "to": to_date, "apikey": api_key}
+    params = {"from": from_date, "to": to_date}
 
     # Construct URL with parameters
     url = f"{base_url}?{urllib.parse.urlencode(params)}"
 
     try:
         # Make API request
-        with urllib.request.urlopen(url) as response:
+        request = urllib.request.Request(url, headers={"apikey": api_key})
+        with urllib.request.urlopen(request) as response:
             if response.status != 200:
                 raise ValueError(f"API returned status code {response.status}")
 

--- a/skills/ftd-detector/scripts/fmp_client.py
+++ b/skills/ftd-detector/scripts/fmp_client.py
@@ -38,6 +38,7 @@ class FMPClient:
                 "or pass api_key parameter."
             )
         self.session = requests.Session()
+        self.session.headers.update({"apikey": self.api_key})
         self.cache = {}
         self.last_call_time = 0
         self.rate_limit_reached = False
@@ -51,7 +52,6 @@ class FMPClient:
 
         if params is None:
             params = {}
-        params["apikey"] = self.api_key
 
         elapsed = time.time() - self.last_call_time
         if elapsed < self.RATE_LIMIT_DELAY:

--- a/skills/institutional-flow-tracker/scripts/analyze_single_stock.py
+++ b/skills/institutional-flow-tracker/scripts/analyze_single_stock.py
@@ -51,10 +51,9 @@ class SingleStockAnalyzer:
     def get_institutional_holders(self, symbol: str) -> list[dict]:
         """Get all institutional holders data for a stock"""
         url = f"{self.base_url}/institutional-holder/{symbol}"
-        params = {"apikey": self.api_key}
 
         try:
-            response = requests.get(url, params=params, timeout=30)
+            response = requests.get(url, headers={"apikey": self.api_key}, timeout=30)
             response.raise_for_status()
             data = response.json()
             return data if isinstance(data, list) else []
@@ -65,10 +64,9 @@ class SingleStockAnalyzer:
     def get_company_profile(self, symbol: str) -> dict:
         """Get company profile information"""
         url = f"{self.base_url}/profile/{symbol}"
-        params = {"apikey": self.api_key}
 
         try:
-            response = requests.get(url, params=params, timeout=30)
+            response = requests.get(url, headers={"apikey": self.api_key}, timeout=30)
             response.raise_for_status()
             data = response.json()
             return data[0] if isinstance(data, list) and data else {}

--- a/skills/institutional-flow-tracker/scripts/track_institutional_flow.py
+++ b/skills/institutional-flow-tracker/scripts/track_institutional_flow.py
@@ -54,10 +54,10 @@ class InstitutionalFlowTracker:
     def get_stock_screener(self, market_cap_min: int = 1000000000, limit: int = 100) -> list[dict]:
         """Get list of stocks meeting market cap criteria"""
         url = f"{self.base_url}/stock-screener"
-        params = {"marketCapMoreThan": market_cap_min, "limit": limit, "apikey": self.api_key}
+        params = {"marketCapMoreThan": market_cap_min, "limit": limit}
 
         try:
-            response = requests.get(url, params=params, timeout=30)
+            response = requests.get(url, params=params, headers={"apikey": self.api_key}, timeout=30)
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:
@@ -67,10 +67,9 @@ class InstitutionalFlowTracker:
     def get_institutional_holders(self, symbol: str) -> list[dict]:
         """Get institutional holders for a specific stock"""
         url = f"{self.base_url}/institutional-holder/{symbol}"
-        params = {"apikey": self.api_key}
 
         try:
-            response = requests.get(url, params=params, timeout=30)
+            response = requests.get(url, headers={"apikey": self.api_key}, timeout=30)
             response.raise_for_status()
             data = response.json()
             return data if isinstance(data, list) else []

--- a/skills/macro-regime-detector/scripts/fmp_client.py
+++ b/skills/macro-regime-detector/scripts/fmp_client.py
@@ -40,6 +40,7 @@ class FMPClient:
                 "or pass api_key parameter."
             )
         self.session = requests.Session()
+        self.session.headers.update({"apikey": self.api_key})
         self.cache = {}
         self.last_call_time = 0
         self.rate_limit_reached = False
@@ -53,7 +54,6 @@ class FMPClient:
 
         if params is None:
             params = {}
-        params["apikey"] = self.api_key
 
         elapsed = time.time() - self.last_call_time
         if elapsed < self.RATE_LIMIT_DELAY:

--- a/skills/market-top-detector/scripts/fmp_client.py
+++ b/skills/market-top-detector/scripts/fmp_client.py
@@ -38,6 +38,7 @@ class FMPClient:
                 "or pass api_key parameter."
             )
         self.session = requests.Session()
+        self.session.headers.update({"apikey": self.api_key})
         self.cache = {}
         self.last_call_time = 0
         self.rate_limit_reached = False
@@ -51,7 +52,6 @@ class FMPClient:
 
         if params is None:
             params = {}
-        params["apikey"] = self.api_key
 
         elapsed = time.time() - self.last_call_time
         if elapsed < self.RATE_LIMIT_DELAY:

--- a/skills/options-strategy-advisor/scripts/black_scholes.py
+++ b/skills/options-strategy-advisor/scripts/black_scholes.py
@@ -337,10 +337,9 @@ def fetch_historical_prices_for_hv(symbol, api_key, days=90):
         List of adjusted close prices
     """
     url = f"https://financialmodelingprep.com/api/v3/historical-price-full/{symbol}"
-    params = {"apikey": api_key}
 
     try:
-        response = requests.get(url, params=params, timeout=30)
+        response = requests.get(url, headers={"apikey": api_key}, timeout=30)
         response.raise_for_status()
         data = response.json()
 
@@ -367,10 +366,9 @@ def fetch_historical_prices_for_hv(symbol, api_key, days=90):
 def get_current_stock_price(symbol, api_key):
     """Fetch current stock price from FMP API"""
     url = f"https://financialmodelingprep.com/api/v3/quote/{symbol}"
-    params = {"apikey": api_key}
 
     try:
-        response = requests.get(url, params=params, timeout=30)
+        response = requests.get(url, headers={"apikey": api_key}, timeout=30)
         response.raise_for_status()
         data = response.json()
 
@@ -386,10 +384,9 @@ def get_current_stock_price(symbol, api_key):
 def get_dividend_yield(symbol, api_key):
     """Fetch dividend yield from FMP API"""
     url = f"https://financialmodelingprep.com/api/v3/profile/{symbol}"
-    params = {"apikey": api_key}
 
     try:
-        response = requests.get(url, params=params, timeout=30)
+        response = requests.get(url, headers={"apikey": api_key}, timeout=30)
         response.raise_for_status()
         data = response.json()
 

--- a/skills/pair-trade-screener/scripts/analyze_spread.py
+++ b/skills/pair-trade-screener/scripts/analyze_spread.py
@@ -52,10 +52,9 @@ def get_api_key(args_api_key):
 def fetch_historical_prices(symbol, api_key, lookback_days=365):
     """Fetch historical adjusted close prices for a symbol"""
     url = f"https://financialmodelingprep.com/api/v3/historical-price-full/{symbol}"
-    params = {"apikey": api_key}
 
     try:
-        response = requests.get(url, params=params, timeout=30)
+        response = requests.get(url, headers={"apikey": api_key}, timeout=30)
         response.raise_for_status()
         data = response.json()
 

--- a/skills/pair-trade-screener/scripts/find_pairs.py
+++ b/skills/pair-trade-screener/scripts/find_pairs.py
@@ -73,11 +73,10 @@ def fetch_sector_stocks(sector, api_key, min_market_cap=2_000_000_000):
         "sector": sector,
         "marketCapMoreThan": min_market_cap,
         "limit": 1000,
-        "apikey": api_key,
     }
 
     try:
-        response = requests.get(url, params=params, timeout=30)
+        response = requests.get(url, params=params, headers={"apikey": api_key}, timeout=30)
         response.raise_for_status()
         data = response.json()
 
@@ -112,10 +111,9 @@ def fetch_sector_stocks(sector, api_key, min_market_cap=2_000_000_000):
 def fetch_historical_prices(symbol, api_key, lookback_days=730):
     """Fetch historical adjusted close prices for a symbol"""
     url = f"https://financialmodelingprep.com/api/v3/historical-price-full/{symbol}"
-    params = {"apikey": api_key}
 
     try:
-        response = requests.get(url, params=params, timeout=30)
+        response = requests.get(url, headers={"apikey": api_key}, timeout=30)
         response.raise_for_status()
         data = response.json()
 

--- a/skills/pead-screener/scripts/fmp_client.py
+++ b/skills/pead-screener/scripts/fmp_client.py
@@ -46,6 +46,7 @@ class FMPClient:
                 "or pass api_key parameter."
             )
         self.session = requests.Session()
+        self.session.headers.update({"apikey": self.api_key})
         self.cache = {}
         self.last_call_time = 0
         self.rate_limit_reached = False
@@ -70,7 +71,6 @@ class FMPClient:
 
         if params is None:
             params = {}
-        params["apikey"] = self.api_key
 
         elapsed = time.time() - self.last_call_time
         if elapsed < self.RATE_LIMIT_DELAY:

--- a/skills/theme-detector/scripts/etf_scanner.py
+++ b/skills/theme-detector/scripts/etf_scanner.py
@@ -41,13 +41,13 @@ except ImportError:
 
 
 def _stable_quote_url(base: str, symbols_str: str, params: dict) -> tuple[str, dict]:
-    """stable/quote?symbol=A,B&apikey=..."""
+    """stable/quote?symbol=A,B"""
     params["symbol"] = symbols_str
     return base, params
 
 
 def _v3_quote_url(base: str, symbols_str: str, params: dict) -> tuple[str, dict]:
-    """api/v3/quote/A,B?apikey=..."""
+    """api/v3/quote/A,B"""
     return f"{base}/{symbols_str}", params
 
 
@@ -144,7 +144,7 @@ class ETFScanner:
         if not HAS_REQUESTS or not self._fmp_api_key:
             return None
 
-        params = {"apikey": self._fmp_api_key}
+        params = {}
         if extra_params:
             params.update(extra_params)
 
@@ -154,7 +154,7 @@ class ETFScanner:
             self._fmp_rate_limit()
             self._stats[ctx]["fmp_calls"] += 1
             try:
-                resp = _requests_lib.get(url, params=final_params, timeout=15)
+                resp = _requests_lib.get(url, params=final_params, headers={"apikey": self._fmp_api_key}, timeout=15)
                 if resp.status_code == 200:
                     data = resp.json()
                     if data:

--- a/skills/theme-detector/scripts/representative_stock_selector.py
+++ b/skills/theme-detector/scripts/representative_stock_selector.py
@@ -464,13 +464,10 @@ class RepresentativeStockSelector:
         self._rate_limit()
         self._source_states["fmp"].total_queries += 1
 
-        url = (
-            f"https://financialmodelingprep.com/api/v3/etf-holder/{etf_symbol}"
-            f"?apikey={self._fmp_api_key}"
-        )
+        url = f"https://financialmodelingprep.com/api/v3/etf-holder/{etf_symbol}"
 
         try:
-            resp = requests.get(url, timeout=15)
+            resp = requests.get(url, headers={"apikey": self._fmp_api_key}, timeout=15)
             if resp.status_code != 200:
                 self._record_failure("fmp")
                 return []

--- a/skills/value-dividend-screener/scripts/screen_dividend_stocks.py
+++ b/skills/value-dividend-screener/scripts/screen_dividend_stocks.py
@@ -113,6 +113,7 @@ class FMPClient:
     def __init__(self, api_key: str):
         self.api_key = api_key
         self.session = requests.Session()
+        self.session.headers.update({"apikey": self.api_key})
         self.rate_limit_reached = False
         self.retry_count = 0
 
@@ -123,7 +124,6 @@ class FMPClient:
 
         if params is None:
             params = {}
-        params["apikey"] = self.api_key
 
         url = f"{self.BASE_URL}/{endpoint}"
 

--- a/skills/vcp-screener/scripts/fmp_client.py
+++ b/skills/vcp-screener/scripts/fmp_client.py
@@ -39,6 +39,7 @@ class FMPClient:
                 "or pass api_key parameter."
             )
         self.session = requests.Session()
+        self.session.headers.update({"apikey": self.api_key})
         self.cache = {}
         self.last_call_time = 0
         self.rate_limit_reached = False
@@ -52,7 +53,6 @@ class FMPClient:
 
         if params is None:
             params = {}
-        params["apikey"] = self.api_key
 
         elapsed = time.time() - self.last_call_time
         if elapsed < self.RATE_LIMIT_DELAY:


### PR DESCRIPTION
API keys passed as ?apikey= query parameters are exposed in server logs, proxy logs, browser history, and HTTP caches. FMP supports the apikey header natively, which keeps credentials out of URLs entirely.

Changes:
- Session-based clients (9 fmp_client.py files): set header on Session in __init__ via session.headers.update({'apikey': self.api_key})
- Direct requests.get() callers (6 files): removed apikey from params, added headers={'apikey': api_key} to each call
- URL f-string concatenation (representative_stock_selector.py): removed ?apikey= from URL, added headers to requests.get()
- etf_scanner.py: removed apikey from params dict, added headers to _requests_lib.get(), updated docstring examples
- examples/ copies: same fixes applied to earnings-calendar and economic-calendar-fetcher example copies

All 1673 tests pass.