### PR TITLE
Improve pead-screener skill (score 86 -> 100)

### DIFF
--- a/skills/pead-screener/SKILL.md
+++ b/skills/pead-screener/SKILL.md
@@ -18,6 +18,9 @@ Screen post-earnings gap-up stocks for PEAD (Post-Earnings Announcement Drift) p
 ## Prerequisites
 
 - FMP API key (set `FMP_API_KEY` environment variable or pass `--api-key`)
+  ```bash
+  export FMP_API_KEY=your_api_key_here
+  ```
 - Free tier (250 calls/day) is sufficient for default screening
 - For Mode B: earnings-trade-analyzer JSON output file with schema_version "1.0"
 


### PR DESCRIPTION
## Summary
- Skill: `pead-screener`
- Score: 86 -> 100

## Improvements
- API key is documented, but no copy-paste setup command is shown. -> Add an explicit example like `export FMP_API_KEY=...`.

Generated by skill self-improvement loop.