### PR TITLE
fix: add stable/v3 endpoint fallback for FMP legacy API deprecation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -175,7 +175,7 @@
         "filename": "skills/market-top-detector/scripts/tests/test_fmp_client.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 17
       }
     ],
     "skills/portfolio-manager/scripts/check_alpaca_connection.py": [
@@ -222,5 +222,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T04:56:42Z"
+  "generated_at": "2026-03-23T22:25:16Z"
 }

--- a/skills/canslim-screener/scripts/fmp_client.py
+++ b/skills/canslim-screener/scripts/fmp_client.py
@@ -24,6 +24,43 @@ except ImportError:
     sys.exit(1)
 
 
+# --- FMP endpoint fallback: stable (new users) -> v3 (legacy users) ---
+
+
+def _stable_quote_url(base, symbols_str, params):
+    """stable/quote?symbol=^GSPC"""
+    params["symbol"] = symbols_str
+    return base, params
+
+
+def _v3_quote_url(base, symbols_str, params):
+    """api/v3/quote/^GSPC"""
+    return f"{base}/{symbols_str}", params
+
+
+def _stable_hist_url(base, symbols_str, params):
+    """stable/historical-price-full?symbol=^GSPC&timeseries=80"""
+    params["symbol"] = symbols_str
+    return base, params
+
+
+def _v3_hist_url(base, symbols_str, params):
+    """api/v3/historical-price-full/^GSPC?timeseries=80"""
+    return f"{base}/{symbols_str}", params
+
+
+_FMP_ENDPOINTS = {
+    "quote": [
+        ("https://financialmodelingprep.com/stable/quote", _stable_quote_url),
+        ("https://financialmodelingprep.com/api/v3/quote", _v3_quote_url),
+    ],
+    "historical": [
+        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
+    ],
+}
+
+
 class FMPClient:
     """Client for Financial Modeling Prep API with rate limiting and caching"""
 
@@ -55,13 +92,16 @@ class FMPClient:
         self.retry_count = 0
         self.max_retries = 1
 
-    def _rate_limited_get(self, url: str, params: Optional[dict] = None) -> Optional[dict]:
+    def _rate_limited_get(
+        self, url: str, params: Optional[dict] = None, quiet: bool = False
+    ) -> Optional[dict]:
         """
         Make rate-limited GET request with retry logic
 
         Args:
             url: Full endpoint URL
             params: Query parameters (apikey sent via header)
+            quiet: If True, suppress non-429 error messages (used by fallback)
 
         Returns:
             JSON response dict, or None on error
@@ -91,7 +131,7 @@ class FMPClient:
                 if self.retry_count <= self.max_retries:
                     print("WARNING: Rate limit exceeded. Waiting 60 seconds...", file=sys.stderr)
                     time.sleep(60)
-                    return self._rate_limited_get(url, params)
+                    return self._rate_limited_get(url, params, quiet=quiet)
                 else:
                     print(
                         "ERROR: Daily API rate limit reached. Stopping analysis.", file=sys.stderr
@@ -100,15 +140,61 @@ class FMPClient:
                     return None
 
             else:
-                print(
-                    f"ERROR: API request failed: {response.status_code} - {response.text[:200]}",
-                    file=sys.stderr,
-                )
+                if not quiet:
+                    print(
+                        f"ERROR: API request failed: {response.status_code} - {response.text[:200]}",
+                        file=sys.stderr,
+                    )
                 return None
 
         except requests.exceptions.RequestException as e:
             print(f"ERROR: Request exception: {e}", file=sys.stderr)
             return None
+
+    def _request_with_fallback(self, endpoint_key, symbols_str, extra_params=None):
+        """Try stable endpoint first, fall back to v3 for legacy users."""
+        params = dict(extra_params) if extra_params else {}
+        endpoints = _FMP_ENDPOINTS[endpoint_key]
+        is_single = "," not in symbols_str
+
+        for i, (base_url, url_builder) in enumerate(endpoints):
+            url, final_params = url_builder(base_url, symbols_str, dict(params))
+            is_last = i == len(endpoints) - 1
+            data = self._rate_limited_get(url, final_params, quiet=not is_last)
+            if not data:
+                continue
+
+            if endpoint_key == "quote":
+                if not isinstance(data, list) or len(data) == 0:
+                    continue
+                # Single-symbol: verify returned symbol matches request
+                if is_single and not any(
+                    q.get("symbol", "").replace("-", ".") == symbols_str.replace("-", ".")
+                    for q in data
+                ):
+                    continue
+
+            if endpoint_key == "historical":
+                if not isinstance(data, dict):
+                    continue
+                if "historicalStockList" in data:
+                    norm = symbols_str.replace("-", ".")
+                    for entry in data["historicalStockList"]:
+                        if entry.get("symbol", "").replace("-", ".") == norm:
+                            return {
+                                "symbol": entry.get("symbol"),
+                                "historical": entry.get("historical", []),
+                            }
+                    continue
+                elif "historical" not in data:
+                    continue
+                # Single-symbol: verify returned symbol matches request
+                elif is_single and data.get("symbol"):
+                    if data["symbol"].replace("-", ".") != symbols_str.replace("-", "."):
+                        continue
+
+            return data
+        return None
 
     def get_income_statement(
         self, symbol: str, period: str = "quarter", limit: int = 8
@@ -165,9 +251,7 @@ class FMPClient:
         if cache_key in self.cache:
             return self.cache[cache_key]
 
-        url = f"{self.BASE_URL}/quote/{symbols}"
-
-        data = self._rate_limited_get(url)
+        data = self._request_with_fallback("quote", symbols)
 
         if data:
             self.cache[cache_key] = data
@@ -195,10 +279,7 @@ class FMPClient:
         if cache_key in self.cache:
             return self.cache[cache_key]
 
-        url = f"{self.BASE_URL}/historical-price-full/{symbol}"
-        params = {"timeseries": days}
-
-        data = self._rate_limited_get(url, params)
+        data = self._request_with_fallback("historical", symbol, {"timeseries": days})
 
         if data:
             self.cache[cache_key] = data

--- a/skills/canslim-screener/scripts/tests/test_fmp_fallback.py
+++ b/skills/canslim-screener/scripts/tests/test_fmp_fallback.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""
+Tests for FMP stable/v3 endpoint fallback in canslim-screener.
+
+Tier A (4): Fallback logic
+Tier B (4): Response normalization
+Tier B+ (2): Shape validation
+Caller regression (2): screen_canslim.py behavior on failure
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_client():
+    """Create FMPClient with a fake API key."""
+    with patch.dict(os.environ, {"FMP_API_KEY": "test_key"}):  # pragma: allowlist secret
+        from fmp_client import FMPClient
+
+        client = FMPClient(api_key="test_key")
+    return client
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    """Create a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.text = text
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Tier A — Fallback logic (4 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLogic:
+    """Verify stable-first, v3-fallback behavior."""
+
+    def test_quote_stable_success(self):
+        """Stable 200 returns data; v3 is never called."""
+        client = _make_client()
+        stable_resp = _mock_response(200, [{"symbol": "^GSPC", "price": 5000}])
+
+        call_count = {"n": 0}
+
+        def fake_get(url, params=None, timeout=30):
+            call_count["n"] += 1
+            if "stable" in url:
+                return stable_resp
+            pytest.fail("v3 endpoint should not be called")
+
+        client.session.get = fake_get
+        result = client.get_quote("^GSPC")
+        assert result == [{"symbol": "^GSPC", "price": 5000}]
+        assert call_count["n"] == 1
+
+    def test_quote_stable_403_falls_back_to_v3(self):
+        """Stable 403 → v3 200 → returns v3 data."""
+        client = _make_client()
+        stable_resp = _mock_response(403, None, "Forbidden")
+        v3_resp = _mock_response(200, [{"symbol": "^GSPC", "price": 5100}])
+
+        def fake_get(url, params=None, timeout=30):
+            if "stable" in url:
+                return stable_resp
+            return v3_resp
+
+        client.session.get = fake_get
+        result = client.get_quote("^GSPC")
+        assert result == [{"symbol": "^GSPC", "price": 5100}]
+
+    def test_quote_both_fail(self):
+        """Both endpoints 403 → returns None."""
+        client = _make_client()
+        resp_403 = _mock_response(403, None, "Forbidden")
+
+        client.session.get = MagicMock(return_value=resp_403)
+        result = client.get_quote("^GSPC")
+        assert result is None
+
+    def test_historical_fallback_to_v3(self):
+        """Stable 403 → v3 200 → returns v3 historical data."""
+        client = _make_client()
+        stable_resp = _mock_response(403, None, "Forbidden")
+        v3_data = {"symbol": "^GSPC", "historical": [{"date": "2026-03-20", "close": 5000}]}
+        v3_resp = _mock_response(200, v3_data)
+
+        def fake_get(url, params=None, timeout=30):
+            if "stable" in url:
+                return stable_resp
+            return v3_resp
+
+        client.session.get = fake_get
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result is not None
+        assert "historical" in result
+        assert result["historical"][0]["close"] == 5000
+
+
+# ---------------------------------------------------------------------------
+# Tier B — Response normalization (4 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestResponseNormalization:
+    """Verify response shape handling for stable vs v3 formats."""
+
+    def test_historical_stable_v3_format_passthrough(self):
+        """Stable returns v3-like {"historical": [...]} → returned as-is."""
+        client = _make_client()
+        data = {"symbol": "^GSPC", "historical": [{"date": "2026-03-20", "close": 5000}]}
+        resp = _mock_response(200, data)
+        client.session.get = MagicMock(return_value=resp)
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result == data
+
+    def test_historical_stable_batch_format_exact_match(self):
+        """Stable returns historicalStockList with matching symbol → normalized."""
+        client = _make_client()
+        batch_data = {
+            "historicalStockList": [
+                {
+                    "symbol": "^GSPC",
+                    "historical": [{"date": "2026-03-20", "close": 5000}],
+                }
+            ]
+        }
+        resp = _mock_response(200, batch_data)
+        client.session.get = MagicMock(return_value=resp)
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result is not None
+        assert result["symbol"] == "^GSPC"
+        assert result["historical"] == [{"date": "2026-03-20", "close": 5000}]
+
+    def test_historical_stable_batch_no_match_falls_back_to_v3(self):
+        """Stable batch has wrong symbol → continue to v3 → v3 200."""
+        client = _make_client()
+        batch_data = {"historicalStockList": [{"symbol": "SPY", "historical": [{"close": 500}]}]}
+        stable_resp = _mock_response(200, batch_data)
+        v3_data = {"symbol": "^GSPC", "historical": [{"close": 5000}]}
+        v3_resp = _mock_response(200, v3_data)
+
+        def fake_get(url, params=None, timeout=30):
+            if "stable" in url:
+                return stable_resp
+            return v3_resp
+
+        client.session.get = fake_get
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result is not None
+        assert result["historical"][0]["close"] == 5000
+
+    def test_historical_batch_no_match_returns_none_when_v3_also_fails(self):
+        """Stable batch no match + v3 403 → returns None."""
+        client = _make_client()
+        batch_data = {"historicalStockList": [{"symbol": "SPY", "historical": [{"close": 500}]}]}
+        stable_resp = _mock_response(200, batch_data)
+        v3_resp = _mock_response(403, None, "Forbidden")
+
+        def fake_get(url, params=None, timeout=30):
+            if "stable" in url:
+                return stable_resp
+            return v3_resp
+
+        client.session.get = fake_get
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tier B+ — Shape validation (2 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestShapeValidation:
+    """Reject truthy-but-wrong-shape responses."""
+
+    def test_quote_rejects_non_list_response(self):
+        """Stable returns truthy dict → skipped, falls back to v3."""
+        client = _make_client()
+        error_data = {"Error Message": "Invalid API KEY"}
+        stable_resp = _mock_response(200, error_data)
+        v3_data = [{"symbol": "^GSPC", "price": 5000}]
+        v3_resp = _mock_response(200, v3_data)
+
+        def fake_get(url, params=None, timeout=30):
+            if "stable" in url:
+                return stable_resp
+            return v3_resp
+
+        client.session.get = fake_get
+        result = client.get_quote("^GSPC")
+        assert result == v3_data
+
+    def test_historical_rejects_non_dict_response(self):
+        """Stable returns truthy list → skipped, falls back to v3."""
+        client = _make_client()
+        stable_resp = _mock_response(200, [1, 2, 3])
+        v3_data = {"symbol": "^GSPC", "historical": [{"close": 5000}]}
+        v3_resp = _mock_response(200, v3_data)
+
+        def fake_get(url, params=None, timeout=30):
+            if "stable" in url:
+                return stable_resp
+            return v3_resp
+
+        client.session.get = fake_get
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result == v3_data
+
+
+# ---------------------------------------------------------------------------
+# Symbol mismatch protection (3 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolMismatch:
+    """Reject responses where returned symbol doesn't match the request."""
+
+    def test_quote_symbol_mismatch_falls_back(self):
+        """Single-symbol quote returning wrong symbol is rejected."""
+        client = _make_client()
+        wrong = _mock_response(200, [{"symbol": "SPY", "price": 500.0}])
+        correct = _mock_response(200, [{"symbol": "^GSPC", "price": 5000.0}])
+        client.session.get = MagicMock(side_effect=[wrong, correct])
+
+        result = client.get_quote("^GSPC")
+        assert result == [{"symbol": "^GSPC", "price": 5000.0}]
+        assert client.session.get.call_count == 2
+
+    def test_historical_symbol_mismatch_falls_back(self):
+        """Single-symbol historical returning wrong symbol is rejected."""
+        client = _make_client()
+        wrong = _mock_response(200, {"symbol": "SPY", "historical": [{"close": 500}]})
+        correct = _mock_response(200, {"symbol": "^GSPC", "historical": [{"close": 5000}]})
+        client.session.get = MagicMock(side_effect=[wrong, correct])
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result["symbol"] == "^GSPC"
+        assert client.session.get.call_count == 2
+
+    def test_batch_quote_skips_symbol_check(self):
+        """Multi-symbol (batch) quote does not apply symbol mismatch check."""
+        client = _make_client()
+        batch_data = [{"symbol": "^GSPC", "price": 5000}, {"symbol": "^VIX", "price": 20}]
+        resp = _mock_response(200, batch_data)
+        client.session.get = MagicMock(return_value=resp)
+
+        result = client.get_quote("^GSPC,^VIX")
+        assert result == batch_data
+        assert client.session.get.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Caller regression (2 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestCallerRegression:
+    """Verify screen_canslim.py behavior when FMP endpoints fail."""
+
+    def test_canslim_exits_on_quote_failure(self):
+        """get_quote("^GSPC") → None causes sys.exit(1)."""
+        with patch.dict(os.environ, {"FMP_API_KEY": "test_key"}):  # pragma: allowlist secret
+            from fmp_client import FMPClient
+
+            with patch.object(FMPClient, "get_quote", return_value=None):
+                with patch("sys.argv", ["screen_canslim.py", "--max-candidates", "1"]):
+                    import screen_canslim
+
+                    with pytest.raises(SystemExit) as exc_info:
+                        screen_canslim.main()
+                    assert exc_info.value.code == 1
+
+    def test_canslim_continues_on_historical_failure(self, capsys):
+        """get_historical_prices("^GSPC") → None prints EMA fallback warning and continues."""
+        with patch.dict(os.environ, {"FMP_API_KEY": "test_key"}):  # pragma: allowlist secret
+            from fmp_client import FMPClient
+
+            mock_quote = [
+                {
+                    "symbol": "^GSPC",
+                    "price": 5000.0,
+                    "yearHigh": 5200.0,
+                    "yearLow": 4200.0,
+                    "changesPercentage": 0.5,
+                }
+            ]
+            mock_vix = [{"symbol": "^VIX", "price": 15.0}]
+
+            def mock_get_quote(symbols):
+                if "^GSPC" in symbols and "^VIX" not in symbols:
+                    return mock_quote
+                if "^VIX" in symbols:
+                    return mock_vix
+                return mock_quote
+
+            with (
+                patch.object(FMPClient, "get_quote", side_effect=mock_get_quote),
+                patch.object(FMPClient, "get_historical_prices", return_value=None),
+                patch.object(FMPClient, "get_income_statement", return_value=None),
+                patch.object(FMPClient, "get_profile", return_value=None),
+                patch.object(FMPClient, "get_institutional_holders", return_value=None),
+                patch(
+                    "sys.argv", ["screen_canslim.py", "--max-candidates", "1", "--universe", "AAPL"]
+                ),
+            ):
+                import screen_canslim
+
+                # Should NOT raise SystemExit — historical failure is non-fatal
+                try:
+                    screen_canslim.main()
+                except SystemExit:
+                    pytest.fail("screen_canslim.main() should not exit when historical prices fail")
+
+            captured = capsys.readouterr()
+            assert "EMA fallback" in captured.out or "historical data unavailable" in captured.out

--- a/skills/ftd-detector/scripts/fmp_client.py
+++ b/skills/ftd-detector/scripts/fmp_client.py
@@ -24,6 +24,43 @@ except ImportError:
     sys.exit(1)
 
 
+# --- FMP endpoint fallback: stable (new users) -> v3 (legacy users) ---
+
+
+def _stable_quote_url(base, symbols_str, params):
+    """stable/quote?symbol=^GSPC"""
+    params["symbol"] = symbols_str
+    return base, params
+
+
+def _v3_quote_url(base, symbols_str, params):
+    """api/v3/quote/^GSPC"""
+    return f"{base}/{symbols_str}", params
+
+
+def _stable_hist_url(base, symbols_str, params):
+    """stable/historical-price-full?symbol=^GSPC&timeseries=80"""
+    params["symbol"] = symbols_str
+    return base, params
+
+
+def _v3_hist_url(base, symbols_str, params):
+    """api/v3/historical-price-full/^GSPC?timeseries=80"""
+    return f"{base}/{symbols_str}", params
+
+
+_FMP_ENDPOINTS = {
+    "quote": [
+        ("https://financialmodelingprep.com/stable/quote", _stable_quote_url),
+        ("https://financialmodelingprep.com/api/v3/quote", _v3_quote_url),
+    ],
+    "historical": [
+        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
+    ],
+}
+
+
 class FMPClient:
     """Client for Financial Modeling Prep API with rate limiting and caching"""
 
@@ -46,7 +83,9 @@ class FMPClient:
         self.max_retries = 1
         self.api_calls_made = 0
 
-    def _rate_limited_get(self, url: str, params: Optional[dict] = None) -> Optional[dict]:
+    def _rate_limited_get(
+        self, url: str, params: Optional[dict] = None, quiet: bool = False
+    ) -> Optional[dict]:
         if self.rate_limit_reached:
             return None
 
@@ -70,20 +109,66 @@ class FMPClient:
                 if self.retry_count <= self.max_retries:
                     print("WARNING: Rate limit exceeded. Waiting 60 seconds...", file=sys.stderr)
                     time.sleep(60)
-                    return self._rate_limited_get(url, params)
+                    return self._rate_limited_get(url, params, quiet=quiet)
                 else:
                     print("ERROR: Daily API rate limit reached.", file=sys.stderr)
                     self.rate_limit_reached = True
                     return None
             else:
-                print(
-                    f"ERROR: API request failed: {response.status_code} - {response.text[:200]}",
-                    file=sys.stderr,
-                )
+                if not quiet:
+                    print(
+                        f"ERROR: API request failed: {response.status_code} - {response.text[:200]}",
+                        file=sys.stderr,
+                    )
                 return None
         except requests.exceptions.RequestException as e:
             print(f"ERROR: Request exception: {e}", file=sys.stderr)
             return None
+
+    def _request_with_fallback(self, endpoint_key, symbols_str, extra_params=None):
+        """Try stable endpoint first, fall back to v3 for legacy users."""
+        params = dict(extra_params) if extra_params else {}
+        endpoints = _FMP_ENDPOINTS[endpoint_key]
+        is_single = "," not in symbols_str
+
+        for i, (base_url, url_builder) in enumerate(endpoints):
+            url, final_params = url_builder(base_url, symbols_str, dict(params))
+            is_last = i == len(endpoints) - 1
+            data = self._rate_limited_get(url, final_params, quiet=not is_last)
+            if not data:
+                continue
+
+            if endpoint_key == "quote":
+                if not isinstance(data, list) or len(data) == 0:
+                    continue
+                # Single-symbol: verify returned symbol matches request
+                if is_single and not any(
+                    q.get("symbol", "").replace("-", ".") == symbols_str.replace("-", ".")
+                    for q in data
+                ):
+                    continue
+
+            if endpoint_key == "historical":
+                if not isinstance(data, dict):
+                    continue
+                if "historicalStockList" in data:
+                    norm = symbols_str.replace("-", ".")
+                    for entry in data["historicalStockList"]:
+                        if entry.get("symbol", "").replace("-", ".") == norm:
+                            return {
+                                "symbol": entry.get("symbol"),
+                                "historical": entry.get("historical", []),
+                            }
+                    continue
+                elif "historical" not in data:
+                    continue
+                # Single-symbol: verify returned symbol matches request
+                elif is_single and data.get("symbol"):
+                    if data["symbol"].replace("-", ".") != symbols_str.replace("-", "."):
+                        continue
+
+            return data
+        return None
 
     def get_quote(self, symbols: str) -> Optional[list[dict]]:
         """Fetch real-time quote data for one or more symbols (comma-separated)"""
@@ -91,8 +176,7 @@ class FMPClient:
         if cache_key in self.cache:
             return self.cache[cache_key]
 
-        url = f"{self.BASE_URL}/quote/{symbols}"
-        data = self._rate_limited_get(url)
+        data = self._request_with_fallback("quote", symbols)
         if data:
             self.cache[cache_key] = data
         return data
@@ -103,9 +187,7 @@ class FMPClient:
         if cache_key in self.cache:
             return self.cache[cache_key]
 
-        url = f"{self.BASE_URL}/historical-price-full/{symbol}"
-        params = {"timeseries": days}
-        data = self._rate_limited_get(url, params)
+        data = self._request_with_fallback("historical", symbol, {"timeseries": days})
         if data:
             self.cache[cache_key] = data
         return data

--- a/skills/ftd-detector/scripts/tests/test_fmp_client.py
+++ b/skills/ftd-detector/scripts/tests/test_fmp_client.py
@@ -1,0 +1,356 @@
+"""Tests for FMP client endpoint fallback (stable -> v3).
+
+Tier A: Fallback logic (4 tests)
+Tier B: Response normalization (4 tests)
+Tier B+: Shape validation (2 tests)
+Tier C: Caller regression (2 tests)
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure scripts directory is on sys.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fmp_client import FMPClient
+
+
+def _make_client():
+    """Create an FMPClient with a fake API key and zero rate-limit delay."""
+    client = FMPClient(api_key="test_key")
+    client.RATE_LIMIT_DELAY = 0
+    return client
+
+
+def _mock_response(status_code, json_data=None):
+    """Create a mock response object."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.text = f"HTTP {status_code}"
+    return resp
+
+
+# =========================================================================
+# Tier A — Fallback logic
+# =========================================================================
+
+
+class TestFallbackLogic:
+    """Tier A: stable -> v3 fallback mechanics."""
+
+    def test_quote_stable_success(self):
+        """Stable 200 returns data; v3 not called."""
+        client = _make_client()
+        quote_data = [{"symbol": "^GSPC", "price": 5000.0}]
+        stable_resp = _mock_response(200, quote_data)
+
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return stable_resp
+
+        client.session.get = MagicMock(side_effect=side_effect)
+        result = client.get_quote("^GSPC")
+        assert result == quote_data
+        # Only stable endpoint called (1 call)
+        assert call_count == 1
+
+    def test_quote_stable_403_falls_back_to_v3(self):
+        """Stable 403, v3 200 -> returns v3 data."""
+        client = _make_client()
+        quote_data = [{"symbol": "^GSPC", "price": 5000.0}]
+        stable_resp = _mock_response(403)
+        v3_resp = _mock_response(200, quote_data)
+
+        responses = [stable_resp, v3_resp]
+        client.session.get = MagicMock(side_effect=responses)
+
+        result = client.get_quote("^GSPC")
+        assert result == quote_data
+        assert client.session.get.call_count == 2
+
+    def test_quote_both_fail(self):
+        """Both 403 -> returns None."""
+        client = _make_client()
+        stable_resp = _mock_response(403)
+        v3_resp = _mock_response(403)
+
+        client.session.get = MagicMock(side_effect=[stable_resp, v3_resp])
+
+        result = client.get_quote("^GSPC")
+        assert result is None
+
+    def test_historical_fallback_to_v3(self):
+        """Stable 403, v3 200 -> returns v3 historical data."""
+        client = _make_client()
+        hist_data = {
+            "symbol": "^GSPC",
+            "historical": [{"date": "2026-03-20", "close": 5000.0}],
+        }
+        stable_resp = _mock_response(403)
+        v3_resp = _mock_response(200, hist_data)
+
+        client.session.get = MagicMock(side_effect=[stable_resp, v3_resp])
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result == hist_data
+        assert client.session.get.call_count == 2
+
+
+# =========================================================================
+# Tier B — Response normalization
+# =========================================================================
+
+
+class TestResponseNormalization:
+    """Tier B: historicalStockList normalization and passthrough."""
+
+    def test_historical_stable_v3_format_passthrough(self):
+        """Stable 200 with {"historical": [...]} -> returned as-is."""
+        client = _make_client()
+        hist_data = {
+            "symbol": "^GSPC",
+            "historical": [{"date": "2026-03-20", "close": 5000.0}],
+        }
+        resp = _mock_response(200, hist_data)
+        client.session.get = MagicMock(return_value=resp)
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result == hist_data
+
+    def test_historical_stable_batch_format_exact_match(self):
+        """Stable 200 with historicalStockList matching symbol -> normalized."""
+        client = _make_client()
+        batch_data = {
+            "historicalStockList": [
+                {
+                    "symbol": "^GSPC",
+                    "historical": [{"date": "2026-03-20", "close": 5000.0}],
+                }
+            ]
+        }
+        resp = _mock_response(200, batch_data)
+        client.session.get = MagicMock(return_value=resp)
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result is not None
+        assert "historical" in result
+        assert result["historical"] == [{"date": "2026-03-20", "close": 5000.0}]
+        assert result["symbol"] == "^GSPC"
+
+    def test_historical_stable_batch_no_match_falls_back_to_v3(self):
+        """Stable batch no match -> continues to v3 200."""
+        client = _make_client()
+        # Stable returns batch with a different symbol
+        batch_data = {
+            "historicalStockList": [
+                {
+                    "symbol": "SPY",
+                    "historical": [{"date": "2026-03-20", "close": 500.0}],
+                }
+            ]
+        }
+        v3_data = {
+            "symbol": "^GSPC",
+            "historical": [{"date": "2026-03-20", "close": 5000.0}],
+        }
+        stable_resp = _mock_response(200, batch_data)
+        v3_resp = _mock_response(200, v3_data)
+
+        client.session.get = MagicMock(side_effect=[stable_resp, v3_resp])
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result == v3_data
+        assert client.session.get.call_count == 2
+
+    def test_historical_batch_no_match_returns_none_when_v3_also_fails(self):
+        """Stable batch no match + v3 403 -> None."""
+        client = _make_client()
+        batch_data = {
+            "historicalStockList": [
+                {
+                    "symbol": "SPY",
+                    "historical": [{"date": "2026-03-20", "close": 500.0}],
+                }
+            ]
+        }
+        stable_resp = _mock_response(200, batch_data)
+        v3_resp = _mock_response(403)
+
+        client.session.get = MagicMock(side_effect=[stable_resp, v3_resp])
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result is None
+
+
+# =========================================================================
+# Tier B+ — Shape validation
+# =========================================================================
+
+
+class TestShapeValidation:
+    """Tier B+: Reject truthy-but-wrong-shape responses."""
+
+    def test_quote_rejects_non_list_response(self):
+        """Stable returns truthy dict -> skipped, falls back to v3."""
+        client = _make_client()
+        # Stable returns a dict (wrong shape for quote)
+        error_data = {"Error Message": "Invalid API call"}
+        v3_data = [{"symbol": "^GSPC", "price": 5000.0}]
+
+        stable_resp = _mock_response(200, error_data)
+        v3_resp = _mock_response(200, v3_data)
+
+        client.session.get = MagicMock(side_effect=[stable_resp, v3_resp])
+
+        result = client.get_quote("^GSPC")
+        assert result == v3_data
+        assert client.session.get.call_count == 2
+
+    def test_historical_rejects_non_dict_response(self):
+        """Stable returns truthy list -> skipped, falls back to v3."""
+        client = _make_client()
+        # Stable returns a list (wrong shape for historical)
+        wrong_data = [1, 2, 3]
+        v3_data = {
+            "symbol": "^GSPC",
+            "historical": [{"date": "2026-03-20", "close": 5000.0}],
+        }
+
+        stable_resp = _mock_response(200, wrong_data)
+        v3_resp = _mock_response(200, v3_data)
+
+        client.session.get = MagicMock(side_effect=[stable_resp, v3_resp])
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result == v3_data
+        assert client.session.get.call_count == 2
+
+
+# =========================================================================
+# Tier B++ — Symbol mismatch protection
+# =========================================================================
+
+
+class TestSymbolMismatch:
+    """Reject responses where returned symbol doesn't match the request."""
+
+    def test_quote_symbol_mismatch_falls_back(self):
+        """Single-symbol quote returning wrong symbol is rejected."""
+        client = _make_client()
+        wrong = _mock_response(200, [{"symbol": "SPY", "price": 500.0}])
+        correct = _mock_response(200, [{"symbol": "^GSPC", "price": 5000.0}])
+        client.session.get = MagicMock(side_effect=[wrong, correct])
+
+        result = client.get_quote("^GSPC")
+        assert result == [{"symbol": "^GSPC", "price": 5000.0}]
+        assert client.session.get.call_count == 2
+
+    def test_historical_symbol_mismatch_falls_back(self):
+        """Single-symbol historical returning wrong symbol is rejected."""
+        client = _make_client()
+        wrong = _mock_response(200, {"symbol": "SPY", "historical": [{"close": 500}]})
+        correct = _mock_response(200, {"symbol": "^GSPC", "historical": [{"close": 5000}]})
+        client.session.get = MagicMock(side_effect=[wrong, correct])
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result["symbol"] == "^GSPC"
+        assert client.session.get.call_count == 2
+
+    def test_batch_quote_skips_symbol_check(self):
+        """Multi-symbol (batch) quote does not apply symbol mismatch check."""
+        client = _make_client()
+        batch_data = [{"symbol": "^GSPC", "price": 5000}, {"symbol": "^VIX", "price": 20}]
+        resp = _mock_response(200, batch_data)
+        client.session.get = MagicMock(return_value=resp)
+
+        result = client.get_quote("^GSPC,^VIX")
+        assert result == batch_data
+        assert client.session.get.call_count == 1
+
+
+# =========================================================================
+# Tier C — Caller regression
+# =========================================================================
+
+
+class TestCallerRegression:
+    """Tier C: Verify ftd_detector.main() handles FMPClient failures correctly."""
+
+    def test_ftd_detector_exits_on_historical_failure(self):
+        """get_historical_prices -> None => main() calls sys.exit(1) (fatal)."""
+        with (
+            patch.dict(os.environ, {"FMP_API_KEY": "test_key"}),  # pragma: allowlist secret
+            patch("sys.argv", ["ftd_detector.py"]),
+        ):
+            # Import inside patch to pick up env var
+            import ftd_detector
+
+            with (
+                patch.object(FMPClient, "get_historical_prices", return_value=None),
+                patch.object(
+                    FMPClient,
+                    "get_quote",
+                    return_value=[{"symbol": "^GSPC", "price": 5000.0}],
+                ),
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    ftd_detector.main()
+                assert exc_info.value.code == 1
+
+    def test_ftd_detector_continues_on_quote_failure(self):
+        """get_quote -> None => main() continues with warning (non-fatal)."""
+        with (
+            patch.dict(os.environ, {"FMP_API_KEY": "test_key"}),  # pragma: allowlist secret
+            patch("sys.argv", ["ftd_detector.py"]),
+        ):
+            import ftd_detector
+
+            sp500_hist = {
+                "historical": [
+                    {
+                        "date": f"2026-03-{20 - i:02d}",
+                        "open": 5000.0,
+                        "high": 5010.0,
+                        "low": 4990.0,
+                        "close": 5000.0 - i * 10,
+                        "volume": 3_000_000_000,
+                    }
+                    for i in range(80)
+                ]
+            }
+            qqq_hist = {
+                "historical": [
+                    {
+                        "date": f"2026-03-{20 - i:02d}",
+                        "open": 450.0,
+                        "high": 455.0,
+                        "low": 445.0,
+                        "close": 450.0 - i,
+                        "volume": 50_000_000,
+                    }
+                    for i in range(80)
+                ]
+            }
+
+            def mock_hist(symbol, days=365):
+                if symbol == "^GSPC":
+                    return sp500_hist
+                elif symbol == "QQQ":
+                    return qqq_hist
+                return None
+
+            with (
+                patch.object(FMPClient, "get_historical_prices", side_effect=mock_hist),
+                patch.object(FMPClient, "get_quote", return_value=None),
+                patch.object(ftd_detector, "generate_json_report"),
+                patch.object(ftd_detector, "generate_markdown_report"),
+            ):
+                # Should NOT raise SystemExit — quote failure is non-fatal
+                ftd_detector.main()

--- a/skills/market-top-detector/scripts/fmp_client.py
+++ b/skills/market-top-detector/scripts/fmp_client.py
@@ -24,6 +24,43 @@ except ImportError:
     sys.exit(1)
 
 
+# --- FMP endpoint fallback: stable (new users) -> v3 (legacy users) ---
+
+
+def _stable_quote_url(base, symbols_str, params):
+    """stable/quote?symbol=^GSPC"""
+    params["symbol"] = symbols_str
+    return base, params
+
+
+def _v3_quote_url(base, symbols_str, params):
+    """api/v3/quote/^GSPC"""
+    return f"{base}/{symbols_str}", params
+
+
+def _stable_hist_url(base, symbols_str, params):
+    """stable/historical-price-full?symbol=^GSPC&timeseries=80"""
+    params["symbol"] = symbols_str
+    return base, params
+
+
+def _v3_hist_url(base, symbols_str, params):
+    """api/v3/historical-price-full/^GSPC?timeseries=80"""
+    return f"{base}/{symbols_str}", params
+
+
+_FMP_ENDPOINTS = {
+    "quote": [
+        ("https://financialmodelingprep.com/stable/quote", _stable_quote_url),
+        ("https://financialmodelingprep.com/api/v3/quote", _v3_quote_url),
+    ],
+    "historical": [
+        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
+    ],
+}
+
+
 class FMPClient:
     """Client for Financial Modeling Prep API with rate limiting and caching"""
 
@@ -46,7 +83,9 @@ class FMPClient:
         self.max_retries = 1
         self.api_calls_made = 0
 
-    def _rate_limited_get(self, url: str, params: Optional[dict] = None) -> Optional[dict]:
+    def _rate_limited_get(
+        self, url: str, params: Optional[dict] = None, quiet: bool = False
+    ) -> Optional[dict]:
         if self.rate_limit_reached:
             return None
 
@@ -70,20 +109,73 @@ class FMPClient:
                 if self.retry_count <= self.max_retries:
                     print("WARNING: Rate limit exceeded. Waiting 60 seconds...", file=sys.stderr)
                     time.sleep(60)
-                    return self._rate_limited_get(url, params)
+                    return self._rate_limited_get(url, params, quiet=quiet)
                 else:
                     print("ERROR: Daily API rate limit reached.", file=sys.stderr)
                     self.rate_limit_reached = True
                     return None
             else:
-                print(
-                    f"ERROR: API request failed: {response.status_code} - {response.text[:200]}",
-                    file=sys.stderr,
-                )
+                if not quiet:
+                    print(
+                        f"ERROR: API request failed: {response.status_code} - {response.text[:200]}",
+                        file=sys.stderr,
+                    )
                 return None
         except requests.exceptions.RequestException as e:
             print(f"ERROR: Request exception: {e}", file=sys.stderr)
             return None
+
+    def _request_with_fallback(self, endpoint_key, symbols_str, extra_params=None):
+        """Try stable endpoint first, fall back to v3 for legacy users.
+
+        Returns parsed JSON in v3-compatible shape, or None if all fail.
+        Non-last endpoints use quiet=True to suppress expected 403 stderr.
+        """
+        params = dict(extra_params) if extra_params else {}
+        endpoints = _FMP_ENDPOINTS[endpoint_key]
+        is_single = "," not in symbols_str
+
+        for i, (base_url, url_builder) in enumerate(endpoints):
+            url, final_params = url_builder(base_url, symbols_str, dict(params))
+            is_last = i == len(endpoints) - 1
+            data = self._rate_limited_get(url, final_params, quiet=not is_last)
+            if not data:  # falsy (None, [], {}) — try next endpoint
+                continue
+
+            # Shape validation: reject truthy-but-wrong-shape responses
+            if endpoint_key == "quote":
+                if not isinstance(data, list) or len(data) == 0:
+                    continue  # callers expect non-empty list
+                # Single-symbol: verify returned symbol matches request
+                if is_single and not any(
+                    q.get("symbol", "").replace("-", ".") == symbols_str.replace("-", ".")
+                    for q in data
+                ):
+                    continue
+
+            if endpoint_key == "historical":
+                if not isinstance(data, dict):
+                    continue  # callers expect dict with .get("historical")
+                if "historicalStockList" in data:
+                    # stable batch format -> v3 single format (exact match only)
+                    norm = symbols_str.replace("-", ".")
+                    for entry in data["historicalStockList"]:
+                        if entry.get("symbol", "").replace("-", ".") == norm:
+                            return {
+                                "symbol": entry.get("symbol"),
+                                "historical": entry.get("historical", []),
+                            }
+                    # Symbol not found — this endpoint is no good, try next
+                    continue
+                elif "historical" not in data:
+                    continue  # truthy dict but missing expected key
+                # Single-symbol: verify returned symbol matches request
+                elif is_single and data.get("symbol"):
+                    if data["symbol"].replace("-", ".") != symbols_str.replace("-", "."):
+                        continue
+
+            return data
+        return None
 
     def get_quote(self, symbols: str) -> Optional[list[dict]]:
         """Fetch real-time quote data for one or more symbols (comma-separated)"""
@@ -91,8 +183,7 @@ class FMPClient:
         if cache_key in self.cache:
             return self.cache[cache_key]
 
-        url = f"{self.BASE_URL}/quote/{symbols}"
-        data = self._rate_limited_get(url)
+        data = self._request_with_fallback("quote", symbols)
         if data:
             self.cache[cache_key] = data
         return data
@@ -103,9 +194,7 @@ class FMPClient:
         if cache_key in self.cache:
             return self.cache[cache_key]
 
-        url = f"{self.BASE_URL}/historical-price-full/{symbol}"
-        params = {"timeseries": days}
-        data = self._rate_limited_get(url, params)
+        data = self._request_with_fallback("historical", symbol, {"timeseries": days})
         if data:
             self.cache[cache_key] = data
         return data

--- a/skills/market-top-detector/scripts/tests/test_fmp_client.py
+++ b/skills/market-top-detector/scripts/tests/test_fmp_client.py
@@ -1,8 +1,10 @@
-"""Tests for FMP Client VIX term structure auto-detection"""
+"""Tests for FMP Client VIX term structure auto-detection and endpoint fallback"""
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -64,3 +66,447 @@ class TestVixTermStructure:
         )
         result = client.get_vix_term_structure()
         assert result is None
+
+
+def _mock_response(status_code, json_data=None, text=""):
+    """Create a mock requests.Response."""
+    resp = Mock()
+    resp.status_code = status_code
+    resp.json = Mock(return_value=json_data)
+    resp.text = text
+    return resp
+
+
+class TestEndpointFallback:
+    """Test stable/v3 endpoint fallback logic in FMPClient."""
+
+    def _make_client(self):
+        """Create FMPClient with mocked session."""
+        with patch.dict(os.environ, {"FMP_API_KEY": "test_key"}):
+            from fmp_client import FMPClient
+
+            client = FMPClient(api_key="test_key")
+        client.RATE_LIMIT_DELAY = 0  # disable rate limiting in tests
+        return client
+
+    # ------------------------------------------------------------------
+    # Tier A — Fallback logic (4 tests)
+    # ------------------------------------------------------------------
+
+    def test_quote_stable_success(self):
+        """Stable 200 returns data, v3 is NOT called."""
+        client = self._make_client()
+        quote_data = [{"symbol": "^GSPC", "price": 5500.0}]
+
+        call_log = []
+
+        def mock_get(url, params=None, timeout=None):
+            call_log.append(url)
+            if "stable" in url:
+                return _mock_response(200, quote_data)
+            return _mock_response(403, text="Forbidden")
+
+        client.session.get = mock_get
+        result = client.get_quote("^GSPC")
+
+        assert result == quote_data
+        assert len(call_log) == 1
+        assert "stable" in call_log[0]
+
+    def test_quote_stable_403_falls_back_to_v3(self):
+        """Stable 403, v3 200 returns v3 data."""
+        client = self._make_client()
+        v3_data = [{"symbol": "^GSPC", "price": 5500.0}]
+
+        def mock_get(url, params=None, timeout=None):
+            if "stable" in url:
+                return _mock_response(403, text="Forbidden")
+            return _mock_response(200, v3_data)
+
+        client.session.get = mock_get
+        result = client.get_quote("^GSPC")
+        assert result == v3_data
+
+    def test_quote_both_fail(self):
+        """Both endpoints 403 returns None."""
+        client = self._make_client()
+
+        def mock_get(url, params=None, timeout=None):
+            return _mock_response(403, text="Forbidden")
+
+        client.session.get = mock_get
+        result = client.get_quote("^GSPC")
+        assert result is None
+
+    def test_historical_fallback_to_v3(self):
+        """Stable 403, v3 200 returns v3 data for historical."""
+        client = self._make_client()
+        v3_data = {"symbol": "^GSPC", "historical": [{"date": "2026-03-20", "close": 5500.0}]}
+
+        def mock_get(url, params=None, timeout=None):
+            if "stable" in url:
+                return _mock_response(403, text="Forbidden")
+            return _mock_response(200, v3_data)
+
+        client.session.get = mock_get
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result == v3_data
+        assert "historical" in result
+
+    # ------------------------------------------------------------------
+    # Tier B — Response normalization (4 tests)
+    # ------------------------------------------------------------------
+
+    def test_historical_stable_v3_format_passthrough(self):
+        """Stable returns v3-compatible format {'historical': [...]} — returned as-is."""
+        client = self._make_client()
+        data = {"symbol": "^GSPC", "historical": [{"date": "2026-03-20", "close": 5500.0}]}
+
+        def mock_get(url, params=None, timeout=None):
+            return _mock_response(200, data)
+
+        client.session.get = mock_get
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result == data
+
+    def test_historical_stable_batch_format_exact_match(self):
+        """Stable returns historicalStockList with matching symbol — normalized."""
+        client = self._make_client()
+        batch_data = {
+            "historicalStockList": [
+                {
+                    "symbol": "^GSPC",
+                    "historical": [{"date": "2026-03-20", "close": 5500.0}],
+                }
+            ]
+        }
+
+        def mock_get(url, params=None, timeout=None):
+            return _mock_response(200, batch_data)
+
+        client.session.get = mock_get
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result is not None
+        assert "historical" in result
+        assert result["historical"] == [{"date": "2026-03-20", "close": 5500.0}]
+
+    def test_historical_stable_batch_no_match_falls_back_to_v3(self):
+        """Stable batch has wrong symbol, falls back to v3 which succeeds."""
+        client = self._make_client()
+        batch_data = {
+            "historicalStockList": [
+                {
+                    "symbol": "SPY",
+                    "historical": [{"date": "2026-03-20", "close": 550.0}],
+                }
+            ]
+        }
+        v3_data = {"symbol": "^GSPC", "historical": [{"date": "2026-03-20", "close": 5500.0}]}
+
+        def mock_get(url, params=None, timeout=None):
+            if "stable" in url:
+                return _mock_response(200, batch_data)
+            return _mock_response(200, v3_data)
+
+        client.session.get = mock_get
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result == v3_data
+
+    def test_historical_batch_no_match_returns_none_when_v3_also_fails(self):
+        """Stable batch no match + v3 403 returns None."""
+        client = self._make_client()
+        batch_data = {
+            "historicalStockList": [
+                {
+                    "symbol": "SPY",
+                    "historical": [{"date": "2026-03-20", "close": 550.0}],
+                }
+            ]
+        }
+
+        def mock_get(url, params=None, timeout=None):
+            if "stable" in url:
+                return _mock_response(200, batch_data)
+            return _mock_response(403, text="Forbidden")
+
+        client.session.get = mock_get
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result is None
+
+    # ------------------------------------------------------------------
+    # Tier B+ — Shape validation (2 tests)
+    # ------------------------------------------------------------------
+
+    def test_quote_rejects_non_list_response(self):
+        """Stable returns truthy dict — skipped, falls back to v3."""
+        client = self._make_client()
+        error_dict = {"Error Message": "Invalid API KEY."}
+        v3_data = [{"symbol": "^GSPC", "price": 5500.0}]
+
+        def mock_get(url, params=None, timeout=None):
+            if "stable" in url:
+                return _mock_response(200, error_dict)
+            return _mock_response(200, v3_data)
+
+        client.session.get = mock_get
+        result = client.get_quote("^GSPC")
+        assert result == v3_data
+
+    def test_historical_rejects_non_dict_response(self):
+        """Stable returns truthy list — skipped, falls back to v3."""
+        client = self._make_client()
+        bad_data = [1, 2, 3]
+        v3_data = {"symbol": "^GSPC", "historical": [{"date": "2026-03-20", "close": 5500.0}]}
+
+        def mock_get(url, params=None, timeout=None):
+            if "stable" in url:
+                return _mock_response(200, bad_data)
+            return _mock_response(200, v3_data)
+
+        client.session.get = mock_get
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result == v3_data
+
+    # ------------------------------------------------------------------
+    # Symbol mismatch protection
+    # ------------------------------------------------------------------
+
+    def test_quote_symbol_mismatch_falls_back(self):
+        """Single-symbol quote returning wrong symbol is rejected."""
+        client = self._make_client()
+        wrong = _mock_response(200, [{"symbol": "SPY", "price": 500.0}])
+        correct = _mock_response(200, [{"symbol": "^GSPC", "price": 5000.0}])
+        client.session.get = MagicMock(side_effect=[wrong, correct])
+
+        result = client.get_quote("^GSPC")
+        assert result == [{"symbol": "^GSPC", "price": 5000.0}]
+        assert client.session.get.call_count == 2
+
+    def test_historical_symbol_mismatch_falls_back(self):
+        """Single-symbol historical returning wrong symbol is rejected."""
+        client = self._make_client()
+        wrong = _mock_response(200, {"symbol": "SPY", "historical": [{"close": 500}]})
+        correct = _mock_response(200, {"symbol": "^GSPC", "historical": [{"close": 5000}]})
+        client.session.get = MagicMock(side_effect=[wrong, correct])
+
+        result = client.get_historical_prices("^GSPC", days=80)
+        assert result["symbol"] == "^GSPC"
+        assert client.session.get.call_count == 2
+
+    def test_batch_quote_skips_symbol_check(self):
+        """Multi-symbol (batch) quote does not apply symbol mismatch check."""
+        client = self._make_client()
+        batch_data = [{"symbol": "^GSPC", "price": 5000}, {"symbol": "^VIX", "price": 20}]
+        resp = _mock_response(200, batch_data)
+        client.session.get = MagicMock(return_value=resp)
+
+        result = client.get_quote("^GSPC,^VIX")
+        assert result == batch_data
+        assert client.session.get.call_count == 1
+
+    # ------------------------------------------------------------------
+    # Skill-specific tests
+    # ------------------------------------------------------------------
+
+    def test_vix_term_structure_works_via_fallback(self):
+        """VIX term structure succeeds when get_quote uses stable->v3 fallback."""
+        client = self._make_client()
+
+        vix_data = [{"symbol": "^VIX", "price": 18.0}]
+        vix3m_data = [{"symbol": "^VIX3M", "price": 20.0}]
+
+        def mock_get(url, params=None, timeout=None):
+            if "stable" in url:
+                return _mock_response(403, text="Forbidden")
+            # v3 fallback: route by symbol in URL path
+            if "^VIX3M" in url:
+                return _mock_response(200, vix3m_data)
+            if "^VIX" in url:
+                return _mock_response(200, vix_data)
+            return _mock_response(404, text="Not Found")
+
+        client.session.get = mock_get
+        result = client.get_vix_term_structure()
+
+        assert result is not None
+        assert result["vix"] == 18.0
+        assert result["vix3m"] == 20.0
+        # 18/20 = 0.9 -> contango
+        assert result["classification"] == "contango"
+        assert result["ratio"] == 0.9
+
+    def test_market_top_exits_on_sp500_failure(self):
+        """main() exits with code 1 when S&P 500 data unavailable."""
+        from fmp_client import FMPClient
+
+        with (
+            patch.object(FMPClient, "__init__", lambda self, **kw: None),
+            patch.object(FMPClient, "get_quote", return_value=None),
+            patch.object(FMPClient, "get_historical_prices", return_value=None),
+            patch.object(
+                FMPClient,
+                "get_api_stats",
+                return_value={
+                    "cache_entries": 0,
+                    "api_calls_made": 0,
+                    "rate_limit_reached": False,
+                },
+            ),
+            patch("sys.argv", ["market_top_detector.py"]),
+        ):
+            # Need to set required attributes that __init__ would set
+            def fake_init(self, **kw):
+                self.api_key = "test"  # pragma: allowlist secret
+                self.session = MagicMock()
+                self.cache = {}
+                self.last_call_time = 0
+                self.rate_limit_reached = False
+                self.retry_count = 0
+                self.max_retries = 1
+                self.api_calls_made = 0
+
+            with patch.object(FMPClient, "__init__", fake_init):
+                import market_top_detector
+
+                with pytest.raises(SystemExit) as exc_info:
+                    market_top_detector.main()
+                assert exc_info.value.code == 1
+
+    def test_market_top_continues_on_vix_failure(self, capsys):
+        """main() continues with warning when VIX unavailable (non-fatal)."""
+        from fmp_client import FMPClient
+
+        sp500_quote = [{"symbol": "^GSPC", "price": 5500.0, "yearHigh": 5600.0}]
+        sp500_hist = {
+            "symbol": "^GSPC",
+            "historical": [
+                {
+                    "date": f"2026-03-{20 - i:02d}",
+                    "close": 5500.0 - i * 10,
+                    "volume": 3_000_000_000,
+                    "open": 5490.0 - i * 10,
+                    "high": 5510.0 - i * 10,
+                    "low": 5480.0 - i * 10,
+                }
+                for i in range(260)
+            ],
+        }
+        qqq_quote = [{"symbol": "QQQ", "price": 480.0, "yearHigh": 500.0}]
+        qqq_hist = {
+            "symbol": "QQQ",
+            "historical": [
+                {
+                    "date": f"2026-03-{20 - i:02d}",
+                    "close": 480.0 - i,
+                    "volume": 50_000_000,
+                    "open": 479.0 - i,
+                    "high": 481.0 - i,
+                    "low": 478.0 - i,
+                }
+                for i in range(260)
+            ],
+        }
+
+        def mock_quote(symbols):
+            if symbols == "^GSPC":
+                return sp500_quote
+            if symbols == "QQQ":
+                return qqq_quote
+            if symbols == "^VIX":
+                return None  # VIX fails
+            if symbols == "^VIX3M":
+                return None
+            # Return generic quote for ETFs
+            return [
+                {
+                    "symbol": symbols.split(",")[0],
+                    "price": 100.0,
+                    "yearHigh": 110.0,
+                    "changesPercentage": 0.5,
+                    "volume": 1_000_000,
+                    "avgVolume": 1_000_000,
+                }
+            ]
+
+        def mock_hist(symbol, days=365):
+            if symbol == "^GSPC":
+                return sp500_hist
+            if symbol == "QQQ":
+                return qqq_hist
+            # Generic history for ETFs
+            return {
+                "symbol": symbol,
+                "historical": [
+                    {
+                        "date": f"2026-03-{20 - i:02d}",
+                        "close": 100.0 + i * 0.1,
+                        "volume": 1_000_000,
+                        "open": 99.9 + i * 0.1,
+                        "high": 100.1 + i * 0.1,
+                        "low": 99.8 + i * 0.1,
+                    }
+                    for i in range(min(days, 260))
+                ],
+            }
+
+        def mock_batch_quotes(symbols):
+            result = {}
+            for s in symbols:
+                q = mock_quote(s)
+                if q:
+                    for item in q:
+                        result[item.get("symbol", s)] = item
+            return result
+
+        def mock_batch_hist(symbols, days=50):
+            result = {}
+            for s in symbols:
+                d = mock_hist(s, days)
+                if d and "historical" in d:
+                    result[s] = d["historical"]
+            return result
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch.dict(os.environ, {"FMP_API_KEY": "test_key"}),  # pragma: allowlist secret
+                patch(
+                    "sys.argv",
+                    [
+                        "market_top_detector.py",
+                        "--static-basket",
+                        "--no-auto-breadth",
+                        "--breadth-200dma",
+                        "60.0",
+                        "--put-call",
+                        "0.70",
+                        "--vix-term",
+                        "contango",
+                        "--output-dir",
+                        tmpdir,
+                    ],
+                ),
+            ):
+                from fmp_client import FMPClient
+
+                with (
+                    patch.object(FMPClient, "get_quote", side_effect=mock_quote),
+                    patch.object(FMPClient, "get_historical_prices", side_effect=mock_hist),
+                    patch.object(FMPClient, "get_batch_quotes", side_effect=mock_batch_quotes),
+                    patch.object(FMPClient, "get_batch_historical", side_effect=mock_batch_hist),
+                ):
+                    import importlib
+
+                    import market_top_detector
+
+                    importlib.reload(market_top_detector)
+
+                    # Should NOT raise SystemExit — VIX failure is non-fatal
+                    try:
+                        market_top_detector.main()
+                    except SystemExit:
+                        pytest.fail("main() should not exit when only VIX fails")
+
+            captured = capsys.readouterr()
+            assert "WARN" in captured.out or "VIX unavailable" in captured.out


### PR DESCRIPTION
## Summary

Fixes #37 — FMP deprecated `/api/v3/` endpoints for users who subscribed after 2025-08-31, returning 403 for index symbols (`^GSPC`, `^VIX`, `^VIX3M`).

- Add `_request_with_fallback()` to try `/stable/` first, fall back to `/api/v3/` for legacy users
- Shape validation: quote must be non-empty list, historical must be dict with `"historical"` key
- Symbol mismatch protection for single-symbol requests (prevents `^GSPC`/`SPY` scale mixing)
- `historicalStockList` (stable batch format) normalization to v3 single format
- `quiet` parameter on `_rate_limited_get()` to suppress expected 403 on non-last endpoints
- Applied to: **ftd-detector**, **market-top-detector**, **canslim-screener**
- Other methods (`get_income_statement`, `get_profile`, etc.) are unaffected

## Test plan

- [x] 15 new tests for ftd-detector (Tier A/B/B+/C + symbol mismatch)
- [x] 16 new tests for market-top-detector (same + VIX fallback + VIX failure regression)
- [x] 15 new tests for canslim-screener (same + quote fatal / historical non-fatal regression)
- [x] All existing tests pass (55 + 195 + 34 = 284 total)
- [x] Live smoke test: ftd-detector, market-top-detector, canslim-screener

🤖 Generated with [Claude Code](https://claude.com/claude-code)