### PR TITLE
Improve skill-designer skill (score 83 -> 98)

### DIFF
--- a/skills/skill-designer/SKILL.md
+++ b/skills/skill-designer/SKILL.md
@@ -23,7 +23,7 @@ documents, helper scripts, and test scaffolding.
 
 - Python 3.9+
 - No external API keys required
-- Reference files must exist under `skills/skill-designer/references/`
+- Reference files must exist under `references/`
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- Skill: `skill-designer`
- Score: 83 -> 98

## Improvements
- Reference paths use full project paths instead of relative paths. -> Use relative paths like `references/...` instead of `skills/skill-designer/references/...` — SKILL.md is loaded in the skill directory context.

Generated by skill self-improvement loop.