### PR TITLE
Migrate FMP API scripts from deprecated v3 to stable endpoints

### DIFF
--- a/skills/earnings-calendar/scripts/fetch_earnings_fmp.py
+++ b/skills/earnings-calendar/scripts/fetch_earnings_fmp.py
@@ -29,7 +29,7 @@ import requests
 class FMPEarningsCalendar:
     """FMP Earnings Calendar API client"""
 
-    BASE_URL = "https://financialmodelingprep.com/api/v3"
+    BASE_URL = "https://financialmodelingprep.com/stable"
     MIN_MARKET_CAP = 2_000_000_000  # $2B
     US_EXCHANGES = ["NYSE", "NASDAQ", "AMEX", "NYSEArca", "BATS", "NMS", "NGM", "NCM"]
 
@@ -55,12 +55,12 @@ class FMPEarningsCalendar:
         Returns:
             List of earnings announcements or None on error
         """
-        url = f"{self.BASE_URL}/earning_calendar"
-        params = {"from": start_date, "to": end_date}
+        url = f"{self.BASE_URL}/earnings-calendar"
+        params = {"from": start_date, "to": end_date, "apikey": self.api_key}
 
         try:
             response = requests.get(
-                url, params=params, headers={"apikey": self.api_key}, timeout=30
+                url, params=params, timeout=30
             )
 
             if response.status_code == 401:
@@ -110,32 +110,27 @@ class FMPEarningsCalendar:
             Dictionary mapping symbol to profile data
         """
         profiles = {}
-        batch_size = 100  # FMP allows batch requests
 
         print(f"✓ Fetching profiles for {len(symbols)} companies...", file=sys.stderr)
 
-        for i in range(0, len(symbols), batch_size):
-            batch = symbols[i : i + batch_size]
-            symbols_str = ",".join(batch)
-
-            url = f"{self.BASE_URL}/profile/{symbols_str}"
-            params = {}
+        for i, symbol in enumerate(symbols):
+            url = f"{self.BASE_URL}/profile"
+            params = {"symbol": symbol, "apikey": self.api_key}
 
             try:
-                response = requests.get(
-                    url, params=params, headers={"apikey": self.api_key}, timeout=30
-                )
+                response = requests.get(url, params=params, timeout=30)
                 response.raise_for_status()
 
-                for profile in response.json():
-                    if isinstance(profile, dict):
-                        profiles[profile.get("symbol")] = profile
+                data = response.json()
+                if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
+                    profiles[data[0].get("symbol")] = data[0]
 
-                print(f"  ✓ Batch {i // batch_size + 1}: {len(batch)} profiles", file=sys.stderr)
+                if (i + 1) % 50 == 0:
+                    print(f"  ✓ Fetched {i + 1}/{len(symbols)} profiles", file=sys.stderr)
 
             except Exception as e:
                 print(
-                    f"  ⚠️  Warning: Failed to fetch batch {i // batch_size + 1}: {str(e)}",
+                    f"  ⚠️  Warning: Failed to fetch profile for {symbol}: {str(e)}",
                     file=sys.stderr,
                 )
                 continue
@@ -165,11 +160,11 @@ class FMPEarningsCalendar:
 
             # Filter by market cap and exchange
             if profile:
-                market_cap = profile.get("mktCap", 0)
+                market_cap = profile.get("marketCap", 0)
                 if market_cap < self.MIN_MARKET_CAP:
                     continue
 
-                exchange = profile.get("exchangeShortName", "N/A")
+                exchange = profile.get("exchange", "N/A")
 
                 # Filter by US exchanges if us_only is True
                 if self.us_only and exchange not in self.US_EXCHANGES:

--- a/skills/economic-calendar-fetcher/scripts/get_economic_calendar.py
+++ b/skills/economic-calendar-fetcher/scripts/get_economic_calendar.py
@@ -44,17 +44,17 @@ def fetch_economic_calendar(from_date: str, to_date: str, api_key: str) -> list[
         urllib.error.HTTPError: If API request fails
         ValueError: If response is invalid
     """
-    base_url = "https://financialmodelingprep.com/api/v3/economic_calendar"
+    base_url = "https://financialmodelingprep.com/stable/economics-calendar"
 
-    # Build query parameters
-    params = {"from": from_date, "to": to_date}
+    # Build query parameters (stable API uses apikey as query param)
+    params = {"from": from_date, "to": to_date, "apikey": api_key}
 
     # Construct URL with parameters
     url = f"{base_url}?{urllib.parse.urlencode(params)}"
 
     try:
         # Make API request
-        request = urllib.request.Request(url, headers={"apikey": api_key})
+        request = urllib.request.Request(url)
         with urllib.request.urlopen(request) as response:
             if response.status != 200:
                 raise ValueError(f"API returned status code {response.status}")
@@ -68,6 +68,9 @@ def fetch_economic_calendar(from_date: str, to_date: str, api_key: str) -> list[
 
     except urllib.error.HTTPError as e:
         error_body = e.read().decode("utf-8") if e.fp else "No error details"
+        # Stable API returns 404 with [] when no events exist
+        if e.code == 404 and error_body.strip() == "[]":
+            return []
         raise urllib.error.HTTPError(
             e.url, e.code, f"FMP API error: {e.reason}. Details: {error_body}", e.hdrs, e.fp
         )


### PR DESCRIPTION
## Summary
- FMP deprecated all `/api/v3/` endpoints after August 2025, causing **403 Forbidden** errors on economic calendar and earnings calendar scripts
- Migrates both scripts to the new `/stable/` API with query-parameter authentication
- Updates field names and profile endpoint format to match the stable API schema

## Changes
| Script | What changed |
|--------|-------------|
| `get_economic_calendar.py` | URL → `/stable/economics-calendar`, auth via query param, handle 404+empty as "no events" |
| `fetch_earnings_fmp.py` | URL → `/stable/earnings-calendar`, profile → `/stable/profile?symbol=X` (no batch), `mktCap` → `marketCap`, `exchangeShortName` → `exchange` |

## Test plan
- [x] Economic calendar returns 0 events without crashing (free tier may not have economics data)
- [x] Earnings calendar returns 9 companies for Apr 13-18 (GS, JPM, JNJ, WFC, C, BAC, TSM, NFLX, PEP)
- [x] Company profiles fetched individually via stable endpoint
- [x] Market cap filtering and exchange filtering work with new field names

🤖 Generated with [Claude Code](https://claude.com/claude-code)