### PR TITLE
Fix FMP historical endpoint 404 and report encoding (Issue #64)

### DIFF
--- a/skills/canslim-screener/scripts/fmp_client.py
+++ b/skills/canslim-screener/scripts/fmp_client.py
@@ -70,7 +70,7 @@ _FMP_ENDPOINTS = {
 }
 
 
-def _normalize_eod_flat_list(data, symbols_str: str):
+def _normalize_eod_flat_list(data, symbols_str: str, limit: Optional[int] = None):
     """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
 
     Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
@@ -80,6 +80,13 @@ def _normalize_eod_flat_list(data, symbols_str: str):
     historicalStockList responses). Returns None when no row matches the
     requested symbol; the caller will record the failure and try the next
     endpoint.
+
+    If `limit` is provided (the original `timeseries=N` request), the
+    `historical` list is truncated to the first `limit` entries. The new
+    EOD endpoint ignores `timeseries` and returns the full available history,
+    so the caller's date-range bounding plus this truncation together preserve
+    the legacy "most-recent N rows" contract. Truncation assumes descending
+    date order, which the FMP EOD endpoint provides (verified live).
 
     Note: empty list ``[]`` does not reach this normalizer because the caller's
     ``if not data: continue`` falsy check handles it earlier in
@@ -104,6 +111,8 @@ def _normalize_eod_flat_list(data, symbols_str: str):
         historical.append({k: v for k, v in row.items() if k != "symbol"})
     if not historical:
         return None
+    if limit is not None and limit > 0:
+        historical = historical[:limit]
     return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
@@ -220,8 +229,12 @@ class FMPClient:
 
             # Normalize new stable EOD flat-list shape to v3-compatible dict.
             # No-op for v3 dict / historicalStockList responses.
+            # `timeseries` (original request) is passed as `limit` so the
+            # EOD endpoint's full-history response is truncated to the
+            # legacy "most-recent N rows" contract.
             if endpoint_key == "historical":
-                data = _normalize_eod_flat_list(data, symbols_str)
+                limit = params.get("timeseries") if isinstance(params, dict) else None
+                data = _normalize_eod_flat_list(data, symbols_str, limit=limit)
                 if not data:
                     self._record_endpoint_failure(base_url)
                     continue

--- a/skills/canslim-screener/scripts/fmp_client.py
+++ b/skills/canslim-screener/scripts/fmp_client.py
@@ -15,6 +15,7 @@ Features:
 import os
 import sys
 import time
+from datetime import date, timedelta
 from typing import Optional
 
 try:
@@ -39,8 +40,16 @@ def _v3_quote_url(base, symbols_str, params):
 
 
 def _stable_hist_url(base, symbols_str, params):
-    """stable/historical-price-full?symbol=^GSPC&timeseries=80"""
+    """stable/historical-price-eod/full?symbol=^GSPC&from=...&to=..."""
     params["symbol"] = symbols_str
+    # New stable EOD endpoint ignores `timeseries`; convert to from/to range
+    # to bound the payload. Use 2x calendar days to cover N trading days
+    # (trading-day/calendar-day ratio ~252/365 ~0.69, so *2 leaves headroom).
+    days = params.pop("timeseries", None)
+    if days is not None:
+        today = date.today()
+        params["from"] = (today - timedelta(days=int(days) * 2)).isoformat()
+        params["to"] = today.isoformat()
     return base, params
 
 
@@ -55,10 +64,47 @@ _FMP_ENDPOINTS = {
         ("https://financialmodelingprep.com/api/v3/quote", _v3_quote_url),
     ],
     "historical": [
-        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/stable/historical-price-eod/full", _stable_hist_url),
         ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
     ],
 }
+
+
+def _normalize_eod_flat_list(data, symbols_str: str):
+    """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
+
+    Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
+    Output : {"symbol": "SPY", "historical": [{"date": ..., "open": ..., ...}, ...]}
+
+    Returns the input unchanged if not a list (passthrough for v3 dict /
+    historicalStockList responses). Returns None when no row matches the
+    requested symbol; the caller will record the failure and try the next
+    endpoint.
+
+    Note: empty list ``[]`` does not reach this normalizer because the caller's
+    ``if not data: continue`` falsy check handles it earlier in
+    ``_request_with_fallback``.
+    """
+    if not isinstance(data, list):
+        return data
+    if not data:
+        return None
+    norm_target = symbols_str.replace("-", ".")
+    matched_symbol = None
+    historical = []
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        # Be permissive: single-symbol endpoint may omit per-row "symbol".
+        # Treat missing symbol as belonging to the requested symbols_str.
+        row_sym = row.get("symbol") or symbols_str
+        if row_sym.replace("-", ".") != norm_target:
+            continue
+        matched_symbol = matched_symbol or row_sym
+        historical.append({k: v for k, v in row.items() if k != "symbol"})
+    if not historical:
+        return None
+    return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
 class FMPClient:
@@ -171,6 +217,14 @@ class FMPClient:
             if not data:
                 self._record_endpoint_failure(base_url)
                 continue
+
+            # Normalize new stable EOD flat-list shape to v3-compatible dict.
+            # No-op for v3 dict / historicalStockList responses.
+            if endpoint_key == "historical":
+                data = _normalize_eod_flat_list(data, symbols_str)
+                if not data:
+                    self._record_endpoint_failure(base_url)
+                    continue
 
             valid = True
             if endpoint_key == "quote":

--- a/skills/canslim-screener/scripts/tests/test_fmp_fallback.py
+++ b/skills/canslim-screener/scripts/tests/test_fmp_fallback.py
@@ -329,3 +329,54 @@ class TestCallerRegression:
 
             captured = capsys.readouterr()
             assert "EMA fallback" in captured.out or "historical data unavailable" in captured.out
+
+
+class TestEODFlatListSuccess:
+    """Issue #64: stable EOD flat list -> public method success (regression)."""
+
+    @patch("fmp_client.requests.Session")
+    def test_get_historical_prices_normalizes_flat_list(self, mock_session_class):
+        """Flat list response from new EOD endpoint -> dict contract preserved."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = _mock_response(
+            200,
+            [
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-29",
+                    "open": 500.0,
+                    "high": 502.0,
+                    "low": 499.0,
+                    "close": 501.0,
+                    "volume": 1_000_000,
+                },
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-28",
+                    "open": 498.0,
+                    "high": 501.0,
+                    "low": 497.0,
+                    "close": 500.0,
+                    "volume": 1_100_000,
+                },
+            ],
+        )
+        mock_session_class.return_value = mock_session
+
+        client = _make_client()
+        client.session = mock_session
+        client.max_retries = 0
+
+        result = client.get_historical_prices("SPY", days=2)
+        assert isinstance(result, dict), f"expected dict, got {type(result).__name__}"
+        assert result["symbol"] == "SPY"
+        assert len(result["historical"]) == 2
+        assert result["historical"][0]["close"] == 501.0
+
+        # URL regression: must hit /historical-price-eod/full with from/to (not timeseries)
+        first_call = mock_session.get.call_args_list[0]
+        url = first_call[0][0]
+        params = first_call[1]["params"]
+        assert "historical-price-eod/full" in url
+        assert "from" in params and "to" in params
+        assert "timeseries" not in params

--- a/skills/earnings-trade-analyzer/scripts/fmp_client.py
+++ b/skills/earnings-trade-analyzer/scripts/fmp_client.py
@@ -17,6 +17,7 @@ Features:
 import os
 import sys
 import time
+from datetime import date, timedelta
 from typing import Optional
 
 try:
@@ -30,8 +31,16 @@ except ImportError:
 
 
 def _stable_hist_url(base, symbols_str, params):
-    """stable/historical-price-full?symbol=SPY&timeseries=90"""
+    """stable/historical-price-eod/full?symbol=SPY&from=...&to=..."""
     params["symbol"] = symbols_str
+    # New stable EOD endpoint ignores `timeseries`; convert to from/to range
+    # to bound the payload. Use 2x calendar days to cover N trading days
+    # (trading-day/calendar-day ratio ~252/365 ~0.69, so *2 leaves headroom).
+    days = params.pop("timeseries", None)
+    if days is not None:
+        today = date.today()
+        params["from"] = (today - timedelta(days=int(days) * 2)).isoformat()
+        params["to"] = today.isoformat()
     return base, params
 
 
@@ -42,10 +51,47 @@ def _v3_hist_url(base, symbols_str, params):
 
 _FMP_ENDPOINTS = {
     "historical": [
-        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/stable/historical-price-eod/full", _stable_hist_url),
         ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
     ],
 }
+
+
+def _normalize_eod_flat_list(data, symbols_str: str):
+    """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
+
+    Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
+    Output : {"symbol": "SPY", "historical": [{"date": ..., "open": ..., ...}, ...]}
+
+    Returns the input unchanged if not a list (passthrough for v3 dict /
+    historicalStockList responses). Returns None when no row matches the
+    requested symbol; the caller will record the failure and try the next
+    endpoint.
+
+    Note: empty list ``[]`` does not reach this normalizer because the caller's
+    ``if not data: continue`` falsy check handles it earlier in
+    ``_request_with_fallback``.
+    """
+    if not isinstance(data, list):
+        return data
+    if not data:
+        return None
+    norm_target = symbols_str.replace("-", ".")
+    matched_symbol = None
+    historical = []
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        # Be permissive: single-symbol endpoint may omit per-row "symbol".
+        # Treat missing symbol as belonging to the requested symbols_str.
+        row_sym = row.get("symbol") or symbols_str
+        if row_sym.replace("-", ".") != norm_target:
+            continue
+        matched_symbol = matched_symbol or row_sym
+        historical.append({k: v for k, v in row.items() if k != "symbol"})
+    if not historical:
+        return None
+    return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
 class ApiCallBudgetExceeded(Exception):
@@ -155,6 +201,14 @@ class FMPClient:
             if not data:  # falsy (None, [], {}) -- try next endpoint
                 self._record_endpoint_failure(base_url)
                 continue
+
+            # Normalize new stable EOD flat-list shape to v3-compatible dict.
+            # No-op for v3 dict / historicalStockList responses.
+            if endpoint_key == "historical":
+                data = _normalize_eod_flat_list(data, symbols_str)
+                if not data:
+                    self._record_endpoint_failure(base_url)
+                    continue
 
             # Shape validation: reject truthy-but-wrong-shape responses
             valid = True

--- a/skills/earnings-trade-analyzer/scripts/fmp_client.py
+++ b/skills/earnings-trade-analyzer/scripts/fmp_client.py
@@ -57,7 +57,7 @@ _FMP_ENDPOINTS = {
 }
 
 
-def _normalize_eod_flat_list(data, symbols_str: str):
+def _normalize_eod_flat_list(data, symbols_str: str, limit: Optional[int] = None):
     """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
 
     Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
@@ -67,6 +67,13 @@ def _normalize_eod_flat_list(data, symbols_str: str):
     historicalStockList responses). Returns None when no row matches the
     requested symbol; the caller will record the failure and try the next
     endpoint.
+
+    If `limit` is provided (the original `timeseries=N` request), the
+    `historical` list is truncated to the first `limit` entries. The new
+    EOD endpoint ignores `timeseries` and returns the full available history,
+    so the caller's date-range bounding plus this truncation together preserve
+    the legacy "most-recent N rows" contract. Truncation assumes descending
+    date order, which the FMP EOD endpoint provides (verified live).
 
     Note: empty list ``[]`` does not reach this normalizer because the caller's
     ``if not data: continue`` falsy check handles it earlier in
@@ -91,6 +98,8 @@ def _normalize_eod_flat_list(data, symbols_str: str):
         historical.append({k: v for k, v in row.items() if k != "symbol"})
     if not historical:
         return None
+    if limit is not None and limit > 0:
+        historical = historical[:limit]
     return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
@@ -204,8 +213,12 @@ class FMPClient:
 
             # Normalize new stable EOD flat-list shape to v3-compatible dict.
             # No-op for v3 dict / historicalStockList responses.
+            # `timeseries` (original request) is passed as `limit` so the
+            # EOD endpoint's full-history response is truncated to the
+            # legacy "most-recent N rows" contract.
             if endpoint_key == "historical":
-                data = _normalize_eod_flat_list(data, symbols_str)
+                limit = params.get("timeseries") if isinstance(params, dict) else None
+                data = _normalize_eod_flat_list(data, symbols_str, limit=limit)
                 if not data:
                     self._record_endpoint_failure(base_url)
                     continue

--- a/skills/earnings-trade-analyzer/scripts/tests/test_fmp_client_historical.py
+++ b/skills/earnings-trade-analyzer/scripts/tests/test_fmp_client_historical.py
@@ -1,0 +1,80 @@
+"""Issue #64: stable/historical-price-eod/full normalization for earnings-trade-analyzer.
+
+This skill's `get_historical_prices()` returns Optional[list[dict]] (NOT dict),
+unlike the other 6 fmp_client implementations. The public method extracts
+`data["historical"]` from the normalizer output. This test pins that contract.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fmp_client import FMPClient
+
+
+def _make_client():
+    client = FMPClient(api_key="test_key", max_api_calls=200)
+    client.max_retries = 0
+    return client
+
+
+def _mock_response(status_code, json_payload):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_payload
+    resp.text = ""
+    return resp
+
+
+class TestEODFlatListSuccess:
+    @patch("fmp_client.requests.Session")
+    def test_get_historical_prices_returns_list(self, mock_session_class):
+        """Flat list response -> public method returns list (NOT dict)."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = _mock_response(
+            200,
+            [
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-29",
+                    "open": 500.0,
+                    "high": 502.0,
+                    "low": 499.0,
+                    "close": 501.0,
+                    "volume": 1_000_000,
+                },
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-28",
+                    "open": 498.0,
+                    "high": 501.0,
+                    "low": 497.0,
+                    "close": 500.0,
+                    "volume": 1_100_000,
+                },
+            ],
+        )
+        mock_session_class.return_value = mock_session
+
+        client = _make_client()
+        client.session = mock_session
+
+        result = client.get_historical_prices("SPY", days=2)
+        # CRITICAL: this skill returns list, not dict
+        assert isinstance(result, list), (
+            f"expected list (skill contract), got {type(result).__name__}"
+        )
+        assert len(result) == 2
+        assert result[0]["date"] == "2026-04-29"
+        assert result[0]["close"] == 501.0
+        assert "symbol" not in result[0], "row-level symbol should be stripped"
+
+        # URL regression
+        first_call = mock_session.get.call_args_list[0]
+        url = first_call[0][0]
+        params = first_call[1]["params"]
+        assert "historical-price-eod/full" in url
+        assert "from" in params and "to" in params
+        assert "timeseries" not in params

--- a/skills/ftd-detector/scripts/fmp_client.py
+++ b/skills/ftd-detector/scripts/fmp_client.py
@@ -15,6 +15,7 @@ Features:
 import os
 import sys
 import time
+from datetime import date, timedelta
 from typing import Optional
 
 try:
@@ -39,8 +40,16 @@ def _v3_quote_url(base, symbols_str, params):
 
 
 def _stable_hist_url(base, symbols_str, params):
-    """stable/historical-price-full?symbol=^GSPC&timeseries=80"""
+    """stable/historical-price-eod/full?symbol=^GSPC&from=...&to=..."""
     params["symbol"] = symbols_str
+    # New stable EOD endpoint ignores `timeseries`; convert to from/to range
+    # to bound the payload. Use 2x calendar days to cover N trading days
+    # (trading-day/calendar-day ratio ~252/365 ~0.69, so *2 leaves headroom).
+    days = params.pop("timeseries", None)
+    if days is not None:
+        today = date.today()
+        params["from"] = (today - timedelta(days=int(days) * 2)).isoformat()
+        params["to"] = today.isoformat()
     return base, params
 
 
@@ -55,10 +64,47 @@ _FMP_ENDPOINTS = {
         ("https://financialmodelingprep.com/api/v3/quote", _v3_quote_url),
     ],
     "historical": [
-        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/stable/historical-price-eod/full", _stable_hist_url),
         ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
     ],
 }
+
+
+def _normalize_eod_flat_list(data, symbols_str: str):
+    """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
+
+    Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
+    Output : {"symbol": "SPY", "historical": [{"date": ..., "open": ..., ...}, ...]}
+
+    Returns the input unchanged if not a list (passthrough for v3 dict /
+    historicalStockList responses). Returns None when no row matches the
+    requested symbol; the caller will record the failure and try the next
+    endpoint.
+
+    Note: empty list ``[]`` does not reach this normalizer because the caller's
+    ``if not data: continue`` falsy check handles it earlier in
+    ``_request_with_fallback``.
+    """
+    if not isinstance(data, list):
+        return data
+    if not data:
+        return None
+    norm_target = symbols_str.replace("-", ".")
+    matched_symbol = None
+    historical = []
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        # Be permissive: single-symbol endpoint may omit per-row "symbol".
+        # Treat missing symbol as belonging to the requested symbols_str.
+        row_sym = row.get("symbol") or symbols_str
+        if row_sym.replace("-", ".") != norm_target:
+            continue
+        matched_symbol = matched_symbol or row_sym
+        historical.append({k: v for k, v in row.items() if k != "symbol"})
+    if not historical:
+        return None
+    return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
 class FMPClient:
@@ -145,6 +191,14 @@ class FMPClient:
             if not data:
                 self._record_endpoint_failure(base_url)
                 continue
+
+            # Normalize new stable EOD flat-list shape to v3-compatible dict.
+            # No-op for v3 dict / historicalStockList responses.
+            if endpoint_key == "historical":
+                data = _normalize_eod_flat_list(data, symbols_str)
+                if not data:
+                    self._record_endpoint_failure(base_url)
+                    continue
 
             valid = True
             if endpoint_key == "quote":

--- a/skills/ftd-detector/scripts/fmp_client.py
+++ b/skills/ftd-detector/scripts/fmp_client.py
@@ -70,7 +70,7 @@ _FMP_ENDPOINTS = {
 }
 
 
-def _normalize_eod_flat_list(data, symbols_str: str):
+def _normalize_eod_flat_list(data, symbols_str: str, limit: Optional[int] = None):
     """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
 
     Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
@@ -80,6 +80,13 @@ def _normalize_eod_flat_list(data, symbols_str: str):
     historicalStockList responses). Returns None when no row matches the
     requested symbol; the caller will record the failure and try the next
     endpoint.
+
+    If `limit` is provided (the original `timeseries=N` request), the
+    `historical` list is truncated to the first `limit` entries. The new
+    EOD endpoint ignores `timeseries` and returns the full available history,
+    so the caller's date-range bounding plus this truncation together preserve
+    the legacy "most-recent N rows" contract. Truncation assumes descending
+    date order, which the FMP EOD endpoint provides (verified live).
 
     Note: empty list ``[]`` does not reach this normalizer because the caller's
     ``if not data: continue`` falsy check handles it earlier in
@@ -104,6 +111,8 @@ def _normalize_eod_flat_list(data, symbols_str: str):
         historical.append({k: v for k, v in row.items() if k != "symbol"})
     if not historical:
         return None
+    if limit is not None and limit > 0:
+        historical = historical[:limit]
     return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
@@ -194,8 +203,12 @@ class FMPClient:
 
             # Normalize new stable EOD flat-list shape to v3-compatible dict.
             # No-op for v3 dict / historicalStockList responses.
+            # `timeseries` (original request) is passed as `limit` so the
+            # EOD endpoint's full-history response is truncated to the
+            # legacy "most-recent N rows" contract.
             if endpoint_key == "historical":
-                data = _normalize_eod_flat_list(data, symbols_str)
+                limit = params.get("timeseries") if isinstance(params, dict) else None
+                data = _normalize_eod_flat_list(data, symbols_str, limit=limit)
                 if not data:
                     self._record_endpoint_failure(base_url)
                     continue

--- a/skills/ftd-detector/scripts/tests/test_fmp_client.py
+++ b/skills/ftd-detector/scripts/tests/test_fmp_client.py
@@ -354,3 +354,54 @@ class TestCallerRegression:
             ):
                 # Should NOT raise SystemExit — quote failure is non-fatal
                 ftd_detector.main()
+
+
+class TestEODFlatListSuccess:
+    """Issue #64: stable EOD flat list -> public method success (regression)."""
+
+    @patch("fmp_client.requests.Session")
+    def test_get_historical_prices_normalizes_flat_list(self, mock_session_class):
+        """Flat list response from new EOD endpoint -> dict contract preserved."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = _mock_response(
+            200,
+            [
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-29",
+                    "open": 500.0,
+                    "high": 502.0,
+                    "low": 499.0,
+                    "close": 501.0,
+                    "volume": 1_000_000,
+                },
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-28",
+                    "open": 498.0,
+                    "high": 501.0,
+                    "low": 497.0,
+                    "close": 500.0,
+                    "volume": 1_100_000,
+                },
+            ],
+        )
+        mock_session_class.return_value = mock_session
+
+        client = _make_client()
+        client.session = mock_session
+        client.max_retries = 0
+
+        result = client.get_historical_prices("SPY", days=2)
+        assert isinstance(result, dict), f"expected dict, got {type(result).__name__}"
+        assert result["symbol"] == "SPY"
+        assert len(result["historical"]) == 2
+        assert result["historical"][0]["close"] == 501.0
+
+        # URL regression: must hit /historical-price-eod/full with from/to (not timeseries)
+        first_call = mock_session.get.call_args_list[0]
+        url = first_call[0][0]
+        params = first_call[1]["params"]
+        assert "historical-price-eod/full" in url
+        assert "from" in params and "to" in params
+        assert "timeseries" not in params

--- a/skills/macro-regime-detector/scripts/fmp_client.py
+++ b/skills/macro-regime-detector/scripts/fmp_client.py
@@ -56,7 +56,7 @@ _FMP_ENDPOINTS = {
 }
 
 
-def _normalize_eod_flat_list(data, symbols_str: str):
+def _normalize_eod_flat_list(data, symbols_str: str, limit: Optional[int] = None):
     """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
 
     Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
@@ -66,6 +66,13 @@ def _normalize_eod_flat_list(data, symbols_str: str):
     historicalStockList responses). Returns None when no row matches the
     requested symbol; the caller will record the failure and try the next
     endpoint.
+
+    If `limit` is provided (the original `timeseries=N` request), the
+    `historical` list is truncated to the first `limit` entries. The new
+    EOD endpoint ignores `timeseries` and returns the full available history,
+    so the caller's date-range bounding plus this truncation together preserve
+    the legacy "most-recent N rows" contract. Truncation assumes descending
+    date order, which the FMP EOD endpoint provides (verified live).
 
     Note: empty list ``[]`` does not reach this normalizer because the caller's
     ``if not data: continue`` falsy check handles it earlier in
@@ -90,6 +97,8 @@ def _normalize_eod_flat_list(data, symbols_str: str):
         historical.append({k: v for k, v in row.items() if k != "symbol"})
     if not historical:
         return None
+    if limit is not None and limit > 0:
+        historical = historical[:limit]
     return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
@@ -184,8 +193,12 @@ class FMPClient:
 
             # Normalize new stable EOD flat-list shape to v3-compatible dict.
             # No-op for v3 dict / historicalStockList responses.
+            # `timeseries` (original request) is passed as `limit` so the
+            # EOD endpoint's full-history response is truncated to the
+            # legacy "most-recent N rows" contract.
             if endpoint_key == "historical":
-                data = _normalize_eod_flat_list(data, symbols_str)
+                limit = params.get("timeseries") if isinstance(params, dict) else None
+                data = _normalize_eod_flat_list(data, symbols_str, limit=limit)
                 if not data:
                     self._record_endpoint_failure(base_url)
                     continue

--- a/skills/macro-regime-detector/scripts/fmp_client.py
+++ b/skills/macro-regime-detector/scripts/fmp_client.py
@@ -16,6 +16,7 @@ Features:
 import os
 import sys
 import time
+from datetime import date, timedelta
 from typing import Optional
 
 try:
@@ -29,8 +30,16 @@ except ImportError:
 
 
 def _stable_hist_url(base, symbols_str, params):
-    """stable/historical-price-full?symbol=SPY&timeseries=600"""
+    """stable/historical-price-eod/full?symbol=SPY&from=...&to=..."""
     params["symbol"] = symbols_str
+    # New stable EOD endpoint ignores `timeseries`; convert to from/to range
+    # to bound the payload. Use 2x calendar days to cover N trading days
+    # (trading-day/calendar-day ratio ~252/365 ~0.69, so *2 leaves headroom).
+    days = params.pop("timeseries", None)
+    if days is not None:
+        today = date.today()
+        params["from"] = (today - timedelta(days=int(days) * 2)).isoformat()
+        params["to"] = today.isoformat()
     return base, params
 
 
@@ -41,10 +50,47 @@ def _v3_hist_url(base, symbols_str, params):
 
 _FMP_ENDPOINTS = {
     "historical": [
-        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/stable/historical-price-eod/full", _stable_hist_url),
         ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
     ],
 }
+
+
+def _normalize_eod_flat_list(data, symbols_str: str):
+    """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
+
+    Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
+    Output : {"symbol": "SPY", "historical": [{"date": ..., "open": ..., ...}, ...]}
+
+    Returns the input unchanged if not a list (passthrough for v3 dict /
+    historicalStockList responses). Returns None when no row matches the
+    requested symbol; the caller will record the failure and try the next
+    endpoint.
+
+    Note: empty list ``[]`` does not reach this normalizer because the caller's
+    ``if not data: continue`` falsy check handles it earlier in
+    ``_request_with_fallback``.
+    """
+    if not isinstance(data, list):
+        return data
+    if not data:
+        return None
+    norm_target = symbols_str.replace("-", ".")
+    matched_symbol = None
+    historical = []
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        # Be permissive: single-symbol endpoint may omit per-row "symbol".
+        # Treat missing symbol as belonging to the requested symbols_str.
+        row_sym = row.get("symbol") or symbols_str
+        if row_sym.replace("-", ".") != norm_target:
+            continue
+        matched_symbol = matched_symbol or row_sym
+        historical.append({k: v for k, v in row.items() if k != "symbol"})
+    if not historical:
+        return None
+    return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
 class FMPClient:
@@ -135,6 +181,14 @@ class FMPClient:
             if not data:
                 self._record_endpoint_failure(base_url)
                 continue
+
+            # Normalize new stable EOD flat-list shape to v3-compatible dict.
+            # No-op for v3 dict / historicalStockList responses.
+            if endpoint_key == "historical":
+                data = _normalize_eod_flat_list(data, symbols_str)
+                if not data:
+                    self._record_endpoint_failure(base_url)
+                    continue
 
             valid = True
             if endpoint_key == "historical":

--- a/skills/macro-regime-detector/scripts/report_generator.py
+++ b/skills/macro-regime-detector/scripts/report_generator.py
@@ -10,7 +10,7 @@ import json
 
 def generate_json_report(analysis: dict, output_file: str):
     """Save full analysis as JSON"""
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         json.dump(analysis, f, indent=2, default=str)
     print(f"JSON report saved to: {output_file}")
 
@@ -419,7 +419,7 @@ def generate_markdown_report(analysis: dict, output_file: str):
     )
     lines.append("")
 
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         f.write("\n".join(lines))
 
     print(f"Markdown report saved to: {output_file}")

--- a/skills/macro-regime-detector/scripts/tests/test_fmp_client.py
+++ b/skills/macro-regime-detector/scripts/tests/test_fmp_client.py
@@ -1,0 +1,70 @@
+"""Issue #64: stable/historical-price-eod/full normalization for macro-regime-detector."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fmp_client import FMPClient
+
+
+def _make_client():
+    client = FMPClient(api_key="test_key")
+    client.max_retries = 0
+    return client
+
+
+def _mock_response(status_code, json_payload):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_payload
+    resp.text = ""
+    return resp
+
+
+class TestEODFlatListSuccess:
+    @patch("fmp_client.requests.Session")
+    def test_get_historical_prices_normalizes_flat_list(self, mock_session_class):
+        """Flat list response -> dict contract preserved."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = _mock_response(
+            200,
+            [
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-29",
+                    "open": 500.0,
+                    "high": 502.0,
+                    "low": 499.0,
+                    "close": 501.0,
+                    "volume": 1_000_000,
+                },
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-28",
+                    "open": 498.0,
+                    "high": 501.0,
+                    "low": 497.0,
+                    "close": 500.0,
+                    "volume": 1_100_000,
+                },
+            ],
+        )
+        mock_session_class.return_value = mock_session
+
+        client = _make_client()
+        client.session = mock_session
+
+        result = client.get_historical_prices("SPY", days=2)
+        assert isinstance(result, dict), f"expected dict, got {type(result).__name__}"
+        assert result["symbol"] == "SPY"
+        assert len(result["historical"]) == 2
+        assert result["historical"][0]["close"] == 501.0
+
+        first_call = mock_session.get.call_args_list[0]
+        url = first_call[0][0]
+        params = first_call[1]["params"]
+        assert "historical-price-eod/full" in url
+        assert "from" in params and "to" in params
+        assert "timeseries" not in params

--- a/skills/market-top-detector/scripts/fmp_client.py
+++ b/skills/market-top-detector/scripts/fmp_client.py
@@ -70,7 +70,7 @@ _FMP_ENDPOINTS = {
 }
 
 
-def _normalize_eod_flat_list(data, symbols_str: str):
+def _normalize_eod_flat_list(data, symbols_str: str, limit: Optional[int] = None):
     """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
 
     Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
@@ -80,6 +80,13 @@ def _normalize_eod_flat_list(data, symbols_str: str):
     historicalStockList responses). Returns None when no row matches the
     requested symbol; the caller will record the failure and try the next
     endpoint.
+
+    If `limit` is provided (the original `timeseries=N` request), the
+    `historical` list is truncated to the first `limit` entries. The new
+    EOD endpoint ignores `timeseries` and returns the full available history,
+    so the caller's date-range bounding plus this truncation together preserve
+    the legacy "most-recent N rows" contract. Truncation assumes descending
+    date order, which the FMP EOD endpoint provides (verified live).
 
     Note: empty list ``[]`` does not reach this normalizer because the caller's
     ``if not data: continue`` falsy check handles it earlier in
@@ -104,6 +111,8 @@ def _normalize_eod_flat_list(data, symbols_str: str):
         historical.append({k: v for k, v in row.items() if k != "symbol"})
     if not historical:
         return None
+    if limit is not None and limit > 0:
+        historical = historical[:limit]
     return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
@@ -200,8 +209,12 @@ class FMPClient:
 
             # Normalize new stable EOD flat-list shape to v3-compatible dict.
             # No-op for v3 dict / historicalStockList responses.
+            # `timeseries` (original request) is passed as `limit` so the
+            # EOD endpoint's full-history response is truncated to the
+            # legacy "most-recent N rows" contract.
             if endpoint_key == "historical":
-                data = _normalize_eod_flat_list(data, symbols_str)
+                limit = params.get("timeseries") if isinstance(params, dict) else None
+                data = _normalize_eod_flat_list(data, symbols_str, limit=limit)
                 if not data:
                     self._record_endpoint_failure(base_url)
                     continue

--- a/skills/market-top-detector/scripts/fmp_client.py
+++ b/skills/market-top-detector/scripts/fmp_client.py
@@ -15,6 +15,7 @@ Features:
 import os
 import sys
 import time
+from datetime import date, timedelta
 from typing import Optional
 
 try:
@@ -39,8 +40,16 @@ def _v3_quote_url(base, symbols_str, params):
 
 
 def _stable_hist_url(base, symbols_str, params):
-    """stable/historical-price-full?symbol=^GSPC&timeseries=80"""
+    """stable/historical-price-eod/full?symbol=^GSPC&from=...&to=..."""
     params["symbol"] = symbols_str
+    # New stable EOD endpoint ignores `timeseries`; convert to from/to range
+    # to bound the payload. Use 2x calendar days to cover N trading days
+    # (trading-day/calendar-day ratio ~252/365 ~0.69, so *2 leaves headroom).
+    days = params.pop("timeseries", None)
+    if days is not None:
+        today = date.today()
+        params["from"] = (today - timedelta(days=int(days) * 2)).isoformat()
+        params["to"] = today.isoformat()
     return base, params
 
 
@@ -55,10 +64,47 @@ _FMP_ENDPOINTS = {
         ("https://financialmodelingprep.com/api/v3/quote", _v3_quote_url),
     ],
     "historical": [
-        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/stable/historical-price-eod/full", _stable_hist_url),
         ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
     ],
 }
+
+
+def _normalize_eod_flat_list(data, symbols_str: str):
+    """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
+
+    Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
+    Output : {"symbol": "SPY", "historical": [{"date": ..., "open": ..., ...}, ...]}
+
+    Returns the input unchanged if not a list (passthrough for v3 dict /
+    historicalStockList responses). Returns None when no row matches the
+    requested symbol; the caller will record the failure and try the next
+    endpoint.
+
+    Note: empty list ``[]`` does not reach this normalizer because the caller's
+    ``if not data: continue`` falsy check handles it earlier in
+    ``_request_with_fallback``.
+    """
+    if not isinstance(data, list):
+        return data
+    if not data:
+        return None
+    norm_target = symbols_str.replace("-", ".")
+    matched_symbol = None
+    historical = []
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        # Be permissive: single-symbol endpoint may omit per-row "symbol".
+        # Treat missing symbol as belonging to the requested symbols_str.
+        row_sym = row.get("symbol") or symbols_str
+        if row_sym.replace("-", ".") != norm_target:
+            continue
+        matched_symbol = matched_symbol or row_sym
+        historical.append({k: v for k, v in row.items() if k != "symbol"})
+    if not historical:
+        return None
+    return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
 class FMPClient:
@@ -151,6 +197,14 @@ class FMPClient:
             if not data:  # falsy (None, [], {}) — try next endpoint
                 self._record_endpoint_failure(base_url)
                 continue
+
+            # Normalize new stable EOD flat-list shape to v3-compatible dict.
+            # No-op for v3 dict / historicalStockList responses.
+            if endpoint_key == "historical":
+                data = _normalize_eod_flat_list(data, symbols_str)
+                if not data:
+                    self._record_endpoint_failure(base_url)
+                    continue
 
             # Shape validation: reject truthy-but-wrong-shape responses
             valid = True

--- a/skills/market-top-detector/scripts/tests/test_fmp_client.py
+++ b/skills/market-top-detector/scripts/tests/test_fmp_client.py
@@ -510,3 +510,62 @@ class TestEndpointFallback:
 
             captured = capsys.readouterr()
             assert "WARN" in captured.out or "VIX unavailable" in captured.out
+
+
+class TestEODFlatListSuccess:
+    """Issue #64: stable EOD flat list -> public method success (regression)."""
+
+    def _make_client(self):
+        with patch.dict(os.environ, {"FMP_API_KEY": "test_key"}):
+            from fmp_client import FMPClient
+
+            client = FMPClient(api_key="test_key")
+        client.max_retries = 0
+        return client
+
+    @patch("fmp_client.requests.Session")
+    def test_get_historical_prices_normalizes_flat_list(self, mock_session_class):
+        """Flat list response from new EOD endpoint -> dict contract preserved."""
+        mock_session = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [
+            {
+                "symbol": "SPY",
+                "date": "2026-04-29",
+                "open": 500.0,
+                "high": 502.0,
+                "low": 499.0,
+                "close": 501.0,
+                "volume": 1_000_000,
+            },
+            {
+                "symbol": "SPY",
+                "date": "2026-04-28",
+                "open": 498.0,
+                "high": 501.0,
+                "low": 497.0,
+                "close": 500.0,
+                "volume": 1_100_000,
+            },
+        ]
+        mock_resp.text = ""
+        mock_session.get.return_value = mock_resp
+        mock_session_class.return_value = mock_session
+
+        client = self._make_client()
+        client.session = mock_session
+
+        result = client.get_historical_prices("SPY", days=2)
+        assert isinstance(result, dict), f"expected dict, got {type(result).__name__}"
+        assert result["symbol"] == "SPY"
+        assert len(result["historical"]) == 2
+        assert result["historical"][0]["close"] == 501.0
+
+        # URL regression: must hit /historical-price-eod/full with from/to
+        first_call = mock_session.get.call_args_list[0]
+        url = first_call[0][0]
+        params = first_call[1]["params"]
+        assert "historical-price-eod/full" in url
+        assert "from" in params and "to" in params
+        assert "timeseries" not in params

--- a/skills/pead-screener/scripts/fmp_client.py
+++ b/skills/pead-screener/scripts/fmp_client.py
@@ -57,7 +57,7 @@ _FMP_ENDPOINTS = {
 }
 
 
-def _normalize_eod_flat_list(data, symbols_str: str):
+def _normalize_eod_flat_list(data, symbols_str: str, limit: Optional[int] = None):
     """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
 
     Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
@@ -67,6 +67,13 @@ def _normalize_eod_flat_list(data, symbols_str: str):
     historicalStockList responses). Returns None when no row matches the
     requested symbol; the caller will record the failure and try the next
     endpoint.
+
+    If `limit` is provided (the original `timeseries=N` request), the
+    `historical` list is truncated to the first `limit` entries. The new
+    EOD endpoint ignores `timeseries` and returns the full available history,
+    so the caller's date-range bounding plus this truncation together preserve
+    the legacy "most-recent N rows" contract. Truncation assumes descending
+    date order, which the FMP EOD endpoint provides (verified live).
 
     Note: empty list ``[]`` does not reach this normalizer because the caller's
     ``if not data: continue`` falsy check handles it earlier in
@@ -91,6 +98,8 @@ def _normalize_eod_flat_list(data, symbols_str: str):
         historical.append({k: v for k, v in row.items() if k != "symbol"})
     if not historical:
         return None
+    if limit is not None and limit > 0:
+        historical = historical[:limit]
     return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
@@ -207,8 +216,12 @@ class FMPClient:
 
             # Normalize new stable EOD flat-list shape to v3-compatible dict.
             # No-op for v3 dict / historicalStockList responses.
+            # `timeseries` (original request) is passed as `limit` so the
+            # EOD endpoint's full-history response is truncated to the
+            # legacy "most-recent N rows" contract.
             if endpoint_key == "historical":
-                data = _normalize_eod_flat_list(data, symbols_str)
+                limit = params.get("timeseries") if isinstance(params, dict) else None
+                data = _normalize_eod_flat_list(data, symbols_str, limit=limit)
                 if not data:
                     self._record_endpoint_failure(base_url)
                     continue

--- a/skills/pead-screener/scripts/fmp_client.py
+++ b/skills/pead-screener/scripts/fmp_client.py
@@ -17,6 +17,7 @@ Features:
 import os
 import sys
 import time
+from datetime import date, timedelta
 from typing import Optional
 
 try:
@@ -30,8 +31,16 @@ except ImportError:
 
 
 def _stable_hist_url(base, symbols_str, params):
-    """stable/historical-price-full?symbol=SPY&timeseries=90"""
+    """stable/historical-price-eod/full?symbol=SPY&from=...&to=..."""
     params["symbol"] = symbols_str
+    # New stable EOD endpoint ignores `timeseries`; convert to from/to range
+    # to bound the payload. Use 2x calendar days to cover N trading days
+    # (trading-day/calendar-day ratio ~252/365 ~0.69, so *2 leaves headroom).
+    days = params.pop("timeseries", None)
+    if days is not None:
+        today = date.today()
+        params["from"] = (today - timedelta(days=int(days) * 2)).isoformat()
+        params["to"] = today.isoformat()
     return base, params
 
 
@@ -42,10 +51,47 @@ def _v3_hist_url(base, symbols_str, params):
 
 _FMP_ENDPOINTS = {
     "historical": [
-        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/stable/historical-price-eod/full", _stable_hist_url),
         ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
     ],
 }
+
+
+def _normalize_eod_flat_list(data, symbols_str: str):
+    """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
+
+    Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
+    Output : {"symbol": "SPY", "historical": [{"date": ..., "open": ..., ...}, ...]}
+
+    Returns the input unchanged if not a list (passthrough for v3 dict /
+    historicalStockList responses). Returns None when no row matches the
+    requested symbol; the caller will record the failure and try the next
+    endpoint.
+
+    Note: empty list ``[]`` does not reach this normalizer because the caller's
+    ``if not data: continue`` falsy check handles it earlier in
+    ``_request_with_fallback``.
+    """
+    if not isinstance(data, list):
+        return data
+    if not data:
+        return None
+    norm_target = symbols_str.replace("-", ".")
+    matched_symbol = None
+    historical = []
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        # Be permissive: single-symbol endpoint may omit per-row "symbol".
+        # Treat missing symbol as belonging to the requested symbols_str.
+        row_sym = row.get("symbol") or symbols_str
+        if row_sym.replace("-", ".") != norm_target:
+            continue
+        matched_symbol = matched_symbol or row_sym
+        historical.append({k: v for k, v in row.items() if k != "symbol"})
+    if not historical:
+        return None
+    return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
 class ApiCallBudgetExceeded(Exception):
@@ -158,6 +204,14 @@ class FMPClient:
             if not data:  # falsy (None, [], {}) -- try next endpoint
                 self._record_endpoint_failure(base_url)
                 continue
+
+            # Normalize new stable EOD flat-list shape to v3-compatible dict.
+            # No-op for v3 dict / historicalStockList responses.
+            if endpoint_key == "historical":
+                data = _normalize_eod_flat_list(data, symbols_str)
+                if not data:
+                    self._record_endpoint_failure(base_url)
+                    continue
 
             # Shape validation: reject truthy-but-wrong-shape responses
             valid = True

--- a/skills/pead-screener/scripts/tests/test_pead_screener.py
+++ b/skills/pead-screener/scripts/tests/test_pead_screener.py
@@ -1042,6 +1042,43 @@ class TestFMPHistoricalNormalizer:
         return client
 
     @patch("fmp_client.requests.Session")
+    def test_eod_flat_list_truncated_to_days(self, mock_session_class):
+        """Contract: returned historical is truncated to `days` rows.
+
+        The new EOD endpoint ignores `timeseries` and returns full history.
+        The normalizer must truncate so callers receive at most N rows,
+        preserving the legacy v3 `timeseries=N` contract.
+        """
+        mock_session = MagicMock()
+        mock_session.get.return_value = self._mock_response(
+            200,
+            [
+                {
+                    "symbol": "SPY",
+                    "date": f"2026-04-{30 - i:02d}",
+                    "open": 500.0,
+                    "high": 502.0,
+                    "low": 499.0,
+                    "close": 500.0 + i,
+                    "volume": 1_000_000,
+                }
+                for i in range(5)
+            ],
+        )
+        mock_session_class.return_value = mock_session
+        client = self._make_client(mock_session)
+
+        result = client.get_historical_prices("SPY", days=2)
+        assert result is not None
+        # API returned 5 rows but we requested days=2; normalizer must truncate
+        assert len(result["historical"]) == 2, (
+            f"expected truncation to 2 rows, got {len(result['historical'])}"
+        )
+        # Most recent first preserved
+        assert result["historical"][0]["date"] == "2026-04-30"
+        assert result["historical"][1]["date"] == "2026-04-29"
+
+    @patch("fmp_client.requests.Session")
     def test_eod_flat_list_normalized(self, mock_session_class):
         """New stable EOD flat list -> v3-compat dict with historical[]."""
         mock_session = MagicMock()

--- a/skills/pead-screener/scripts/tests/test_pead_screener.py
+++ b/skills/pead-screener/scripts/tests/test_pead_screener.py
@@ -1023,6 +1023,186 @@ class TestFMPClient:
             assert "budget exhausted" in str(e).lower()
 
 
+class TestFMPHistoricalNormalizer:
+    """Cover stable/historical-price-eod/full flat-list normalization (Issue #64)."""
+
+    @staticmethod
+    def _mock_response(status_code, json_payload):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = json_payload
+        resp.text = ""
+        return resp
+
+    @staticmethod
+    def _make_client(mock_session):
+        client = FMPClient(api_key="test_key", max_api_calls=200)
+        client.session = mock_session
+        client.max_retries = 0
+        return client
+
+    @patch("fmp_client.requests.Session")
+    def test_eod_flat_list_normalized(self, mock_session_class):
+        """New stable EOD flat list -> v3-compat dict with historical[]."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = self._mock_response(
+            200,
+            [
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-29",
+                    "open": 500.0,
+                    "high": 502.0,
+                    "low": 499.0,
+                    "close": 501.0,
+                    "volume": 1_000_000,
+                },
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-28",
+                    "open": 498.0,
+                    "high": 501.0,
+                    "low": 497.0,
+                    "close": 500.0,
+                    "volume": 1_100_000,
+                },
+            ],
+        )
+        mock_session_class.return_value = mock_session
+        client = self._make_client(mock_session)
+
+        result = client.get_historical_prices("SPY", days=2)
+        assert result is not None
+        assert result["symbol"] == "SPY"
+        assert len(result["historical"]) == 2
+        assert result["historical"][0]["date"] == "2026-04-29"
+        assert result["historical"][0]["close"] == 501.0
+        assert "symbol" not in result["historical"][0], (
+            "row-level symbol should be stripped to mirror v3 shape"
+        )
+
+    @patch("fmp_client.requests.Session")
+    def test_empty_list_falls_back_via_falsy_path(self, mock_session_class):
+        """Empty list response is caught by `if not data: continue` before normalizer."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = self._mock_response(200, [])
+        mock_session_class.return_value = mock_session
+        client = self._make_client(mock_session)
+
+        result = client.get_historical_prices("SPY", days=2)
+        # Both stable and v3 fallback see empty/None -> final result None
+        assert result is None
+
+    @patch("fmp_client.requests.Session")
+    def test_eod_symbol_mismatch_rejected(self, mock_session_class):
+        """List with no matching symbol -> normalizer returns None, fallback exhausted."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = self._mock_response(
+            200,
+            [{"symbol": "QQQ", "date": "2026-04-29", "open": 1.0, "close": 1.0}],
+        )
+        mock_session_class.return_value = mock_session
+        client = self._make_client(mock_session)
+
+        result = client.get_historical_prices("SPY", days=2)
+        assert result is None
+
+    @patch("fmp_client.requests.Session")
+    def test_eod_row_without_symbol_field(self, mock_session_class):
+        """Single-symbol endpoint may omit per-row 'symbol' -> treat as requested symbol."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = self._mock_response(
+            200,
+            [
+                {"date": "2026-04-29", "open": 500.0, "close": 501.0},
+                {"date": "2026-04-28", "open": 498.0, "close": 500.0},
+            ],
+        )
+        mock_session_class.return_value = mock_session
+        client = self._make_client(mock_session)
+
+        result = client.get_historical_prices("SPY", days=2)
+        assert result is not None
+        assert result["symbol"] == "SPY"
+        assert len(result["historical"]) == 2
+        assert result["historical"][0]["close"] == 501.0
+
+    @patch("fmp_client.requests.Session")
+    def test_eod_index_symbol_normalized(self, mock_session_class):
+        """Dot/dash normalization (BRK.B vs BRK-B style) works."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = self._mock_response(
+            200,
+            [{"symbol": "BRK.B", "date": "2026-04-29", "open": 400.0, "close": 401.0}],
+        )
+        mock_session_class.return_value = mock_session
+        client = self._make_client(mock_session)
+
+        result = client.get_historical_prices("BRK-B", days=1)
+        assert result is not None
+        assert result["historical"][0]["close"] == 401.0
+
+    @patch("fmp_client.requests.Session")
+    def test_legacy_v3_dict_passthrough(self, mock_session_class):
+        """v3 fallback dict shape passes normalizer untouched."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = self._mock_response(
+            200,
+            {"symbol": "SPY", "historical": [{"date": "2026-04-29", "close": 501.0}]},
+        )
+        mock_session_class.return_value = mock_session
+        client = self._make_client(mock_session)
+
+        result = client.get_historical_prices("SPY", days=1)
+        assert result is not None
+        assert result["historical"][0]["close"] == 501.0
+
+    @patch("fmp_client.requests.Session")
+    def test_legacy_historicalStockList_still_works(self, mock_session_class):
+        """historicalStockList batch shape still handled by existing branch."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = self._mock_response(
+            200,
+            {
+                "historicalStockList": [
+                    {"symbol": "SPY", "historical": [{"date": "2026-04-29", "close": 501.0}]},
+                    {"symbol": "QQQ", "historical": [{"date": "2026-04-29", "close": 400.0}]},
+                ]
+            },
+        )
+        mock_session_class.return_value = mock_session
+        client = self._make_client(mock_session)
+
+        result = client.get_historical_prices("SPY", days=1)
+        assert result is not None
+        assert result["symbol"] == "SPY"
+        assert result["historical"][0]["close"] == 501.0
+
+    @patch("fmp_client.requests.Session")
+    def test_url_uses_eod_endpoint(self, mock_session_class):
+        """Regression: stable URL must be /historical-price-eod/full, not /historical-price-full."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = self._mock_response(
+            200,
+            [{"symbol": "SPY", "date": "2026-04-29", "close": 1.0}],
+        )
+        mock_session_class.return_value = mock_session
+        client = self._make_client(mock_session)
+
+        client.get_historical_prices("SPY", days=1)
+        # First call should hit the new EOD URL with from/to params (not timeseries)
+        first_call = mock_session.get.call_args_list[0]
+        url = first_call[0][0]
+        params = first_call[1]["params"]
+        assert "historical-price-eod/full" in url
+        assert "historical-price-full" not in url.replace("historical-price-eod/full", "")
+        assert params.get("symbol") == "SPY"
+        assert "from" in params and "to" in params
+        assert "timeseries" not in params, (
+            "timeseries must be converted to from/to since stable EOD ignores timeseries"
+        )
+
+
 # ===========================================================================
 # TestPartialWeekBoundary
 # ===========================================================================

--- a/skills/vcp-screener/scripts/fmp_client.py
+++ b/skills/vcp-screener/scripts/fmp_client.py
@@ -16,6 +16,7 @@ Features:
 import os
 import sys
 import time
+from datetime import date, timedelta
 from typing import Optional
 
 try:
@@ -40,8 +41,16 @@ def _v3_quote_url(base, symbols_str, params):
 
 
 def _stable_hist_url(base, symbols_str, params):
-    """stable/historical-price-full?symbol=^GSPC&timeseries=80"""
+    """stable/historical-price-eod/full?symbol=^GSPC&from=...&to=..."""
     params["symbol"] = symbols_str
+    # New stable EOD endpoint ignores `timeseries`; convert to from/to range
+    # to bound the payload. Use 2x calendar days to cover N trading days
+    # (trading-day/calendar-day ratio ~252/365 ~0.69, so *2 leaves headroom).
+    days = params.pop("timeseries", None)
+    if days is not None:
+        today = date.today()
+        params["from"] = (today - timedelta(days=int(days) * 2)).isoformat()
+        params["to"] = today.isoformat()
     return base, params
 
 
@@ -56,10 +65,47 @@ _FMP_ENDPOINTS = {
         ("https://financialmodelingprep.com/api/v3/quote", _v3_quote_url),
     ],
     "historical": [
-        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/stable/historical-price-eod/full", _stable_hist_url),
         ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
     ],
 }
+
+
+def _normalize_eod_flat_list(data, symbols_str: str):
+    """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
+
+    Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
+    Output : {"symbol": "SPY", "historical": [{"date": ..., "open": ..., ...}, ...]}
+
+    Returns the input unchanged if not a list (passthrough for v3 dict /
+    historicalStockList responses). Returns None when no row matches the
+    requested symbol; the caller will record the failure and try the next
+    endpoint.
+
+    Note: empty list ``[]`` does not reach this normalizer because the caller's
+    ``if not data: continue`` falsy check handles it earlier in
+    ``_request_with_fallback``.
+    """
+    if not isinstance(data, list):
+        return data
+    if not data:
+        return None
+    norm_target = symbols_str.replace("-", ".")
+    matched_symbol = None
+    historical = []
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        # Be permissive: single-symbol endpoint may omit per-row "symbol".
+        # Treat missing symbol as belonging to the requested symbols_str.
+        row_sym = row.get("symbol") or symbols_str
+        if row_sym.replace("-", ".") != norm_target:
+            continue
+        matched_symbol = matched_symbol or row_sym
+        historical.append({k: v for k, v in row.items() if k != "symbol"})
+    if not historical:
+        return None
+    return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
 class FMPClient:
@@ -152,6 +198,14 @@ class FMPClient:
             if not data:  # falsy (None, [], {}) — try next endpoint
                 self._record_endpoint_failure(base_url)
                 continue
+
+            # Normalize new stable EOD flat-list shape to v3-compatible dict.
+            # No-op for v3 dict / historicalStockList responses.
+            if endpoint_key == "historical":
+                data = _normalize_eod_flat_list(data, symbols_str)
+                if not data:
+                    self._record_endpoint_failure(base_url)
+                    continue
 
             # Shape validation: reject truthy-but-wrong-shape responses
             valid = True

--- a/skills/vcp-screener/scripts/fmp_client.py
+++ b/skills/vcp-screener/scripts/fmp_client.py
@@ -71,7 +71,7 @@ _FMP_ENDPOINTS = {
 }
 
 
-def _normalize_eod_flat_list(data, symbols_str: str):
+def _normalize_eod_flat_list(data, symbols_str: str, limit: Optional[int] = None):
     """Convert stable/historical-price-eod/full flat list to v3-compatible dict.
 
     Input  : [{"symbol": "SPY", "date": "...", "open": ..., ...}, ...]
@@ -81,6 +81,13 @@ def _normalize_eod_flat_list(data, symbols_str: str):
     historicalStockList responses). Returns None when no row matches the
     requested symbol; the caller will record the failure and try the next
     endpoint.
+
+    If `limit` is provided (the original `timeseries=N` request), the
+    `historical` list is truncated to the first `limit` entries. The new
+    EOD endpoint ignores `timeseries` and returns the full available history,
+    so the caller's date-range bounding plus this truncation together preserve
+    the legacy "most-recent N rows" contract. Truncation assumes descending
+    date order, which the FMP EOD endpoint provides (verified live).
 
     Note: empty list ``[]`` does not reach this normalizer because the caller's
     ``if not data: continue`` falsy check handles it earlier in
@@ -105,6 +112,8 @@ def _normalize_eod_flat_list(data, symbols_str: str):
         historical.append({k: v for k, v in row.items() if k != "symbol"})
     if not historical:
         return None
+    if limit is not None and limit > 0:
+        historical = historical[:limit]
     return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
@@ -201,8 +210,12 @@ class FMPClient:
 
             # Normalize new stable EOD flat-list shape to v3-compatible dict.
             # No-op for v3 dict / historicalStockList responses.
+            # `timeseries` (original request) is passed as `limit` so the
+            # EOD endpoint's full-history response is truncated to the
+            # legacy "most-recent N rows" contract.
             if endpoint_key == "historical":
-                data = _normalize_eod_flat_list(data, symbols_str)
+                limit = params.get("timeseries") if isinstance(params, dict) else None
+                data = _normalize_eod_flat_list(data, symbols_str, limit=limit)
                 if not data:
                     self._record_endpoint_failure(base_url)
                     continue

--- a/skills/vcp-screener/scripts/tests/test_fmp_client_historical.py
+++ b/skills/vcp-screener/scripts/tests/test_fmp_client_historical.py
@@ -1,0 +1,70 @@
+"""Issue #64: stable/historical-price-eod/full normalization for macro-regime-detector."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fmp_client import FMPClient
+
+
+def _make_client():
+    client = FMPClient(api_key="test_key")
+    client.max_retries = 0
+    return client
+
+
+def _mock_response(status_code, json_payload):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_payload
+    resp.text = ""
+    return resp
+
+
+class TestEODFlatListSuccess:
+    @patch("fmp_client.requests.Session")
+    def test_get_historical_prices_normalizes_flat_list(self, mock_session_class):
+        """Flat list response -> dict contract preserved."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = _mock_response(
+            200,
+            [
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-29",
+                    "open": 500.0,
+                    "high": 502.0,
+                    "low": 499.0,
+                    "close": 501.0,
+                    "volume": 1_000_000,
+                },
+                {
+                    "symbol": "SPY",
+                    "date": "2026-04-28",
+                    "open": 498.0,
+                    "high": 501.0,
+                    "low": 497.0,
+                    "close": 500.0,
+                    "volume": 1_100_000,
+                },
+            ],
+        )
+        mock_session_class.return_value = mock_session
+
+        client = _make_client()
+        client.session = mock_session
+
+        result = client.get_historical_prices("SPY", days=2)
+        assert isinstance(result, dict), f"expected dict, got {type(result).__name__}"
+        assert result["symbol"] == "SPY"
+        assert len(result["historical"]) == 2
+        assert result["historical"][0]["close"] == 501.0
+
+        first_call = mock_session.get.call_args_list[0]
+        url = first_call[0][0]
+        params = first_call[1]["params"]
+        assert "historical-price-eod/full" in url
+        assert "from" in params and "to" in params
+        assert "timeseries" not in params

--- a/skills/vcp-screener/scripts/tests/test_fmp_client_historical.py
+++ b/skills/vcp-screener/scripts/tests/test_fmp_client_historical.py
@@ -1,4 +1,4 @@
-"""Issue #64: stable/historical-price-eod/full normalization for macro-regime-detector."""
+"""Issue #64: stable/historical-price-eod/full normalization for vcp-screener."""
 
 import os
 import sys


### PR DESCRIPTION
## Summary

Fixes #64.

The `stable/historical-price-full` FMP endpoint returns **HTTP 404** for current accounts (Starter plan and newer), breaking historical-price retrieval in **7 skills**. The replacement endpoint `stable/historical-price-eod/full` also has a different response shape (flat list of dicts instead of `{"symbol", "historical": [...]}`), so a URL change alone is insufficient.

This PR migrates all 7 affected `fmp_client.py` modules and fixes a related Windows encoding crash in `macro-regime-detector/report_generator.py`.

### Affected skills (7)

`pead-screener`, `macro-regime-detector`, `canslim-screener`, `earnings-trade-analyzer`, `ftd-detector`, `market-top-detector`, `vcp-screener`

## What changed

### Per fmp_client.py (7 files)
- Update stable URL to `stable/historical-price-eod/full`
- Convert `timeseries=N` parameter to `from`/`to` date range. **Live verification confirmed `timeseries` is fully ignored on the new endpoint (returns ~1255 rows for any value)**, so a date-range conversion is required to bound payload size. Uses 2x calendar days as buffer to safely cover N trading days.
- Add module-level `_normalize_eod_flat_list` helper that:
  - Passes through dict responses (v3 fallback / `historicalStockList`) unchanged — no regression for legacy users
  - Converts flat list to v3-compatible `{"symbol", "historical"}` dict
  - Permissive on missing per-row `symbol` field (single-symbol endpoint may omit it)
  - Returns `None` for symbol mismatch so the caller falls back to v3
- Insert normalizer call in `_request_with_fallback` before existing validation (gated by `endpoint_key == "historical"` so `quote` paths are unaffected)

### macro-regime-detector/report_generator.py
- Add `encoding="utf-8"` to both `open()` calls (JSON L13, Markdown L422). The Markdown writer uses zone emoji 🟢🟡🟠🔴⚫⚪ which raised `UnicodeEncodeError` on Windows (cp1252).

### Tests
- `pead-screener` `TestFMPHistoricalNormalizer` (8 cases) — canonical reference
- `earnings-trade-analyzer` new `test_fmp_client_historical.py` — pins this skill's `Optional[list[dict]]` contract (different from the other 6 which return `Optional[dict]`)
- 5 other skills — flat-list success test + URL regression test in each fmp_client test file

Each test asserts: (1) public method returns expected contract type, (2) URL hits `historical-price-eod/full`, (3) `timeseries` is converted to `from`/`to`. A missing normalizer call in any of the 7 fmp_client modules will surface as a test failure rather than silent breakage.

## Verification

### Live endpoint
```
HTTP 404  stable/historical-price-full?symbol=SPY&timeseries=5  (broken)
HTTP 200  stable/historical-price-eod/full?symbol=SPY&from=...&to=...  (working)
```

### E2E smoke (with FMP_API_KEY)
All 7 skills successfully fetch `SPY` data via `get_historical_prices()`. `earnings-trade-analyzer` correctly returns `list`; the other 6 return `dict`.

### Test gate
`scripts/run_all_tests.sh` (= pre-push hook): **43/43 passed** (theme-detector and canslim-screener are pre-existing skips unrelated to this PR; canslim-screener tests for this PR pass when run directly: 35 passed).

### Windows encoding smoke
`LC_ALL=C python -c "...generate_markdown_report(...)..."` succeeds after the fix (raised `UnicodeEncodeError` before).

## Out of scope (follow-up issues to file)

These contain `stable/historical-price-full` URL references but use thin adapters or independent fallback structures, not the shared `_request_with_fallback` pattern. They warrant a separate audit:

- `skills/pair-trade-screener/scripts/find_pairs.py:114`
- `skills/theme-detector/scripts/etf_scanner.py:71`
- `skills/trader-memory-core/scripts/fmp_price_adapter.py:18`
- `skills/dividend-growth-pullback-screener/`, `skills/value-dividend-screener/` URL refs
- `references/`, `SKILL.md` documentation URL mentions
- Extracting `_shared/fmp_normalizer.py` to remove the 7-fold duplication (DRY)

## Test plan

- [x] Live FMP endpoint check (HTTP 200, flat list, descending date order)
- [x] All 7 skills' test suites pass in isolation (run_all_tests.sh)
- [x] 14 new normalizer/regression tests pass
- [x] `LC_ALL=C` smoke for encoding fix
- [x] pre-commit (ruff, ruff-format, codespell, detect-secrets, etc.) clean
- [x] pre-push hook clean (43/43 skill suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)