### PR TITLE
docs(parabolic-short): runbook quality fix — --fmp-only + rejection logging

### DIFF
--- a/skills/parabolic-short-trade-planner/references/smoke_test_runbook.md
+++ b/skills/parabolic-short-trade-planner/references/smoke_test_runbook.md
@@ -76,6 +76,41 @@ If any gate fails, the script prints `FAIL <name> — HTTP <code> — <body
 truncated>`. Common failure causes are documented in the
 **Troubleshooting matrix** at the end.
 
+### 2a. FMP-only mode (no Alpaca credentials)
+
+Contributors who only have an FMP key configured can validate the
+FMP wire shape without needing Alpaca paper credentials:
+
+```bash
+python3 skills/parabolic-short-trade-planner/scripts/check_live_apis.py --fmp-only
+```
+
+Expected output:
+
+```
+Mode: --fmp-only (Alpaca gates will be skipped)
+PASS fmp.historical_price_eod_full — N bars; Issue #64 shape verified
+PASS fmp.profile — mktCap=...
+PASS fmp.sp500_constituent — N constituents
+SKIP alpaca.assets_aapl — explicitly skipped via --fmp-only
+SKIP alpaca.assets_404_graceful — explicitly skipped via --fmp-only
+Required gates: 2/2 passed (FMP only; Alpaca gates skipped, sp500 is optional warning)
+```
+
+Exit code is 0 when the FMP required gates pass. The Alpaca gates
+print as `SKIP` and never count toward the exit code in this mode.
+
+If you forget the flag and Alpaca creds are unset, the script still
+runs the FMP gates, prints `SKIP` for the Alpaca gates, and tells you
+to either pass `--fmp-only` or set the Alpaca env vars. This avoids
+the previous behaviour of aborting at setup.
+
+The Alpaca gates (`alpaca.assets_aapl`, `alpaca.assets_404_graceful`)
+are **maintainer-only** verification when FMP is the only API the
+contributor has access to. Production deployment of Phase 2 / Phase 3
+still requires Alpaca credentials — `--fmp-only` is for runbook
+validation, not production use.
+
 ## 3. Phase 1 — Tier 1 rejection smoke (`smoke_universe_diverse.csv`)
 
 ```bash
@@ -93,6 +128,30 @@ mid-caps), so most or all tickers will reject at the soft thresholds
 (`min_roc_5d`, `min_ma20_extension_pct`). **Zero candidates is a PASS
 for this tier** provided `--verbose` shows at least one rejection
 reason, which proves the invalidation path is live.
+
+Expected `--verbose` rejection log (one line per rejected ticker,
+under `INFO parabolic_short.screen Universe size: ...`):
+
+```
+DEBUG parabolic_short.screen Rejected JNJ: min_roc_5d threshold not met (got -0.13%, need >=30.00%)
+DEBUG parabolic_short.screen Rejected PG: min_roc_5d threshold not met (got -0.62%, need >=30.00%)
+DEBUG parabolic_short.screen Rejected KO: min_roc_5d threshold not met (got 2.54%, need >=30.00%)
+...
+```
+
+Other rejection reasons that may appear depending on the CSV /
+market state:
+
+- `Rejected <T>: insufficient_history (<N> bars; need >=21)` — recent
+  IPO or post-split; the screener cannot compute its 20-bar metrics.
+- `Rejected <T>: invalidation (<reasons>)` — hard-gate rejection
+  (market cap below mode floor, ADV below floor, earnings within
+  window, IPO too recent, catalyst blackout).
+- `Rejected <T>: min_ma20_extension_pct threshold not met (got <X>%, need >=<Y>%)`
+- `Rejected <T>: min_atr_extension threshold not met (got <X>, need >=<Y>)`
+
+Tier 1 PASS requires at least one such rejection line — that proves
+the rejection path is live, not silently swallowed.
 
 Output:
 

--- a/skills/parabolic-short-trade-planner/scripts/check_live_apis.py
+++ b/skills/parabolic-short-trade-planner/scripts/check_live_apis.py
@@ -29,6 +29,7 @@ first 200 chars of the error body on failures.
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 from datetime import date, timedelta
@@ -67,6 +68,10 @@ def _print_warn(name: str, detail: str) -> None:
 
 def _print_fail(name: str, detail: str) -> None:
     print(f"FAIL {name} — {detail}")
+
+
+def _print_skip(name: str, detail: str) -> None:
+    print(f"SKIP {name} — {detail}")
 
 
 def check_fmp_historical(api_key: str) -> bool:
@@ -252,9 +257,29 @@ def check_alpaca_404_graceful(api_key: str, secret: str, paper: bool) -> bool:
     return True
 
 
-def main() -> int:
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Live API smoke check for parabolic-short-trade-planner",
+    )
+    p.add_argument(
+        "--fmp-only",
+        action="store_true",
+        help=(
+            "Skip Alpaca gates entirely. Useful for contributors who only have "
+            "an FMP key configured. Exit 0 when the FMP required gates pass; "
+            "the Alpaca gates are reported as SKIP and never gate the exit code."
+        ),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+
     print("=" * 70)
     print("Parabolic Short — live API smoke check")
+    if args.fmp_only:
+        print("Mode: --fmp-only (Alpaca gates will be skipped)")
     print("=" * 70)
 
     fmp_key = os.environ.get("FMP_API_KEY")
@@ -265,22 +290,54 @@ def main() -> int:
     if not fmp_key:
         print("FAIL setup — FMP_API_KEY env var is missing")
         return 1
-    if not alpaca_key or not alpaca_secret:
-        print("FAIL setup — ALPACA_API_KEY / ALPACA_SECRET_KEY env vars are missing")
-        return 1
 
-    results = {
+    # Run the FMP gates first; they don't depend on Alpaca config.
+    results: dict[str, bool] = {
         "fmp_historical": check_fmp_historical(fmp_key),
         "fmp_profile": check_fmp_profile(fmp_key),
         "fmp_sp500": check_fmp_sp500(fmp_key),  # optional, never gates exit code
-        "alpaca_assets_aapl": check_alpaca_assets_aapl(alpaca_key, alpaca_secret, alpaca_paper),
-        "alpaca_404_graceful": check_alpaca_404_graceful(alpaca_key, alpaca_secret, alpaca_paper),
     }
 
-    required = ("fmp_historical", "fmp_profile", "alpaca_assets_aapl", "alpaca_404_graceful")
-    passed = sum(1 for k in required if results[k])
+    # Decide whether to run the Alpaca gates.
+    alpaca_skipped = args.fmp_only or not alpaca_key or not alpaca_secret
+
+    if alpaca_skipped:
+        if args.fmp_only:
+            reason = "explicitly skipped via --fmp-only"
+        else:
+            reason = "ALPACA_API_KEY / ALPACA_SECRET_KEY env vars not configured"
+        _print_skip("alpaca.assets_aapl", reason)
+        _print_skip("alpaca.assets_404_graceful", reason)
+    else:
+        results["alpaca_assets_aapl"] = check_alpaca_assets_aapl(
+            alpaca_key, alpaca_secret, alpaca_paper
+        )
+        results["alpaca_404_graceful"] = check_alpaca_404_graceful(
+            alpaca_key, alpaca_secret, alpaca_paper
+        )
+
+    # Required-gate set depends on whether Alpaca was skipped. In either case
+    # the FMP gates are required; the Alpaca gates are only required when
+    # they were actually attempted.
+    required = ["fmp_historical", "fmp_profile"]
+    if not alpaca_skipped:
+        required.extend(["alpaca_assets_aapl", "alpaca_404_graceful"])
+
+    passed = sum(1 for k in required if results.get(k))
     print("-" * 70)
-    print(f"Required gates: {passed}/{len(required)} passed (sp500 is optional warning)")
+    if alpaca_skipped:
+        print(
+            f"Required gates: {passed}/{len(required)} passed "
+            f"(FMP only; Alpaca gates skipped, sp500 is optional warning)"
+        )
+        if not args.fmp_only:
+            print(
+                "Note: pass --fmp-only to acknowledge intent, or set ALPACA_API_KEY / "
+                "ALPACA_SECRET_KEY to run the full check."
+            )
+    else:
+        print(f"Required gates: {passed}/{len(required)} passed (sp500 is optional warning)")
+
     return 0 if passed == len(required) else 1
 
 

--- a/skills/parabolic-short-trade-planner/scripts/screen_parabolic.py
+++ b/skills/parabolic-short-trade-planner/scripts/screen_parabolic.py
@@ -99,6 +99,7 @@ def screen_one_candidate(
     """
     bars = normalize_bars(bars_recent_first, output_order="chronological")
     if len(bars) < 21:  # need at least 20 bars for MA / ATR / range expansion
+        logger.debug("Rejected %s: insufficient_history (%d bars; need >=21)", ticker, len(bars))
         return None
 
     closes = [b["close"] for b in bars]
@@ -129,18 +130,40 @@ def screen_one_candidate(
 
     invalidation = check_invalidation(candidate_for_invalidation, mode=mode)
     if invalidation["is_invalid"]:
-        logger.debug("%s rejected: %s", ticker, ", ".join(invalidation["reasons"]))
+        logger.debug("Rejected %s: invalidation (%s)", ticker, ", ".join(invalidation["reasons"]))
         return None
 
     # Threshold gates from CLI (these are softer than invalidation — they
-    # filter watchlist size, not safety).
+    # filter watchlist size, not safety). Log per-ticker at DEBUG so
+    # `--verbose` runs surface the smoke-runbook Tier-1 PASS evidence
+    # ("--verbose documents at least one rejection reason").
     min_roc_5d = args.min_roc_5d if args.min_roc_5d is not None else DEFAULT_MIN_ROC_5D[mode]
-    if (raw_metrics.get("return_5d_pct") or 0) < min_roc_5d:
+    return_5d = raw_metrics.get("return_5d_pct") or 0
+    if return_5d < min_roc_5d:
+        logger.debug(
+            "Rejected %s: min_roc_5d threshold not met (got %.2f%%, need >=%.2f%%)",
+            ticker,
+            return_5d,
+            min_roc_5d,
+        )
         return None
-    if (raw_metrics.get("ext_20dma_pct") or 0) < args.min_ma20_extension_pct:
+    ext_pct = raw_metrics.get("ext_20dma_pct") or 0
+    if ext_pct < args.min_ma20_extension_pct:
+        logger.debug(
+            "Rejected %s: min_ma20_extension_pct threshold not met (got %.2f%%, need >=%.2f%%)",
+            ticker,
+            ext_pct,
+            args.min_ma20_extension_pct,
+        )
         return None
     ext_atr = raw_metrics.get("ext_20dma_atr")
     if ext_atr is None or ext_atr < args.min_atr_extension:
+        logger.debug(
+            "Rejected %s: min_atr_extension threshold not met (got %s, need >=%.2f)",
+            ticker,
+            f"{ext_atr:.2f}" if ext_atr is not None else "None",
+            args.min_atr_extension,
+        )
         return None
 
     composite = calculate_composite_score(component_payload["components"])
@@ -277,6 +300,12 @@ def main(argv: list[str] | None = None) -> int:
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(levelname)s %(name)s %(message)s",
     )
+    # Quiet HTTP-library noise so per-ticker rejection logs are
+    # visible under --verbose. Without this, urllib3.connectionpool
+    # DEBUG lines bury the application-level rejection messages the
+    # smoke runbook's Tier 1 PASS criterion looks for.
+    for noisy in ("urllib3", "urllib3.connectionpool"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
     as_of = args.as_of or datetime.now().date().isoformat()
 
     if args.dry_run:

--- a/skills/parabolic-short-trade-planner/scripts/tests/test_check_live_apis.py
+++ b/skills/parabolic-short-trade-planner/scripts/tests/test_check_live_apis.py
@@ -1,0 +1,146 @@
+"""Tests for check_live_apis.py — focused on the --fmp-only path
+and the missing-Alpaca SKIP behaviour added to address the runbook
+gap surfaced during the live smoke run.
+
+Network is mocked at the requests.get level so these stay offline.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import check_live_apis as cla
+
+
+def _fmp_historical_response() -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = [
+        {
+            "date": "2026-05-01",
+            "open": 1.0,
+            "high": 1.1,
+            "low": 0.9,
+            "close": 1.0,
+            "volume": 1000,
+        }
+    ]
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _fmp_profile_response() -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = [{"symbol": "AAPL", "mktCap": 4_000_000_000_000}]
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _fmp_sp500_response() -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = [{"symbol": "AAPL"}, {"symbol": "MSFT"}]
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _route_get(url: str, **_kwargs):
+    """Dispatch mocked GET responses by URL substring."""
+    if "historical-price-eod/full" in url:
+        return _fmp_historical_response()
+    if "/profile/" in url:
+        return _fmp_profile_response()
+    if "/sp500_constituent" in url:
+        return _fmp_sp500_response()
+    raise AssertionError(f"Unexpected GET to {url!r} in --fmp-only mode")
+
+
+@pytest.fixture
+def fmp_only_env(monkeypatch):
+    monkeypatch.setenv("FMP_API_KEY", "fmp-test-key")  # pragma: allowlist secret
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
+
+
+@pytest.fixture
+def full_env(monkeypatch):
+    monkeypatch.setenv("FMP_API_KEY", "fmp-test-key")  # pragma: allowlist secret
+    monkeypatch.setenv("ALPACA_API_KEY", "alp-test-key")  # pragma: allowlist secret
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "alp-test-secret")  # pragma: allowlist secret
+    monkeypatch.setenv("ALPACA_PAPER", "true")
+
+
+class TestFmpOnlyFlag:
+    def test_fmp_only_exits_zero_on_fmp_pass(self, fmp_only_env, capsys):
+        with patch("requests.get", side_effect=_route_get):
+            rc = cla.main(["--fmp-only"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Mode: --fmp-only" in out
+        assert "PASS fmp.historical_price_eod_full" in out
+        assert "PASS fmp.profile" in out
+        assert "SKIP alpaca.assets_aapl — explicitly skipped via --fmp-only" in out
+        assert "SKIP alpaca.assets_404_graceful — explicitly skipped via --fmp-only" in out
+        # No raw FAIL setup line — that was the old behaviour.
+        assert "FAIL setup" not in out
+
+    def test_fmp_only_does_not_call_alpaca(self, fmp_only_env):
+        with patch("requests.get", side_effect=_route_get) as get:
+            cla.main(["--fmp-only"])
+        called_urls = [c.args[0] for c in get.call_args_list]
+        assert all("alpaca.markets" not in u for u in called_urls), called_urls
+
+
+class TestImplicitFmpOnlyWhenAlpacaMissing:
+    """Without --fmp-only and without Alpaca creds, the script should
+    still run FMP gates and emit SKIP for Alpaca, plus a hint to add
+    --fmp-only or set the env vars. Exit 0 when FMP gates pass."""
+
+    def test_no_alpaca_creds_skips_alpaca_and_passes(self, fmp_only_env, capsys):
+        with patch("requests.get", side_effect=_route_get):
+            rc = cla.main([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        # FMP runs to completion
+        assert "PASS fmp.historical_price_eod_full" in out
+        # Alpaca gates marked SKIP with the env-var-missing reason
+        assert "SKIP alpaca.assets_aapl — ALPACA_API_KEY" in out
+        # Hint nudges the user to choose --fmp-only or configure Alpaca
+        assert "--fmp-only" in out
+
+
+class TestFullModePathStillFails:
+    """Sanity: when both keys are set but Alpaca raises, the required
+    gate still gates the exit code. Regression test against accidentally
+    making Alpaca optional in the full path."""
+
+    def test_full_mode_alpaca_failure_returns_nonzero(self, full_env):
+        def router(url: str, **_kwargs):
+            if "data.alpaca.markets" in url or "paper-api.alpaca.markets" in url:
+                resp = MagicMock()
+                resp.status_code = 500
+                resp.text = "boom"
+                resp.raise_for_status.side_effect = RuntimeError("HTTP 500")
+                return resp
+            return _route_get(url)
+
+        with patch("requests.get", side_effect=router):
+            rc = cla.main([])
+        assert rc != 0
+
+
+class TestMissingFmpStillFails:
+    def test_missing_fmp_returns_nonzero(self, monkeypatch, capsys):
+        monkeypatch.delenv("FMP_API_KEY", raising=False)
+        rc = cla.main([])
+        assert rc == 1
+        assert "FAIL setup — FMP_API_KEY" in capsys.readouterr().out

--- a/skills/parabolic-short-trade-planner/scripts/tests/test_screen_parabolic_smoke.py
+++ b/skills/parabolic-short-trade-planner/scripts/tests/test_screen_parabolic_smoke.py
@@ -7,6 +7,7 @@ extension). Acts as the executable schema contract for downstream skills.
 """
 
 import json
+import logging
 from pathlib import Path
 
 # screen_parabolic.py is a CLI module; import works because conftest puts
@@ -71,6 +72,31 @@ class TestDryRunPipeline:
         assert "Parabolic Short Watchlist" in md
         if candidates:
             assert candidates[0]["ticker"] in md
+
+
+class TestRejectionLogging:
+    """The smoke runbook's Tier 1 PASS criterion is "--verbose
+    documents at least one rejection reason". Pin that contract: when
+    a candidate fails a soft threshold, the screener emits a DEBUG
+    line of the form "Rejected <T>: <reason> ..." which is visible
+    under --verbose (which sets root level to DEBUG)."""
+
+    def test_soft_threshold_rejection_logs_reason(self, caplog):
+        # CALM is a flat fixture that fails min_roc_5d at the default
+        # 30% threshold. Capturing at DEBUG simulates --verbose.
+        args = _make_args()
+        with caplog.at_level(logging.DEBUG, logger="parabolic_short.screen"):
+            screen_parabolic.run_dry_run(str(FIXTURE_PATH), args)
+        rejection_lines = [r.message for r in caplog.records if r.message.startswith("Rejected ")]
+        # At least one ticker must have logged a rejection reason.
+        assert rejection_lines, (
+            "Expected at least one 'Rejected ...' DEBUG line — the smoke "
+            "runbook's Tier 1 PASS criterion depends on this."
+        )
+        # Reason text should be human-readable (not just a code).
+        assert any("threshold not met" in line for line in rejection_lines), (
+            f"Expected a 'threshold not met' rejection reason; got {rejection_lines}"
+        )
 
 
 class TestMainCLI:


### PR DESCRIPTION
## Why this PR exists

A live smoke run of the v0.5 runbook (2026-05-02) surfaced two gaps
that block a fresh contributor from following the runbook end-to-end.
Both are scoped tightly per the issue triage:

1. \`check_live_apis.py\` aborted at setup if Alpaca creds were
   missing → contributors with FMP-only access could not validate
   the FMP wire-shape contract at all.
2. \`screen_parabolic.py\` Phase 1 \`--verbose\` did not log
   per-ticker rejection reasons → the runbook's Tier 1 PASS criterion
   ("--verbose documents at least one rejection reason") was
   unverifiable from runtime output.

Fixed both, kept scope small. \`rejection_summary\` in JSON
intentionally NOT added — logging is enough to close the runbook gap.

## Changes

### \`check_live_apis.py\`
- New \`--fmp-only\` flag: SKIPs Alpaca gates explicitly, exits 0
  on FMP required-gate pass.
- Implicit fallback when Alpaca creds are unset (no flag): runs FMP,
  prints SKIP for Alpaca, hints the user toward \`--fmp-only\` or
  configuring Alpaca. Exit 0 on FMP pass (was: exit 1 at setup).
- Full mode (both keys configured) unchanged: Alpaca required-gate
  failure still gates the exit code.

### \`screen_parabolic.py\`
- Each silent \`return None\` rejection branch in
  \`screen_one_candidate\` now emits a DEBUG line of the form
  \`Rejected <T>: <reason> (got X, need Y)\`.
- \`urllib3\` / \`urllib3.connectionpool\` loggers pinned to WARNING
  in \`main()\` so the rejection lines are not buried under HTTP debug
  noise under \`--verbose\`.

### \`smoke_test_runbook.md\`
- New Section 2a documents \`--fmp-only\` usage + expected output.
- Section 3 expanded with expected \`--verbose\` rejection log examples
  and the four reason variants a runbook user may encounter.
- "Maintainer-only" framing for the Alpaca gates when FMP is the only
  API the contributor has access to.

### Tests (6 new)
- \`test_check_live_apis.py\` (5 tests): \`--fmp-only\` happy path,
  no Alpaca call under \`--fmp-only\`, implicit skip when creds
  missing, full mode still gates on Alpaca failure, missing FMP
  still fails.
- \`test_screen_parabolic_smoke.py\` (1 new test):
  \`test_soft_threshold_rejection_logs_reason\` asserts the
  Rejected log line appears at DEBUG level.

## Test plan

- [x] \`pytest skills/parabolic-short-trade-planner/scripts/tests/\`
      → **232 passed** (226 prior + 6 new).
- [x] \`ruff check\` + \`ruff format --check\` clean.
- [x] \`pre-commit run\` clean (incl. pre-push test suite).
- [x] Manual verification:
      - \`check_live_apis.py --fmp-only\` exits 0 with FMP creds only.
      - \`check_live_apis.py\` (no flag, no Alpaca) prints SKIP +
        hint, exits 0.
      - \`check_live_apis.py\` (full env) still PASS 4/4 + sp500.
      - \`screen_parabolic.py --universe finviz-csv ...
        --verbose\` against the diverse smoke CSV now prints
        \`Rejected JNJ: min_roc_5d threshold not met (got -0.13%,
        need >=30.00%)\` for all 15 rejected tickers.

## Out of scope

- \`rejection_summary\` JSON field (per issue triage).
- Renaming the runbook tier criteria — they already say "log",
  the only fix needed was making the log actually appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)