### PR TITLE
fix(parabolic-short): wire earnings calendar + recent_earnings_catalyst warning

### DIFF
--- a/skills/parabolic-short-trade-planner/scripts/parabolic_report_generator.py
+++ b/skills/parabolic-short-trade-planner/scripts/parabolic_report_generator.py
@@ -30,7 +30,9 @@ def render_candidate(
     warnings: list[str],
     key_levels: dict,
     invalidation_checks_passed: bool,
-    earnings_within_days: int | None,
+    earnings_meta: dict | None = None,
+    earnings_blackout_days: int = 2,
+    market_data_as_of: str | None = None,
     market_cap_usd: float | None,
 ) -> dict:
     """Build one candidate dict in the v1.0 schema shape.
@@ -38,10 +40,23 @@ def render_candidate(
     ``components`` is rendered as **weighted** sub-scores so the values sum
     to the composite ``score``. The ``component_breakdown`` from the scorer
     is the source of truth.
+
+    ``earnings_meta`` carries the four earnings fields (last/next dates,
+    ``trading_days_since_earnings`` in TRADING days,
+    ``earnings_within_days`` in CALENDAR days). ``earnings_blackout_days``
+    is the configured threshold (CLI ``--exclude-earnings-within-days``)
+    used to compute ``earnings_in_blackout_window`` here. The legacy
+    ``earnings_within_2d`` field is kept (literal ≤2 calendar-day check)
+    for backward compatibility with older readers.
     """
     components_weighted = {
         name: bd["weighted_score"] for name, bd in composite_result["component_breakdown"].items()
     }
+    meta = earnings_meta or {}
+    earnings_within_days = meta.get("earnings_within_days")
+    earnings_in_blackout_window = (
+        earnings_within_days is not None and earnings_within_days <= earnings_blackout_days
+    )
     earnings_within_2d = earnings_within_days is not None and earnings_within_days <= 2
     return {
         "ticker": ticker,
@@ -54,7 +69,18 @@ def render_candidate(
         "metrics": raw_metrics,
         "key_levels": key_levels,
         "invalidation_checks_passed": invalidation_checks_passed,
-        "earnings_within_2d": earnings_within_2d,
+        # Earnings metadata block. Units are intentionally split:
+        # ``earnings_within_days`` is CALENDAR days to the next earnings
+        # event (forward, used by the hard blackout); ``trading_days_since_earnings``
+        # is TRADING days since the last event (backward, used by the soft warning).
+        "last_earnings_date": meta.get("last_earnings_date"),
+        "next_earnings_date": meta.get("next_earnings_date"),
+        "trading_days_since_earnings": meta.get("trading_days_since_earnings"),
+        "earnings_within_days": earnings_within_days,
+        "earnings_blackout_days": earnings_blackout_days,
+        "earnings_in_blackout_window": earnings_in_blackout_window,
+        "earnings_within_2d": earnings_within_2d,  # legacy fixed-name field
+        "market_data_as_of": market_data_as_of,
         "market_cap_usd": market_cap_usd,
     }
 
@@ -65,19 +91,49 @@ def build_json_report(
     mode: str,
     universe: str,
     as_of: str,
+    run_date: str | None = None,
     data_source: str = "FMP",
     data_latency_sec: int = 0,
     generated_at: str | None = None,
 ) -> dict:
     """Top-level JSON report. ``candidates`` is a list of dicts shaped by
-    :func:`render_candidate`."""
+    :func:`render_candidate`.
+
+    Date semantics:
+
+    * ``as_of`` — Phase 2 planning date (= CLI ``--as-of`` / today). This
+      contract is consumed by ``generate_pre_market_plan.py`` for plan IDs
+      and SSR state filenames; never mutate.
+    * ``run_date`` — same value as ``as_of`` (the planning date), surfaced
+      under a distinct key for forward-compat readability.
+    * ``generated_at`` — wallclock ISO-8601 timestamp.
+    * ``market_data_as_of`` — derived from the candidates' per-symbol
+      values: ``None`` when no candidates, the unique date when all share
+      one, or ``max(...)`` with a top-level
+      ``warnings: ["mixed_market_data_as_of"]`` annotation when mixed.
+    """
     a_count = sum(1 for c in candidates if c.get("rank") == "A")
+    md_dates = sorted(
+        {c.get("market_data_as_of") for c in candidates if c.get("market_data_as_of")}
+    )
+    if not md_dates:
+        market_data_as_of: str | None = None
+        report_warnings: list[str] = []
+    elif len(md_dates) == 1:
+        market_data_as_of = md_dates[0]
+        report_warnings = []
+    else:
+        market_data_as_of = md_dates[-1]
+        report_warnings = ["mixed_market_data_as_of"]
     return {
         "schema_version": SCHEMA_VERSION,
         "skill": SKILL_NAME,
         "phase": PHASE,
         "generated_at": generated_at or _now_iso(),
         "as_of": as_of,
+        "run_date": run_date if run_date is not None else as_of,
+        "market_data_as_of": market_data_as_of,
+        "warnings": report_warnings,
         "data_source": data_source,
         "data_latency_sec": data_latency_sec,
         "mode": mode,

--- a/skills/parabolic-short-trade-planner/scripts/screen_parabolic.py
+++ b/skills/parabolic-short-trade-planner/scripts/screen_parabolic.py
@@ -263,7 +263,14 @@ def screen_one_candidate(
     raw_metrics = component_payload["raw_metrics"]
     candidate_for_invalidation["adv_20d_usd"] = raw_metrics.get("adv_20d_usd")
 
-    invalidation = check_invalidation(candidate_for_invalidation, mode=mode)
+    # Plumb the CLI override into the invalidation rules so a non-default
+    # --exclude-earnings-within-days is actually honored by the hard
+    # blackout (the mode-default would otherwise stay at 2 calendar days).
+    invalidation = check_invalidation(
+        candidate_for_invalidation,
+        mode=mode,
+        override={"earnings_blackout_days": args.exclude_earnings_within_days},
+    )
     if invalidation["is_invalid"]:
         logger.debug("Rejected %s: invalidation (%s)", ticker, ", ".join(invalidation["reasons"]))
         return None

--- a/skills/parabolic-short-trade-planner/scripts/screen_parabolic.py
+++ b/skills/parabolic-short-trade-planner/scripts/screen_parabolic.py
@@ -22,7 +22,7 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 # Allow running as a script: scripts/ and scripts/calculators/ on sys.path.
@@ -66,7 +66,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--min-adv-usd", type=float, default=None)
     p.add_argument("--min-market-cap", type=float, default=None)
     p.add_argument("--max-market-cap", type=float, default=None)
-    p.add_argument("--exclude-earnings-within-days", type=int, default=2)
+    p.add_argument(
+        "--exclude-earnings-within-days",
+        type=int,
+        default=2,
+        help="Calendar days; hard-invalidates a candidate when next earnings is within this window (forward-looking).",
+    )
+    p.add_argument(
+        "--earnings-catalyst-window-days",
+        type=int,
+        default=10,
+        help="Trading days; emits recent_earnings_catalyst warning when last earnings is within this window (backward-looking).",
+    )
     p.add_argument("--top", type=int, default=DEFAULT_TOP)
     p.add_argument("--watch-min-grade", choices=["A", "B", "C", "D"], default="C")
     p.add_argument("--max-api-calls", type=int, default=800)
@@ -80,6 +91,116 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return p
 
 
+# ---------- Earnings helpers ----------
+
+
+def _count_trading_days(start: date, end: date) -> int:
+    """Count Mon-Fri days, exclusive of ``start``, inclusive of ``end``.
+
+    Holiday calendar is not modeled — the Mon-Fri approximation is off by
+    one on weeks containing US exchange holidays. For the typical 10-day
+    catalyst window this is tolerable.
+
+    Returns 0 when ``start == end`` and a negative number when
+    ``end < start``.
+    """
+    if end < start:
+        return -((start - end).days)
+    count = 0
+    current = start
+    while current < end:
+        current += timedelta(days=1)
+        if current.weekday() < 5:
+            count += 1
+    return count
+
+
+def _resolve_market_data_as_of(bars_recent_first: list[dict]) -> str | None:
+    """Return YYYY-MM-DD of the latest bar, or None if unavailable.
+
+    FMP historical responses are recent-first, so the first element holds
+    the latest session. ``date`` is a string we truncate to YYYY-MM-DD to
+    drop any time component.
+    """
+    if not bars_recent_first:
+        return None
+    raw = bars_recent_first[0].get("date")
+    if not raw:
+        return None
+    return str(raw)[:10]
+
+
+def _index_earnings_events(events: list[dict]) -> dict[str, list[dict]]:
+    """Group an FMP earnings_calendar response by symbol.
+
+    Defensive parser: skips rows missing ``symbol`` or ``date``,
+    uppercases the symbol, and skips rows with unparsable ISO dates.
+    FMP shapes vary by endpoint version (``symbol`` vs ``ticker``,
+    ``date`` vs ``fiscalDateEnding``) — accept either.
+
+    Returns ``{symbol: [{"date": "YYYY-MM-DD", "raw": original_event}, ...]}``
+    sorted ascending by date.
+    """
+    by_symbol: dict[str, list[dict]] = {}
+    for ev in events or []:
+        if not isinstance(ev, dict):
+            continue
+        sym_raw = ev.get("symbol") or ev.get("ticker")
+        date_raw = ev.get("date") or ev.get("fiscalDateEnding")
+        if not sym_raw or not date_raw:
+            continue
+        try:
+            ev_date = datetime.fromisoformat(str(date_raw)[:10]).date()
+        except (TypeError, ValueError):
+            continue
+        sym = str(sym_raw).upper()
+        by_symbol.setdefault(sym, []).append({"date": ev_date.isoformat(), "raw": ev})
+    for sym in by_symbol:
+        by_symbol[sym].sort(key=lambda e: e["date"])
+    return by_symbol
+
+
+def _compute_earnings_metadata(
+    events_for_symbol: list[dict],
+    market_data_as_of: date,
+) -> dict:
+    """Compute earnings metadata for one symbol relative to a reference date.
+
+    ``trading_days_since_earnings`` is in **trading days** (Mon-Fri), used
+    for the soft ``recent_earnings_catalyst`` warning.
+
+    ``earnings_within_days`` is in **calendar days** to the next earnings
+    event, used for the hard forward-looking blackout in
+    ``invalidation_rules.check_invalidation``. Calendar days match the
+    legacy semantic of ``earnings_blackout_days``.
+    """
+    last_date: date | None = None
+    next_date: date | None = None
+    for ev in events_for_symbol or []:
+        try:
+            ev_date = datetime.fromisoformat(ev["date"]).date()
+        except (KeyError, TypeError, ValueError):
+            continue
+        if ev_date <= market_data_as_of:
+            if last_date is None or ev_date > last_date:
+                last_date = ev_date
+        else:
+            if next_date is None or ev_date < next_date:
+                next_date = ev_date
+    tdse: int | None = None
+    if last_date is not None:
+        tdse = _count_trading_days(last_date, market_data_as_of)
+    cal_days_to_next: int | None = None
+    if next_date is not None:
+        cal_days_to_next = (next_date - market_data_as_of).days
+    return {
+        "last_earnings_date": last_date.isoformat() if last_date else None,
+        "next_earnings_date": next_date.isoformat() if next_date else None,
+        "trading_days_since_earnings": tdse,
+        "earnings_within_days": cal_days_to_next,
+    }
+
+
 # ---------- Pipeline ----------
 
 
@@ -89,13 +210,26 @@ def screen_one_candidate(
     bars_recent_first: list[dict],
     quote: dict,
     profile: dict,
-    earnings_within_days: int | None,
+    earnings_meta: dict | None = None,
+    market_data_as_of: str | None = None,
     mode: str,
     args: argparse.Namespace,
 ) -> dict | None:
     """Run the full pipeline on one symbol. Returns the rendered candidate
     dict (schema v1.0), or ``None`` if the symbol fails invalidation or
     scoring.
+
+    ``earnings_meta`` carries the four earnings fields produced by
+    :func:`_compute_earnings_metadata` (``last_earnings_date``,
+    ``next_earnings_date``, ``trading_days_since_earnings``,
+    ``earnings_within_days``). ``earnings_within_days`` (calendar days to
+    the next earnings event) feeds the hard blackout in
+    :func:`check_invalidation`; ``trading_days_since_earnings`` (trading
+    days since the last earnings event) drives the soft
+    ``recent_earnings_catalyst`` warning.
+
+    ``market_data_as_of`` is YYYY-MM-DD of the latest bar; surfaced in the
+    rendered candidate for downstream callers.
     """
     bars = normalize_bars(bars_recent_first, output_order="chronological")
     if len(bars) < 21:  # need at least 20 bars for MA / ATR / range expansion
@@ -112,6 +246,7 @@ def screen_one_candidate(
     # what we need; cheap to evaluate before any scoring math.
     market_cap = profile.get("mktCap") if profile else None
     days_listed = profile.get("days_listed_actual") if profile else None
+    earnings_within_days = earnings_meta.get("earnings_within_days") if earnings_meta else None
     candidate_for_invalidation = {
         "ticker": ticker,
         "close": closes[-1],
@@ -179,6 +314,15 @@ def screen_one_candidate(
         }
     )
 
+    # Soft warning: last earnings within the catalyst window. Routes through
+    # the existing warnings list so Phase 2 (manual_reasons.py) treats it as
+    # an advisory manual reason — Phase 2 still allows trading without
+    # forcing trade_allowed_without_manual=False.
+    tdse = earnings_meta.get("trading_days_since_earnings") if earnings_meta else None
+    if tdse is not None and tdse <= args.earnings_catalyst_window_days:
+        if "recent_earnings_catalyst" not in state["warnings"]:
+            state["warnings"].append("recent_earnings_catalyst")
+
     key_levels = {
         "dma_10": raw_metrics.get("dma_10"),
         "dma_20": raw_metrics.get("dma_20"),
@@ -198,7 +342,9 @@ def screen_one_candidate(
         warnings=state["warnings"],
         key_levels=key_levels,
         invalidation_checks_passed=True,
-        earnings_within_days=earnings_within_days,
+        earnings_meta=earnings_meta,
+        earnings_blackout_days=args.exclude_earnings_within_days,
+        market_data_as_of=market_data_as_of,
         market_cap_usd=market_cap,
     )
 
@@ -206,22 +352,69 @@ def screen_one_candidate(
 def run_dry_run(fixture_path: str, args: argparse.Namespace) -> list[dict]:
     """Run the pipeline against an in-memory fixture JSON.
 
-    Fixture shape::
+    Fixture shape (all earnings/market_data fields are optional)::
 
         {"symbols": [{"ticker": "...", "bars": [...recent-first OHLCV...],
                       "quote": {...}, "profile": {...},
-                      "earnings_within_days": int|null}, ...]}
+                      "earnings_within_days": int|null,
+                      "last_earnings_date": "YYYY-MM-DD"|null,
+                      "next_earnings_date": "YYYY-MM-DD"|null,
+                      "trading_days_since_earnings": int|null,
+                      "market_data_as_of": "YYYY-MM-DD"|null}, ...]}
+
+    Precedence for ``trading_days_since_earnings``:
+
+    1. If the fixture provides an explicit value, use it as-is.
+    2. Otherwise, compute it from ``last_earnings_date`` and
+       ``market_data_as_of`` (or the latest bar date) when both are known.
+    3. Otherwise, leave as ``None``.
+
+    ``market_data_as_of`` defaults to the latest bar's date when not
+    supplied by the fixture.
     """
     with open(fixture_path, encoding="utf-8") as fh:
         fixture = json.load(fh)
     out: list[dict] = []
     for sym in fixture["symbols"]:
+        bars = sym["bars"]
+        market_data_as_of = sym.get("market_data_as_of") or _resolve_market_data_as_of(bars)
+        # Build earnings_meta from explicit fixture fields, falling back to
+        # computed values where possible.
+        last_iso = sym.get("last_earnings_date")
+        next_iso = sym.get("next_earnings_date")
+        explicit_tdse = sym.get("trading_days_since_earnings")
+        explicit_within = sym.get("earnings_within_days")
+        tdse = explicit_tdse
+        if tdse is None and last_iso and market_data_as_of:
+            try:
+                tdse = _count_trading_days(
+                    datetime.fromisoformat(last_iso).date(),
+                    datetime.fromisoformat(market_data_as_of).date(),
+                )
+            except ValueError:
+                tdse = None
+        within = explicit_within
+        if within is None and next_iso and market_data_as_of:
+            try:
+                within = (
+                    datetime.fromisoformat(next_iso).date()
+                    - datetime.fromisoformat(market_data_as_of).date()
+                ).days
+            except ValueError:
+                within = None
+        earnings_meta = {
+            "last_earnings_date": last_iso,
+            "next_earnings_date": next_iso,
+            "trading_days_since_earnings": tdse,
+            "earnings_within_days": within,
+        }
         c = screen_one_candidate(
             ticker=sym["ticker"],
-            bars_recent_first=sym["bars"],
+            bars_recent_first=bars,
             quote=sym.get("quote", {}),
             profile=sym.get("profile", {}),
-            earnings_within_days=sym.get("earnings_within_days"),
+            earnings_meta=earnings_meta,
+            market_data_as_of=market_data_as_of,
             mode=args.mode,
             args=args,
         )
@@ -230,8 +423,13 @@ def run_dry_run(fixture_path: str, args: argparse.Namespace) -> list[dict]:
     return out
 
 
-def run_live(args: argparse.Namespace) -> list[dict]:
-    """Pull universe + per-symbol data from FMP and run the pipeline."""
+def run_live(args: argparse.Namespace, run_date: str) -> list[dict]:
+    """Pull universe + per-symbol data from FMP and run the pipeline.
+
+    ``run_date`` (YYYY-MM-DD, normally ``args.as_of`` or today) centers
+    the bulk earnings-calendar fetch window. Per-symbol
+    ``market_data_as_of`` is then derived from each symbol's latest bar.
+    """
     from fmp_client import FMPClient  # local import: only needed in live mode
 
     api_key = args.api_key or os.getenv("FMP_API_KEY")
@@ -242,6 +440,22 @@ def run_live(args: argparse.Namespace) -> list[dict]:
     symbols = _resolve_universe(args, client)
     logger.info("Universe size: %d", len(symbols))
 
+    # One bulk earnings-calendar fetch covers the catalyst window backward
+    # and the blackout window forward. The +7 calendar-day buffer absorbs
+    # weekends/holidays at the window edges so per-symbol
+    # market_data_as_of values that drift slightly from run_date still
+    # land inside the fetched range.
+    catalyst_window = args.earnings_catalyst_window_days
+    exclude_window = args.exclude_earnings_within_days
+    try:
+        center = datetime.fromisoformat(run_date).date()
+    except ValueError:
+        center = datetime.now().date()
+    from_date = (center - timedelta(days=catalyst_window + 7)).isoformat()
+    to_date = (center + timedelta(days=exclude_window + 7)).isoformat()
+    raw_events = client.get_earnings_calendar(from_date, to_date) or []
+    earnings_by_symbol = _index_earnings_events(raw_events)
+
     out: list[dict] = []
     for sym in symbols:
         if client.api_calls_made >= args.max_api_calls:
@@ -251,12 +465,26 @@ def run_live(args: argparse.Namespace) -> list[dict]:
         if not bars_payload or "historical" not in bars_payload:
             continue
         profile = client.get_company_profile(sym) or {}
+        bars_recent_first = bars_payload["historical"]
+        market_data_as_of = _resolve_market_data_as_of(bars_recent_first)
+        earnings_meta: dict | None = None
+        if market_data_as_of:
+            try:
+                ref_date = datetime.fromisoformat(market_data_as_of).date()
+            except ValueError:
+                ref_date = None
+            if ref_date is not None:
+                earnings_meta = _compute_earnings_metadata(
+                    earnings_by_symbol.get(sym.upper(), []),
+                    ref_date,
+                )
         c = screen_one_candidate(
             ticker=sym,
-            bars_recent_first=bars_payload["historical"],
+            bars_recent_first=bars_recent_first,
             quote={},
             profile=profile,
-            earnings_within_days=None,  # earnings calendar lookup is per-symbol; skip in MVP
+            earnings_meta=earnings_meta,
+            market_data_as_of=market_data_as_of,
             mode=args.mode,
             args=args,
         )
@@ -314,7 +542,7 @@ def main(argv: list[str] | None = None) -> int:
         candidates = run_dry_run(args.fixture, args)
         data_source = "fixture"
     else:
-        candidates = run_live(args)
+        candidates = run_live(args, run_date=as_of)
         data_source = "FMP"
 
     # Apply --watch-min-grade and --top after scoring/grading.
@@ -327,6 +555,7 @@ def main(argv: list[str] | None = None) -> int:
         mode=args.mode,
         universe=args.universe,
         as_of=as_of,
+        run_date=as_of,
         data_source=data_source,
     )
     json_path, md_path = write_outputs(report, args.output_dir, args.output_prefix, as_of)

--- a/skills/parabolic-short-trade-planner/scripts/tests/test_earnings_metadata.py
+++ b/skills/parabolic-short-trade-planner/scripts/tests/test_earnings_metadata.py
@@ -1,0 +1,164 @@
+"""Unit tests for the earnings-calendar helpers in screen_parabolic.
+
+Pins behavior of:
+
+* :func:`_count_trading_days` — weekday counting (no holiday calendar).
+* :func:`_resolve_market_data_as_of` — latest-bar-date probe with FMP
+  recent-first input.
+* :func:`_index_earnings_events` — defensive parser tolerating shape
+  drift in the FMP earnings_calendar response.
+* :func:`_compute_earnings_metadata` — last/next earnings detection and
+  the unit split (trading days backward / calendar days forward).
+"""
+
+from datetime import date
+
+from screen_parabolic import (
+    _compute_earnings_metadata,
+    _count_trading_days,
+    _index_earnings_events,
+    _resolve_market_data_as_of,
+)
+
+
+class TestCountTradingDays:
+    def test_same_day_zero(self):
+        d = date(2026, 5, 8)  # Friday
+        assert _count_trading_days(d, d) == 0
+
+    def test_friday_to_monday_is_one(self):
+        # Friday → Monday: counts only Monday (Sat/Sun skipped).
+        assert _count_trading_days(date(2026, 5, 8), date(2026, 5, 11)) == 1
+
+    def test_wednesday_to_friday_is_two(self):
+        # Wed (2026-05-06) → Fri (2026-05-08): Thu + Fri = 2 trading days.
+        assert _count_trading_days(date(2026, 5, 6), date(2026, 5, 8)) == 2
+
+    def test_full_week_is_five(self):
+        # Mon → next Mon: 4 weekday gaps + the next Monday = 5 trading days.
+        assert _count_trading_days(date(2026, 5, 4), date(2026, 5, 11)) == 5
+
+    def test_end_before_start_is_negative(self):
+        assert _count_trading_days(date(2026, 5, 8), date(2026, 5, 6)) < 0
+
+
+class TestResolveMarketDataAsOf:
+    def test_returns_latest_bar_date_when_recent_first(self):
+        bars = [
+            {"date": "2026-05-08", "close": 24.0},
+            {"date": "2026-05-07", "close": 22.5},
+        ]
+        assert _resolve_market_data_as_of(bars) == "2026-05-08"
+
+    def test_truncates_datetime_to_yyyy_mm_dd(self):
+        bars = [{"date": "2026-05-08T16:00:00-04:00", "close": 1.0}]
+        assert _resolve_market_data_as_of(bars) == "2026-05-08"
+
+    def test_empty_bars_returns_none(self):
+        assert _resolve_market_data_as_of([]) is None
+
+    def test_missing_date_returns_none(self):
+        assert _resolve_market_data_as_of([{"close": 1.0}]) is None
+
+
+class TestIndexEarningsEvents:
+    def test_groups_by_symbol_and_sorts_by_date(self):
+        events = [
+            {"symbol": "AAPL", "date": "2026-04-30"},
+            {"symbol": "FLNC", "date": "2026-05-06"},
+            {"symbol": "AAPL", "date": "2026-01-29"},
+        ]
+        out = _index_earnings_events(events)
+        assert set(out.keys()) == {"AAPL", "FLNC"}
+        assert [e["date"] for e in out["AAPL"]] == ["2026-01-29", "2026-04-30"]
+        assert [e["date"] for e in out["FLNC"]] == ["2026-05-06"]
+
+    def test_uppercases_symbol(self):
+        out = _index_earnings_events([{"symbol": "flnc", "date": "2026-05-06"}])
+        assert "FLNC" in out
+        assert "flnc" not in out
+
+    def test_skips_rows_missing_symbol_or_date(self):
+        out = _index_earnings_events(
+            [
+                {"symbol": "OK", "date": "2026-05-06"},
+                {"date": "2026-05-06"},  # missing symbol
+                {"symbol": "MISSING_DATE"},  # missing date
+                {},  # empty
+                None,  # not a dict
+            ]
+        )
+        assert list(out.keys()) == ["OK"]
+
+    def test_skips_unparsable_dates(self):
+        out = _index_earnings_events(
+            [
+                {"symbol": "GOOD", "date": "2026-05-06"},
+                {"symbol": "BAD", "date": "not-a-date"},
+            ]
+        )
+        assert "GOOD" in out
+        assert "BAD" not in out
+
+    def test_accepts_alternate_field_names(self):
+        # Some FMP variants use ``ticker`` / ``fiscalDateEnding``.
+        out = _index_earnings_events([{"ticker": "ALT", "fiscalDateEnding": "2026-05-06"}])
+        assert "ALT" in out
+
+    def test_empty_input_returns_empty_dict(self):
+        assert _index_earnings_events([]) == {}
+        assert _index_earnings_events(None) == {}
+
+
+class TestComputeEarningsMetadata:
+    def test_only_past_event_sets_last_only(self):
+        events = [{"date": "2026-05-06"}]
+        meta = _compute_earnings_metadata(events, date(2026, 5, 8))
+        assert meta["last_earnings_date"] == "2026-05-06"
+        assert meta["next_earnings_date"] is None
+        # 2026-05-06 (Wed) → 2026-05-08 (Fri): Thu + Fri = 2 trading days.
+        assert meta["trading_days_since_earnings"] == 2
+        assert meta["earnings_within_days"] is None
+
+    def test_only_future_event_sets_next_only(self):
+        events = [{"date": "2026-05-12"}]
+        meta = _compute_earnings_metadata(events, date(2026, 5, 8))
+        assert meta["last_earnings_date"] is None
+        assert meta["next_earnings_date"] == "2026-05-12"
+        assert meta["trading_days_since_earnings"] is None
+        # Calendar days, not trading days.
+        assert meta["earnings_within_days"] == 4
+
+    def test_event_on_reference_day_counts_as_last(self):
+        # An event dated exactly on ``market_data_as_of`` is treated as the
+        # most recent past event (boundary inclusive).
+        events = [{"date": "2026-05-08"}]
+        meta = _compute_earnings_metadata(events, date(2026, 5, 8))
+        assert meta["last_earnings_date"] == "2026-05-08"
+        assert meta["next_earnings_date"] is None
+        assert meta["trading_days_since_earnings"] == 0
+
+    def test_picks_max_past_and_min_future(self):
+        events = [
+            {"date": "2025-11-24"},
+            {"date": "2026-02-04"},
+            {"date": "2026-05-06"},
+            {"date": "2026-08-10"},
+        ]
+        meta = _compute_earnings_metadata(events, date(2026, 5, 8))
+        assert meta["last_earnings_date"] == "2026-05-06"
+        assert meta["next_earnings_date"] == "2026-08-10"
+
+    def test_no_events_returns_all_none(self):
+        meta = _compute_earnings_metadata([], date(2026, 5, 8))
+        assert meta == {
+            "last_earnings_date": None,
+            "next_earnings_date": None,
+            "trading_days_since_earnings": None,
+            "earnings_within_days": None,
+        }
+
+    def test_skips_unparsable_event_dates(self):
+        events = [{"date": "2026-05-06"}, {"date": "garbage"}]
+        meta = _compute_earnings_metadata(events, date(2026, 5, 8))
+        assert meta["last_earnings_date"] == "2026-05-06"

--- a/skills/parabolic-short-trade-planner/scripts/tests/test_report_generator.py
+++ b/skills/parabolic-short-trade-planner/scripts/tests/test_report_generator.py
@@ -51,7 +51,7 @@ def _sample_candidate(ticker: str = "XYZ", grade: str = "A") -> dict:
             "session_low": 71.30,
         },
         invalidation_checks_passed=True,
-        earnings_within_days=None,
+        earnings_meta=None,
         market_cap_usd=1_850_000_000,
     )
 
@@ -70,6 +70,9 @@ class TestTopLevelSchema:
             "phase",
             "generated_at",
             "as_of",
+            "run_date",
+            "market_data_as_of",
+            "warnings",
             "data_source",
             "data_latency_sec",
             "mode",
@@ -122,7 +125,7 @@ class TestTopLevelSchema:
             warnings=[],
             key_levels={},
             invalidation_checks_passed=True,
-            earnings_within_days=None,
+            earnings_meta=None,
             market_cap_usd=2_000_000_000,
         )
         report = build_json_report(
@@ -145,7 +148,14 @@ class TestCandidateSchema:
             "metrics",
             "key_levels",
             "invalidation_checks_passed",
+            "last_earnings_date",
+            "next_earnings_date",
+            "trading_days_since_earnings",
+            "earnings_within_days",
+            "earnings_blackout_days",
+            "earnings_in_blackout_window",
             "earnings_within_2d",
+            "market_data_as_of",
             "market_cap_usd",
         ):
             assert key in c, f"missing candidate key {key!r}"
@@ -186,10 +196,16 @@ class TestCandidateSchema:
             warnings=[],
             key_levels={},
             invalidation_checks_passed=False,
-            earnings_within_days=1,
+            earnings_meta={
+                "last_earnings_date": None,
+                "next_earnings_date": "2026-05-01",
+                "trading_days_since_earnings": None,
+                "earnings_within_days": 1,
+            },
             market_cap_usd=2_000_000_000,
         )
         assert soon["earnings_within_2d"] is True
+        assert soon["earnings_in_blackout_window"] is True  # default blackout=2
         # earnings_within_days = 5 → flag is False
         far = render_candidate(
             ticker="FAR",
@@ -200,10 +216,37 @@ class TestCandidateSchema:
             warnings=[],
             key_levels={},
             invalidation_checks_passed=True,
-            earnings_within_days=5,
+            earnings_meta={
+                "last_earnings_date": None,
+                "next_earnings_date": "2026-05-05",
+                "trading_days_since_earnings": None,
+                "earnings_within_days": 5,
+            },
             market_cap_usd=2_000_000_000,
         )
         assert far["earnings_within_2d"] is False
+        assert far["earnings_in_blackout_window"] is False
+        # With a wider configured blackout, the same 5 days does fall in the window.
+        wider = render_candidate(
+            ticker="WIDER",
+            composite_result=composite,
+            component_scores_raw={},
+            raw_metrics={},
+            state_caps=[],
+            warnings=[],
+            key_levels={},
+            invalidation_checks_passed=True,
+            earnings_meta={
+                "last_earnings_date": None,
+                "next_earnings_date": "2026-05-05",
+                "trading_days_since_earnings": None,
+                "earnings_within_days": 5,
+            },
+            earnings_blackout_days=7,
+            market_cap_usd=2_000_000_000,
+        )
+        assert wider["earnings_within_2d"] is False  # legacy field still literal ≤2
+        assert wider["earnings_in_blackout_window"] is True  # configured threshold ≤7
 
 
 class TestSerialization:

--- a/skills/parabolic-short-trade-planner/scripts/tests/test_screen_parabolic_smoke.py
+++ b/skills/parabolic-short-trade-planner/scripts/tests/test_screen_parabolic_smoke.py
@@ -17,6 +17,26 @@ import screen_parabolic  # noqa: E402
 FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "dry_run_minimal.json"
 
 
+def _flnc_like_fixture(tmp_path, last_earnings_date: str = "2026-04-28"):
+    """Clone the minimal fixture and inject earnings metadata for the
+    parabolic XYZ symbol so it simulates an FLNC-like post-earnings move.
+
+    ``last_earnings_date`` defaults to 2026-04-28 (Tuesday) → 2 trading
+    days before the XYZ fixture's latest bar 2026-04-30 (Thursday).
+    """
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    for sym in fixture["symbols"]:
+        if sym["ticker"] == "XYZ":
+            sym["last_earnings_date"] = last_earnings_date
+            sym["market_data_as_of"] = "2026-04-30"
+            # Leave trading_days_since_earnings unset to exercise the
+            # "compute from last_earnings_date" branch in run_dry_run.
+            break
+    out_path = tmp_path / "dry_run_with_earnings.json"
+    out_path.write_text(json.dumps(fixture))
+    return out_path
+
+
 def _make_args(**overrides):
     parser = screen_parabolic.build_arg_parser()
     args = parser.parse_args(
@@ -97,6 +117,54 @@ class TestRejectionLogging:
         assert any("threshold not met" in line for line in rejection_lines), (
             f"Expected a 'threshold not met' rejection reason; got {rejection_lines}"
         )
+
+
+class TestRecentEarningsCatalystWarning:
+    """When the fixture supplies a ``last_earnings_date`` within the
+    catalyst window, the screener must emit the
+    ``recent_earnings_catalyst`` warning. This is the FLNC-style
+    post-earnings parabolic case that motivated the fix."""
+
+    def test_warning_appears_for_recent_earnings(self, tmp_path):
+        fixture = _flnc_like_fixture(tmp_path, last_earnings_date="2026-04-28")
+        args = _make_args()
+        candidates = screen_parabolic.run_dry_run(str(fixture), args)
+        xyz = next(c for c in candidates if c["ticker"] == "XYZ")
+        assert "recent_earnings_catalyst" in xyz["warnings"]
+        assert xyz["last_earnings_date"] == "2026-04-28"
+        # 2026-04-28 (Tue) → 2026-04-30 (Thu): Wed + Thu = 2 trading days.
+        assert xyz["trading_days_since_earnings"] == 2
+        # Forward-looking blackout fields are independent.
+        assert xyz["earnings_within_2d"] is False
+        assert xyz["earnings_in_blackout_window"] is False
+        assert xyz["market_data_as_of"] == "2026-04-30"
+
+    def test_warning_absent_outside_catalyst_window(self, tmp_path):
+        # 2026-03-13 (Fri) is well beyond the default 10-trading-day window
+        # from market_data_as_of 2026-04-30.
+        fixture = _flnc_like_fixture(tmp_path, last_earnings_date="2026-03-13")
+        args = _make_args()
+        candidates = screen_parabolic.run_dry_run(str(fixture), args)
+        xyz = next(c for c in candidates if c["ticker"] == "XYZ")
+        assert "recent_earnings_catalyst" not in xyz["warnings"]
+
+    def test_top_level_market_data_as_of_propagates(self, tmp_path):
+        fixture = _flnc_like_fixture(tmp_path, last_earnings_date="2026-04-28")
+        args = _make_args()
+        candidates = screen_parabolic.run_dry_run(str(fixture), args)
+        report = screen_parabolic.build_json_report(
+            candidates=candidates,
+            mode=args.mode,
+            universe=args.universe,
+            as_of=args.as_of,
+            run_date=args.as_of,
+            data_source="fixture",
+        )
+        # XYZ is the only surviving candidate, so the unique-date branch
+        # should set top-level market_data_as_of without a mixed warning.
+        assert report["market_data_as_of"] == "2026-04-30"
+        assert "mixed_market_data_as_of" not in report["warnings"]
+        assert report["as_of"] == report["run_date"] == "2026-04-30"
 
 
 class TestMainCLI:

--- a/skills/parabolic-short-trade-planner/scripts/tests/test_screen_parabolic_smoke.py
+++ b/skills/parabolic-short-trade-planner/scripts/tests/test_screen_parabolic_smoke.py
@@ -37,6 +37,23 @@ def _flnc_like_fixture(tmp_path, last_earnings_date: str = "2026-04-28"):
     return out_path
 
 
+def _upcoming_earnings_fixture(tmp_path, next_earnings_date: str):
+    """Clone the minimal fixture and set the XYZ symbol's next earnings.
+
+    Used to exercise the forward-looking blackout via
+    ``--exclude-earnings-within-days``.
+    """
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    for sym in fixture["symbols"]:
+        if sym["ticker"] == "XYZ":
+            sym["next_earnings_date"] = next_earnings_date
+            sym["market_data_as_of"] = "2026-04-30"
+            break
+    out_path = tmp_path / "dry_run_with_upcoming_earnings.json"
+    out_path.write_text(json.dumps(fixture))
+    return out_path
+
+
 def _make_args(**overrides):
     parser = screen_parabolic.build_arg_parser()
     args = parser.parse_args(
@@ -165,6 +182,42 @@ class TestRecentEarningsCatalystWarning:
         assert report["market_data_as_of"] == "2026-04-30"
         assert "mixed_market_data_as_of" not in report["warnings"]
         assert report["as_of"] == report["run_date"] == "2026-04-30"
+
+
+class TestExcludeEarningsWithinDaysOverride:
+    """The CLI flag ``--exclude-earnings-within-days`` must propagate as
+    an override into ``check_invalidation`` so the hard blackout uses
+    the user-supplied threshold, not the mode default of 2 calendar days.
+    """
+
+    def test_default_threshold_excludes_within_2_calendar_days(self, tmp_path):
+        # next_earnings_date is 1 calendar day after market_data_as_of
+        # (2026-04-30 → 2026-05-01) — caught by the default blackout of 2.
+        fixture = _upcoming_earnings_fixture(tmp_path, next_earnings_date="2026-05-01")
+        args = _make_args()  # default --exclude-earnings-within-days 2
+        candidates = screen_parabolic.run_dry_run(str(fixture), args)
+        assert all(c["ticker"] != "XYZ" for c in candidates), (
+            "XYZ should be hard-invalidated when next earnings is 1 day out"
+        )
+
+    def test_default_threshold_keeps_candidate_4_days_out(self, tmp_path):
+        # 4 calendar days out — outside the default 2-day blackout.
+        fixture = _upcoming_earnings_fixture(tmp_path, next_earnings_date="2026-05-04")
+        args = _make_args()
+        candidates = screen_parabolic.run_dry_run(str(fixture), args)
+        assert any(c["ticker"] == "XYZ" for c in candidates)
+
+    def test_widened_threshold_excludes_4_days_out(self, tmp_path):
+        # Same fixture (4 calendar days out) but with --exclude-earnings-within-days 5.
+        # Without the override plumbing, this widened threshold is silently
+        # ignored and the candidate slips through.
+        fixture = _upcoming_earnings_fixture(tmp_path, next_earnings_date="2026-05-04")
+        args = _make_args(exclude_earnings_within_days=5)
+        candidates = screen_parabolic.run_dry_run(str(fixture), args)
+        assert all(c["ticker"] != "XYZ" for c in candidates), (
+            "XYZ should be hard-invalidated when next earnings is 4 days out "
+            "and --exclude-earnings-within-days=5"
+        )
 
 
 class TestMainCLI:


### PR DESCRIPTION
## Summary

Phase 1 screener was passing `earnings_within_days=None` as an MVP shortcut at `screen_parabolic.py:259`. Two consequences:

1. `--exclude-earnings-within-days` (default 2) was **dead code** — `invalidation_rules.check_invalidation` never saw a non-null value in live mode.
2. `earnings_within_2d: false` in candidate output was a **stub** — never measured.

A real false-negative surfaced 2026-05-09: **FLNC** screened B-rank parabolic short with `earnings_within_2d:false`, but FMP confirms FLNC reported Q2 FY26 on 2026-05-06 (T+2 trading days). The +98% 5d move is event-driven (post-earnings + AI-power thematic squeeze), not a pure technical blow-off — a meaningfully different setup that warrants caller attention.

## Design

Two earnings-aware checks, separated by direction:

| Check | Direction | Unit | Action |
| --- | --- | --- | --- |
| `--exclude-earnings-within-days` (existing, now wired) | forward to next earnings | calendar days | hard invalidation |
| `--earnings-catalyst-window-days` (new, default 10) | backward from last earnings | trading days | soft `recent_earnings_catalyst` warning → Phase 2 advisory manual reason |

Schema additions kept strict — **`as_of` semantics intact** to preserve `generate_pre_market_plan.py:299`'s plan ID / SSR state contract:

| Field | Meaning |
| --- | --- |
| `as_of` | Phase 2 planning date (= CLI `--as-of`). Unchanged. |
| `run_date` | Planning date, surfaced as a separate key for forward-compat readability. |
| `generated_at` | Wallclock ISO-8601 timestamp (existing). |
| `market_data_as_of` | Latest bar date used for the technical metrics. **NEW.** |

Per-candidate adds: `last_earnings_date`, `next_earnings_date`, `trading_days_since_earnings` (TRADING days), `earnings_within_days` (CALENDAR days, forward), `earnings_blackout_days` (configured threshold), `earnings_in_blackout_window`, `market_data_as_of`. Legacy `earnings_within_2d` retained.

## Implementation notes

- **Bulk earnings fetch**: one `get_earnings_calendar(from, to)` call per screen, centered on `run_date` with `[catalyst_window+7, exclude_window+7]` calendar-day buffer. No per-symbol round trips; existing `fmp_client.py:371` method reused.
- **Defensive parser**: `_index_earnings_events` tolerates FMP shape drift — accepts `symbol`/`ticker` and `date`/`fiscalDateEnding`, uppercases the symbol, drops rows missing fields or with unparsable ISO dates.
- **Trading-day math**: inline `_count_trading_days` (Mon–Fri, no holiday calendar). Off-by-one on holiday weeks is tolerable for the 10-day catalyst window.
- **Warning dedup guard**: `recent_earnings_catalyst` is only appended if not already present, future-proofing against multiple injection paths.
- **Phase 2 unchanged**: `manual_reasons.py:44` already routes warnings into `advisory_manual_reasons`, so the soft path wires without Phase 2 edits. `recent_earnings_catalyst` is correctly classified as advisory (not blocking).

## Test plan

- [x] **Unit tests** (`test_earnings_metadata.py`, 21 new) for `_count_trading_days`, `_resolve_market_data_as_of`, `_index_earnings_events` (defensive paths), `_compute_earnings_metadata` (last/next/boundary/no-events).
- [x] **Smoke tests** (`test_screen_parabolic_smoke.py`, 3 new) for the FLNC-style recent-earnings warning path, the absent-warning-outside-window path, and top-level `market_data_as_of` propagation.
- [x] **Schema tests** (`test_report_generator.py`) updated with new keys + a wider `earnings_blackout_days` threshold case.
- [x] **Full suite**: 256/256 parabolic-short tests pass.
- [x] **Live FLNC re-screen** (2026-05-09): `last_earnings_date=2026-05-06`, `trading_days_since_earnings=2`, `warnings=[recent_earnings_catalyst]`, `earnings_within_2d=false`, `earnings_in_blackout_window=false`, `as_of=run_date=2026-05-09`, `market_data_as_of=2026-05-08`.
- [x] **Mid-cap re-screen** (605 symbols): also surfaces **FROG** (2026-05-07 earnings, tdse=1) — additional false-negative caught.
- [x] **Phase 2 regression**: plan IDs identical to prior run (`FLNC-20260509-{ORL5,FR5,VWF}`), `recent_earnings_catalyst` correctly appears in `advisory_manual_reasons` with `warning:` prefix, `trade_allowed_without_manual=False` preserved (still gated by HTB/locate/premarket H-L blockers).
- [x] Pre-commit + pre-push hooks pass.

## Out of scope (explicit)

- Hard `state_cap:event_driven_earnings_catalyst` blocking cap — warning is sufficient.
- Holiday calendar in `_count_trading_days`.
- Mock router extension in `test_check_live_apis.py` (no live earnings gate added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)