### PR TITLE
feat(skills-index): SSoT metadata foundation (PR1 of solo-trader-OS layering)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,15 @@ repos:
         files: 'skills/.*/SKILL\.md$|docs/.*/skills/.*\.md$'
         pass_filenames: false
 
+      - id: validate-skills-index
+        name: Validate skills-index.yaml against skills/ folder
+        entry: python3 scripts/validate_skills_index.py
+        language: system
+        # Re-run whenever any of the SSoT inputs OR the validator/spec change.
+        # pass_filenames: false → hook always validates the entire repo.
+        files: '^(skills-index\.yaml|skills/[^/]+/SKILL\.md|workflows/.*\.yaml|scripts/validate_skills_index\.py|scripts/tests/test_validate_skills_index\.py|docs/dev/metadata-and-workflow-schema\.md)$'
+        pass_filenames: false
+
       # Pre-push hook: run all skill-level tests before pushing
       # Tests run per-skill to avoid module name collisions (scorer.py, helpers.py, etc.)
       - id: pytest-pre-push

--- a/docs/dev/metadata-and-workflow-schema.md
+++ b/docs/dev/metadata-and-workflow-schema.md
@@ -1,0 +1,312 @@
+# Metadata and Workflow Schema (Developer Reference)
+
+This document is the single reference for the two YAML schemas that connect this repository together:
+
+- `skills-index.yaml` — single source of truth for skill metadata
+- `workflows/*.yaml` — operational workflow manifests
+
+Both schemas are versioned (`schema_version: 1`). New fields are always additive. Existing fields are never repurposed. If a meaning needs to change, add a new field and deprecate the old one.
+
+The companion validator is `scripts/validate_skills_index.py`.
+
+---
+
+## 1. `skills-index.yaml`
+
+### 1.1 Top-level shape
+
+```yaml
+schema_version: 1
+
+categories:
+  - market-regime
+  - core-portfolio
+  - swing-opportunity
+  - trade-planning
+  - trade-memory
+  - strategy-research
+  - advanced-satellite
+  - meta
+
+skills:
+  - id: <skill-id>
+    display_name: <Human Title>
+    category: <one of categories>
+    status: production | beta | experimental | deprecated
+    summary: >-
+      One-sentence description.
+
+    timeframe: daily | weekly | event-driven | research | unknown
+    difficulty: beginner | intermediate | advanced | unknown
+
+    integrations:
+      - id: <integration-id>
+        type: <integration_type>
+        requirement: <requirement>
+        note: <free-text>
+
+    inputs: [<input-name>, ...]
+    outputs: [<output-name>, ...]
+    workflows: [<workflow-id>, ...]
+    hand_written_doc: true | false
+```
+
+### 1.2 Required vs best-effort fields
+
+**Required** (validator hard-blocks under all strictness levels):
+
+| Field | Rule | Error code |
+|---|---|---|
+| `id` | Equals the directory name under `skills/`. Must match SKILL.md frontmatter `name`. | `IDX003`, `IDX004` |
+| `display_name` | Non-empty string. Index-owned (NOT cross-checked against frontmatter). | — |
+| `category` | One of the 8 enum values above. | `IDX005` |
+| `status` | One of `production` / `beta` / `experimental` / `deprecated`. | `IDX006` |
+| `summary` | Non-empty string. | `IDX009` |
+
+**Best-effort** (warn-only by default; required under `--strict-metadata`):
+
+| Field | Rule |
+|---|---|
+| `timeframe` | One of the enum values; `unknown` allowed by default. |
+| `difficulty` | One of the enum values; `unknown` allowed by default. |
+| `integrations` | List form (see §1.3). May be empty for skills with no dependencies, but prefer `[{id: local_calculation, type: calculation, requirement: not_required}]`. |
+| `inputs` | List of strings. May be `[]`. |
+| `outputs` | List of strings. May be `[]`. |
+| `workflows` | List of workflow IDs. Default mode warns on missing files; `--strict-workflows` errors. |
+| `hand_written_doc` | Boolean. Defaults to `false`. |
+
+### 1.3 `integrations` schema
+
+```yaml
+integrations:
+  - id: <integration-id>          # alpaca, fmp, finviz, holdings_csv, websearch, local_calculation, ...
+    type: <integration_type>      # see enum below
+    requirement: <requirement>    # see enum below
+    note: <free-text>             # short justification or pointer
+```
+
+**`integration_type` enum:**
+
+| Value | Use for |
+|---|---|
+| `broker` | Alpaca, IBKR, brokerage APIs |
+| `market_data` | FMP, yfinance, paid market data APIs |
+| `screener` | FINVIZ Elite and similar screener APIs |
+| `web` | WebSearch / WebFetch / general HTTP |
+| `local_file` | CSV / YAML / JSON / Markdown inputs from local disk |
+| `image` | Chart screenshots and other image inputs |
+| `mcp` | MCP servers (non-broker) |
+| `calculation` | Pure local computation, no I/O |
+| `none` | Edge case: no integration record applies |
+| `unknown` | Bootstrap could not determine; flagged for owner review |
+
+**`requirement` enum:**
+
+| Value | Meaning |
+|---|---|
+| `required` | Skill cannot run without this integration |
+| `recommended` | Works without it but degraded |
+| `optional` | Alternative input path |
+| `not_required` | Explicit "no dependency" marker; pair with `type: none` or `type: calculation` |
+| `unknown` | Bootstrap could not determine; flagged for owner review |
+
+`not_used` is intentionally NOT supported — in a list form, integrations that aren't used are simply omitted.
+
+**`type: calculation` vs `type: none`:**
+
+- `type: calculation` — skill performs deterministic local computation. Pair with `id: local_calculation` and `requirement: not_required`. Use this for `position-sizer` and similar pure-compute skills.
+- `type: none` — explicit "no integration record applies". Reserved for edge cases. Prefer `calculation` whenever the skill does any computation.
+
+### 1.4 `workflows` field semantics
+
+Each entry is a `workflow id` (= filename in `workflows/` minus `.yaml`).
+
+- **Default mode**: missing workflow files emit a warning. Useful while bootstrapping.
+- **`--strict-workflows`**: missing workflow files are errors (`WF001`).
+
+This field is the back-reference. The forward reference (workflow → skill) is in each `workflows/<id>.yaml`'s `required_skills` / `optional_skills` / `steps`.
+
+### 1.5 Governance rules
+
+1. **`display_name` is index-owned.** Validator does NOT cross-check it against `SKILL.md` frontmatter. Only `id` ↔ frontmatter `name` parity is enforced.
+2. **Deprecated skills stay in the index.** `status: deprecated` entries remain. They are excluded from `.skill` bundles and from any workflow's `required_skills`, but they remain queryable. Skills physically removed from `skills/` are also removed from the index.
+3. **`bootstrap_skills_index.py` is a one-time migration helper.** After PR1 merges, `skills-index.yaml` is the source of truth; do not re-run bootstrap as a sync tool. `CLAUDE.md` becomes a downstream consumer of the index.
+4. **No CLAUDE.md ↔ index parity check.** Once the index exists, the CLAUDE.md API matrix is informational. A future PR may regenerate the matrix from the index, but the index is canonical.
+
+---
+
+## 2. Workflow manifests (`workflows/*.yaml`)
+
+### 2.1 Top-level shape
+
+```yaml
+schema_version: 1
+id: <workflow-id>                 # must equal filename (sans .yaml)
+display_name: <Human Title>
+cadence: daily | weekly | monthly | ad-hoc
+estimated_minutes: <int>
+target_users: [<user-persona>, ...]
+difficulty: beginner | intermediate | advanced
+api_profile: no-api-basic | fmp-required | alpaca-required | mixed
+
+when_to_run: >-
+  <prose>
+when_not_to_run: >-
+  <prose>
+
+required_skills: [<skill-id>, ...]
+optional_skills: [<skill-id>, ...]
+
+artifacts:
+  - id: <artifact-id>
+    produced_by_step: <step-number>
+    required: true | false
+    downstream_hints: [<workflow-id>, ...]   # informational only, NOT validated
+
+steps:
+  - step: <int>
+    name: <step-title>
+    skill: <skill-id>
+    optional: true | false       # default false
+    consumes: [<artifact-id>, ...]
+    produces: [<artifact-id>, ...]
+    decision_gate: true | false
+    decision_question: >-
+      <question, required when decision_gate is true>
+    depends_on: [<step-number>, ...]   # only earlier steps
+
+manual_review:
+  - <prose, one item per line>
+
+journal_destination: <skill-id>
+
+# Only on monthly-performance-review:
+final_outputs:
+  - id: <output-id>
+```
+
+### 2.2 Internal-consistency rules
+
+These are validated under `--strict-workflows`:
+
+| Rule | Error code |
+|---|---|
+| Workflow filename equals `id` | `WF002` |
+| Every `step.skill` exists in `skills-index.yaml` | `WF003` |
+| `depends_on` references only earlier steps | `WF004` |
+| `decision_gate: true` step has non-empty `decision_question` | `WF005` |
+| `journal_destination` resolves to a skill `id` | `WF006` |
+| `consumes` artifacts produced by an earlier step | `WF007` |
+| No `deprecated` skill in `required_skills` | `WF008` |
+| Every `required_skills` entry appears in at least one non-optional step | `WF009` |
+| Every non-optional `step.skill` appears in `required_skills` | `WF010` |
+| Workflow file referenced by an index entry's `workflows:` exists | `WF001` |
+
+### 2.3 Optional-artifact consumption
+
+A step's `consumes:` list MAY reference an artifact whose `required: false`. Validator checks:
+
+- The artifact is declared in `artifacts:` ✅
+- The artifact is produced by an earlier step ✅
+- The optional-producing step actually runs at execution time — NOT validated. Operational concern, not schema concern.
+
+A step's `consumes:` list MAY NOT reference an artifact produced in a later step (covered by `WF007`).
+
+### 2.4 `downstream_hints` is informational
+
+`artifacts[].downstream_hints` is a free-form list of workflow IDs that *might* consume the artifact downstream. The validator does not check this. It is meant for human navigation and (future) Navigator hints.
+
+If a hard inter-workflow contract is needed later, add a separate field (e.g. `consumed_by_workflows: [...]` with strict semantics). Never repurpose `downstream_hints`.
+
+### 2.5 `one_of:` is intentionally NOT in v1
+
+Cases like "either `vcp-screener` or `canslim-screener`" are expressed by:
+
+- Promoting one to `required_skills`
+- Demoting the alternative to `optional_skills`
+
+Adding `one_of:` later is an additive schema change.
+
+---
+
+## 3. Validator strictness levels
+
+```bash
+# Default — pre-commit mode
+python3 scripts/validate_skills_index.py
+
+# PR2+ — CI / pre-push mode
+python3 scripts/validate_skills_index.py --strict-workflows
+
+# Future — tighten metadata completeness
+python3 scripts/validate_skills_index.py --strict-metadata
+```
+
+| Check group | default | `--strict-workflows` | `--strict-metadata` |
+|---|---|---|---|
+| Index ↔ folder bijection | ✅ | ✅ | ✅ |
+| Frontmatter `name` ↔ index `id` | ✅ | ✅ | ✅ |
+| Required fields populated | ✅ | ✅ | ✅ |
+| `category` / `status` enum | ✅ | ✅ | ✅ |
+| No duplicate `id` | ✅ | ✅ | ✅ |
+| `integrations[].requirement` enum | ✅ | ✅ | ✅ |
+| `summary` non-empty | ✅ | ✅ | ✅ |
+| `workflows[]` references resolve | ⚠️ warn | ✅ error | ✅ error |
+| Workflow internal-consistency rules | — | ✅ error | ✅ error |
+| `timeframe` / `difficulty` not `unknown` | ⚠️ warn | ⚠️ warn | ✅ error |
+| `inputs` / `outputs` populated | ⚠️ warn | ⚠️ warn | ✅ error |
+| `unknown` integrations allowed | ⚠️ warn | ⚠️ warn | ❌ rejected |
+
+---
+
+## 4. Error code catalog
+
+### Index-level (always strict)
+
+| Code | Meaning |
+|---|---|
+| `IDX001` | Duplicate skill `id` |
+| `IDX002` | Index entry exists but `skills/<id>/` does not |
+| `IDX003` | `skills/<id>/` exists but no index entry |
+| `IDX004` | SKILL.md frontmatter `name` ≠ index `id` |
+| `IDX005` | Invalid `category` |
+| `IDX006` | Invalid `status` |
+| `IDX007` | Invalid `integration_type` |
+| `IDX008` | Invalid `requirement` |
+| `IDX009` | Empty `summary` |
+| `IDX010` | Missing or wrong `schema_version` (must equal `1`) |
+| `IDX011` | Missing `categories:` block, or contents do not match the canonical 8 |
+
+### Tiered severity (default warn → strict-metadata error)
+
+| Code | Meaning |
+|---|---|
+| `IDX012` | Integration uses an `unknown` marker (`id` / `type` / `requirement`); flagged for owner review. Warning by default; error under `--strict-metadata`. |
+
+### Workflow-level (strict-workflows)
+
+| Code | Meaning |
+|---|---|
+| `WF001` | Workflow file referenced by index does not exist |
+| `WF002` | Workflow `id` does not match filename |
+| `WF003` | Step `skill` not found in `skills-index.yaml` |
+| `WF004` | `depends_on` references a future step |
+| `WF005` | `decision_gate: true` step missing `decision_question` |
+| `WF006` | `journal_destination` does not resolve to a skill |
+| `WF007` | Step consumes an artifact before it is produced |
+| `WF008` | Deprecated skill listed in `required_skills` |
+| `WF009` | `required_skills` entry never appears in a non-optional step |
+| `WF010` | Non-optional step `skill` missing from `required_skills` |
+| `WF011` | `required_skills` / `optional_skills` entry not in `skills-index.yaml` |
+| `WF012` | `artifacts[].produced_by_step` does not match the corresponding step's `produces` (either direction) |
+
+---
+
+## 5. Migration policy
+
+- Schema changes: bump `schema_version` only when the change is breaking. Additive fields do NOT bump.
+- Field renames: never. Add a new field, deprecate the old one in a comment, remove after one full version cycle.
+- Enum value additions: allowed without bumping `schema_version`. Validator must accept unknown enum values gracefully (warn, never crash).
+- Removed fields: marked `deprecated` in this doc for one cycle before deletion.
+
+See also: project memory `feedback_schema_evolution.md` — "Add new schema fields, never mutate existing ones for backward compat".

--- a/scripts/dev/bootstrap_skills_index.py
+++ b/scripts/dev/bootstrap_skills_index.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""One-shot migration helper: bootstrap skills-index.yaml from existing repo state.
+
+This script is intentionally placed under `scripts/dev/` to mark it as
+non-permanent. After PR1 merges, `skills-index.yaml` is the source of truth
+and CLAUDE.md becomes a downstream consumer. Do NOT re-run this as a sync
+tool — direct edits to skills-index.yaml are the maintenance path.
+
+What it does:
+  1. Scans skills/*/SKILL.md → id, summary (from frontmatter `description`)
+  2. Heuristic display_name (Title-cased, with common abbreviations capitalized)
+  3. Heuristic category from id keywords (human reviews and corrects)
+  4. Parses CLAUDE.md API Requirements Matrix → integrations[]
+  5. Emits skills-index.yaml at project root (or stdout under --dry-run)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Heuristics
+# ---------------------------------------------------------------------------
+
+# id-keyword → category mapping (first match wins)
+CATEGORY_HINTS: list[tuple[list[str], str]] = [
+    (
+        [
+            "breadth",
+            "uptrend",
+            "regime",
+            "distribution-day",
+            "macro",
+            "market-top",
+            "ftd",
+            "exposure",
+            "downtrend",
+            "market-environment",
+            "market-news",
+            "bubble",
+        ],
+        "market-regime",
+    ),
+    (["portfolio", "kanchi", "dividend"], "core-portfolio"),
+    (["vcp", "canslim", "breakout", "theme"], "swing-opportunity"),
+    (["position-sizer", "technical-analyst"], "trade-planning"),
+    (["memory", "postmortem", "journal", "trade-hypothesis"], "trade-memory"),
+    (["backtest", "edge-", "scenario", "strategy-pivot", "stanley"], "strategy-research"),
+    (
+        [
+            "parabolic",
+            "options",
+            "earnings",
+            "pead",
+            "pair-trade",
+            "institutional-flow",
+            "finviz",
+            "ibd-distribution",
+        ],
+        "advanced-satellite",
+    ),
+    (
+        [
+            "skill-designer",
+            "skill-idea",
+            "skill-integration",
+            "dual-axis",
+            "data-quality-checker",
+            "downtrend-duration",
+            "signal-postmortem-analyzer",
+            "us-stock-analysis",
+            "sector-analyst",
+        ],
+        "meta",
+    ),
+]
+
+# Common abbreviations to capitalize when generating display_name
+DISPLAY_NAME_OVERRIDES = {
+    "vcp": "VCP",
+    "canslim": "CANSLIM",
+    "pead": "PEAD",
+    "ftd": "FTD",
+    "ibd": "IBD",
+    "mcp": "MCP",
+    "us": "US",
+    "etf": "ETF",
+    "rsi": "RSI",
+    "atr": "ATR",
+    "ai": "AI",
+    "fmp": "FMP",
+    "sop": "SOP",
+}
+
+# Skills not in CLAUDE.md API matrix that we know are pure-local
+KNOWN_PURE_LOCAL = {
+    # Add IDs here only when we are certain — otherwise leave as `unknown`.
+}
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser (mirrors check_skill_frontmatter.py)
+# ---------------------------------------------------------------------------
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+FIELD_RE = re.compile(r"^(\w+):\s*(.+)$", re.MULTILINE)
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+    return dict(FIELD_RE.findall(match.group(1)))
+
+
+# ---------------------------------------------------------------------------
+# Display name heuristic
+# ---------------------------------------------------------------------------
+
+
+def to_display_name(skill_id: str) -> str:
+    parts = skill_id.split("-")
+    out = []
+    for part in parts:
+        out.append(DISPLAY_NAME_OVERRIDES.get(part, part.capitalize()))
+    return " ".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Category heuristic
+# ---------------------------------------------------------------------------
+
+
+def guess_category(skill_id: str) -> str | None:
+    for keywords, category in CATEGORY_HINTS:
+        for kw in keywords:
+            if kw in skill_id:
+                return category
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE.md API matrix parser
+# ---------------------------------------------------------------------------
+
+
+MATRIX_HEADER_RE = re.compile(
+    r"^\|\s*Skill\s*\|\s*FMP API\s*\|\s*FINVIZ Elite\s*\|\s*Alpaca\s*\|", re.MULTILINE
+)
+ROW_RE = re.compile(r"^\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.*?)\s*\|$")
+
+
+def display_name_to_id(name: str) -> str:
+    """Convert "Earnings Trade Analyzer" → "earnings-trade-analyzer"."""
+    cleaned = name.replace("**", "").strip()
+    return cleaned.lower().replace(" ", "-")
+
+
+def cell_to_requirement(cell: str) -> str | None:
+    """Translate a matrix cell into a requirement value."""
+    cell = cell.strip()
+    if "Required" in cell and "Not" not in cell:
+        return "required"
+    if "Optional" in cell and "Recommended" in cell:
+        return "recommended"
+    if "Optional" in cell:
+        return "optional"
+    # "Not used" / "Not required" / blank → no entry
+    return None
+
+
+def parse_claude_md_matrix(claude_md: Path) -> dict[str, list[dict]]:
+    """Return {skill_id: [integration entries]} parsed from CLAUDE.md."""
+    text = claude_md.read_text(encoding="utf-8")
+    header = MATRIX_HEADER_RE.search(text)
+    if not header:
+        return {}
+
+    # Pull lines from the header until the first blank or non-table line
+    lines = text[header.start() :].splitlines()
+    # Skip header + separator (first 2 lines)
+    data_lines = []
+    for line in lines[2:]:
+        if not line.startswith("|"):
+            break
+        data_lines.append(line)
+
+    out: dict[str, list[dict]] = {}
+    for line in data_lines:
+        m = ROW_RE.match(line)
+        if not m:
+            continue
+        name, fmp_cell, finviz_cell, alpaca_cell, notes = m.groups()
+        skill_id = display_name_to_id(name)
+
+        integrations: list[dict] = []
+        fmp = cell_to_requirement(fmp_cell)
+        if fmp:
+            integrations.append(
+                {
+                    "id": "fmp",
+                    "type": "market_data",
+                    "requirement": fmp,
+                    "note": "Financial Modeling Prep API",
+                }
+            )
+        finviz = cell_to_requirement(finviz_cell)
+        if finviz:
+            integrations.append(
+                {
+                    "id": "finviz",
+                    "type": "screener",
+                    "requirement": finviz,
+                    "note": "FINVIZ Elite API",
+                }
+            )
+        alpaca = cell_to_requirement(alpaca_cell)
+        if alpaca:
+            integrations.append(
+                {
+                    "id": "alpaca",
+                    "type": "broker",
+                    "requirement": alpaca,
+                    "note": "Alpaca brokerage MCP/API",
+                }
+            )
+
+        # No paid-API entry → infer from notes column
+        if not integrations:
+            note_lower = notes.lower()
+            if "image" in note_lower:
+                integrations.append(
+                    {
+                        "id": "chart_image",
+                        "type": "image",
+                        "requirement": "required",
+                        "note": "Chart screenshot input",
+                    }
+                )
+            elif "websearch" in note_lower or "webfetch" in note_lower:
+                integrations.append(
+                    {
+                        "id": "websearch",
+                        "type": "web",
+                        "requirement": "required",
+                        "note": "Web search / fetch",
+                    }
+                )
+            elif (
+                "calculation" in note_lower or "scoring" in note_lower or "validation" in note_lower
+            ):
+                integrations.append(
+                    {
+                        "id": "local_calculation",
+                        "type": "calculation",
+                        "requirement": "not_required",
+                        "note": notes.strip() or "Pure local calculation",
+                    }
+                )
+            elif "user provides" in note_lower or "user-provided" in note_lower:
+                integrations.append(
+                    {
+                        "id": "user_input",
+                        "type": "local_file",
+                        "requirement": "required",
+                        "note": notes.strip() or "User-provided data",
+                    }
+                )
+            else:
+                # Unable to infer — flag for review
+                integrations.append(
+                    {
+                        "id": "unknown",
+                        "type": "unknown",
+                        "requirement": "unknown",
+                        "note": f"TODO: review; CLAUDE.md row notes: {notes.strip()}",
+                    }
+                )
+
+        out[skill_id] = integrations
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main bootstrap
+# ---------------------------------------------------------------------------
+
+
+def build_index(project_root: Path) -> dict[str, Any]:
+    skills_dir = project_root / "skills"
+    claude_md = project_root / "CLAUDE.md"
+    matrix = parse_claude_md_matrix(claude_md) if claude_md.is_file() else {}
+
+    skill_entries: list[dict] = []
+    for child in sorted(skills_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        skill_md = child / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+        skill_id = child.name
+        text = skill_md.read_text(encoding="utf-8")
+        fm = parse_frontmatter(text)
+        description = (fm.get("description") or "").strip().strip("'\"")
+        # Truncate long descriptions to a one-sentence summary
+        summary = description.split(". ")[0].rstrip(".") + "."
+        if len(summary) > 240:
+            summary = summary[:237].rstrip() + "..."
+
+        category = guess_category(skill_id) or "meta"
+
+        integrations = matrix.get(skill_id)
+        if not integrations:
+            if skill_id in KNOWN_PURE_LOCAL:
+                integrations = [
+                    {
+                        "id": "local_calculation",
+                        "type": "calculation",
+                        "requirement": "not_required",
+                        "note": "Pure local calculation",
+                    }
+                ]
+            else:
+                integrations = [
+                    {
+                        "id": "unknown",
+                        "type": "unknown",
+                        "requirement": "unknown",
+                        "note": "TODO: review; not found in CLAUDE.md API matrix",
+                    }
+                ]
+
+        entry = {
+            "id": skill_id,
+            "display_name": to_display_name(skill_id),
+            "category": category,
+            "status": "production",
+            "summary": summary,
+            "timeframe": "unknown",
+            "difficulty": "unknown",
+            "integrations": integrations,
+            "inputs": [],
+            "outputs": [],
+            "workflows": [],
+            "hand_written_doc": False,
+        }
+        skill_entries.append(entry)
+
+    return {
+        "schema_version": 1,
+        "categories": [
+            "market-regime",
+            "core-portfolio",
+            "swing-opportunity",
+            "trade-planning",
+            "trade-memory",
+            "strategy-research",
+            "advanced-satellite",
+            "meta",
+        ],
+        "skills": skill_entries,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bootstrap skills-index.yaml from skills/*/SKILL.md and CLAUDE.md "
+            "(one-time migration helper, NOT a sync tool)."
+        )
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to the repository root (default: cwd)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output path (default: <project-root>/skills-index.yaml)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the generated YAML to stdout instead of writing.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing skills-index.yaml. Required for non-dry runs over an existing file.",
+    )
+    args = parser.parse_args(argv)
+
+    output = args.output or (args.project_root / "skills-index.yaml")
+    if not args.dry_run and output.exists() and not args.force:
+        print(
+            f"ERROR: {output} already exists. Pass --force to overwrite, "
+            "or --dry-run to preview without writing.",
+            file=sys.stderr,
+        )
+        return 2
+
+    index = build_index(args.project_root)
+    rendered = yaml.safe_dump(index, sort_keys=False, allow_unicode=True, width=100)
+
+    if args.dry_run:
+        sys.stdout.write(rendered)
+        return 0
+
+    output.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {output} ({len(index['skills'])} skills).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_validate_skills_index.py
+++ b/scripts/tests/test_validate_skills_index.py
@@ -1,0 +1,811 @@
+"""Validator tests — one per error code, plus happy path.
+
+Each test builds a minimal repository layout in tmp_path and asserts the
+validator emits the specific error code.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from validate_skills_index import Finding, validate  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write_skill(project_root: Path, skill_id: str, frontmatter_name: str | None = None) -> None:
+    """Create skills/<id>/SKILL.md with frontmatter."""
+    if frontmatter_name is None:
+        frontmatter_name = skill_id
+    skill_dir = project_root / "skills" / skill_id
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: {frontmatter_name}
+description: Test skill {skill_id}.
+---
+
+# {skill_id}
+""",
+        encoding="utf-8",
+    )
+
+
+def write_index(project_root: Path, skills: list[dict]) -> None:
+    import yaml as _yaml
+
+    payload = {
+        "schema_version": 1,
+        "categories": [
+            "market-regime",
+            "core-portfolio",
+            "swing-opportunity",
+            "trade-planning",
+            "trade-memory",
+            "strategy-research",
+            "advanced-satellite",
+            "meta",
+        ],
+        "skills": skills,
+    }
+    (project_root / "skills-index.yaml").write_text(
+        _yaml.safe_dump(payload, sort_keys=False), encoding="utf-8"
+    )
+
+
+def write_workflow(project_root: Path, workflow_id: str, content: dict) -> Path:
+    import yaml as _yaml
+
+    workflows_dir = project_root / "workflows"
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+    path = workflows_dir / f"{workflow_id}.yaml"
+    path.write_text(_yaml.safe_dump(content, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def codes(findings: list[Finding]) -> list[str]:
+    return [f.code for f in findings if f.severity == "error"]
+
+
+def warning_codes(findings: list[Finding]) -> list[str]:
+    return [f.code for f in findings if f.severity == "warning"]
+
+
+def minimal_skill(skill_id: str, **overrides) -> dict:
+    base = {
+        "id": skill_id,
+        "display_name": skill_id.replace("-", " ").title(),
+        "category": "core-portfolio",
+        "status": "production",
+        "summary": f"Summary for {skill_id}.",
+        "timeframe": "weekly",
+        "difficulty": "intermediate",
+        "integrations": [
+            {
+                "id": "local_calculation",
+                "type": "calculation",
+                "requirement": "not_required",
+                "note": "Pure local calculation.",
+            }
+        ],
+        "inputs": ["test_input"],
+        "outputs": ["test_output"],
+        "workflows": [],
+        "hand_written_doc": False,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_default_mode(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_skill(tmp_path, "beta")
+    write_index(tmp_path, [minimal_skill("alpha"), minimal_skill("beta")])
+
+    findings = validate(tmp_path)
+    assert codes(findings) == [], findings
+
+
+def test_happy_path_strict_workflows_no_workflows(tmp_path: Path) -> None:
+    """No workflows[] references and no workflows/ directory → still passes strict-workflows."""
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha")])
+
+    findings = validate(tmp_path, strict_workflows=True)
+    assert codes(findings) == [], findings
+
+
+def test_warns_when_workflows_reference_missing_in_default(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha", workflows=["nonexistent"])])
+
+    findings = validate(tmp_path)  # default mode
+    assert codes(findings) == [], findings
+    assert "WF001" in warning_codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# Index-level error codes
+# ---------------------------------------------------------------------------
+
+
+def test_idx001_duplicate_skill_id(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha"), minimal_skill("alpha")])
+    findings = validate(tmp_path)
+    assert "IDX001" in codes(findings)
+
+
+def test_idx002_index_entry_without_folder(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha"), minimal_skill("ghost")])
+    findings = validate(tmp_path)
+    assert "IDX002" in codes(findings)
+
+
+def test_idx003_folder_without_index_entry(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_skill(tmp_path, "orphan")
+    write_index(tmp_path, [minimal_skill("alpha")])
+    findings = validate(tmp_path)
+    assert "IDX003" in codes(findings)
+
+
+def test_idx004_frontmatter_name_mismatch(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha", frontmatter_name="wrong-name")
+    write_index(tmp_path, [minimal_skill("alpha")])
+    findings = validate(tmp_path)
+    assert "IDX004" in codes(findings)
+
+
+def test_idx005_invalid_category(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha", category="bogus")])
+    findings = validate(tmp_path)
+    assert "IDX005" in codes(findings)
+
+
+def test_idx006_invalid_status(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha", status="bogus")])
+    findings = validate(tmp_path)
+    assert "IDX006" in codes(findings)
+
+
+def test_idx007_invalid_integration_type(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill(
+                "alpha",
+                integrations=[{"id": "x", "type": "bogus", "requirement": "required"}],
+            )
+        ],
+    )
+    findings = validate(tmp_path)
+    assert "IDX007" in codes(findings)
+
+
+def test_idx008_invalid_requirement(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill(
+                "alpha",
+                integrations=[{"id": "x", "type": "broker", "requirement": "bogus"}],
+            )
+        ],
+    )
+    findings = validate(tmp_path)
+    assert "IDX008" in codes(findings)
+
+
+def test_idx009_empty_summary(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha", summary="   ")])
+    findings = validate(tmp_path)
+    assert "IDX009" in codes(findings)
+
+
+def test_idx010_missing_schema_version(tmp_path: Path) -> None:
+    """schema_version absent or not equal to supported version → hard error."""
+    import yaml as _yaml
+
+    write_skill(tmp_path, "alpha")
+    payload = {
+        # schema_version intentionally missing
+        "categories": [
+            "market-regime",
+            "core-portfolio",
+            "swing-opportunity",
+            "trade-planning",
+            "trade-memory",
+            "strategy-research",
+            "advanced-satellite",
+            "meta",
+        ],
+        "skills": [minimal_skill("alpha")],
+    }
+    (tmp_path / "skills-index.yaml").write_text(_yaml.safe_dump(payload), encoding="utf-8")
+    findings = validate(tmp_path)
+    assert "IDX010" in codes(findings)
+
+
+def test_idx010_wrong_schema_version(tmp_path: Path) -> None:
+    import yaml as _yaml
+
+    write_skill(tmp_path, "alpha")
+    payload = {
+        "schema_version": 999,
+        "categories": [
+            "market-regime",
+            "core-portfolio",
+            "swing-opportunity",
+            "trade-planning",
+            "trade-memory",
+            "strategy-research",
+            "advanced-satellite",
+            "meta",
+        ],
+        "skills": [minimal_skill("alpha")],
+    }
+    (tmp_path / "skills-index.yaml").write_text(_yaml.safe_dump(payload), encoding="utf-8")
+    findings = validate(tmp_path)
+    assert "IDX010" in codes(findings)
+
+
+def test_idx011_missing_categories_block(tmp_path: Path) -> None:
+    """categories block absent → hard error."""
+    import yaml as _yaml
+
+    write_skill(tmp_path, "alpha")
+    payload = {
+        "schema_version": 1,
+        # categories intentionally missing
+        "skills": [minimal_skill("alpha")],
+    }
+    (tmp_path / "skills-index.yaml").write_text(_yaml.safe_dump(payload), encoding="utf-8")
+    findings = validate(tmp_path)
+    assert "IDX011" in codes(findings)
+
+
+def test_idx011_categories_not_canonical(tmp_path: Path) -> None:
+    """categories block present but not the canonical 8 → hard error."""
+    import yaml as _yaml
+
+    write_skill(tmp_path, "alpha")
+    payload = {
+        "schema_version": 1,
+        "categories": ["market-regime", "extra-bogus"],  # subset/different
+        "skills": [minimal_skill("alpha")],
+    }
+    (tmp_path / "skills-index.yaml").write_text(_yaml.safe_dump(payload), encoding="utf-8")
+    findings = validate(tmp_path)
+    assert "IDX011" in codes(findings)
+
+
+def test_idx011_categories_with_duplicate(tmp_path: Path) -> None:
+    """All 8 canonical categories present, but one is duplicated → hard error.
+
+    set() comparison alone would miss this; length check catches it.
+    """
+    import yaml as _yaml
+
+    write_skill(tmp_path, "alpha")
+    payload = {
+        "schema_version": 1,
+        "categories": [
+            "market-regime",
+            "market-regime",  # duplicated — set() would still equal VALID_CATEGORIES
+            "core-portfolio",
+            "swing-opportunity",
+            "trade-planning",
+            "trade-memory",
+            "strategy-research",
+            "advanced-satellite",
+            "meta",
+        ],
+        "skills": [minimal_skill("alpha")],
+    }
+    (tmp_path / "skills-index.yaml").write_text(_yaml.safe_dump(payload), encoding="utf-8")
+    findings = validate(tmp_path)
+    assert "IDX011" in codes(findings)
+
+
+def test_idx012_unknown_integration_warns_in_default(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill(
+                "alpha",
+                integrations=[
+                    {
+                        "id": "unknown",
+                        "type": "unknown",
+                        "requirement": "unknown",
+                        "note": "TODO",
+                    }
+                ],
+            )
+        ],
+    )
+    findings = validate(tmp_path)
+    assert "IDX012" in warning_codes(findings)
+    assert codes(findings) == []  # default mode: no errors
+
+
+def test_idx012_unknown_integration_errors_in_strict_metadata(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill(
+                "alpha",
+                integrations=[
+                    {
+                        "id": "unknown",
+                        "type": "unknown",
+                        "requirement": "unknown",
+                        "note": "TODO",
+                    }
+                ],
+            )
+        ],
+    )
+    findings = validate(tmp_path, strict_metadata=True)
+    assert "IDX012" in codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# Workflow-level error codes (require --strict-workflows)
+# ---------------------------------------------------------------------------
+
+
+def _setup_minimal_workflow_repo(tmp_path: Path, **wf_overrides) -> None:
+    """Create one skill + one valid workflow that we then mutate."""
+    write_skill(tmp_path, "alpha")
+    write_skill(tmp_path, "beta")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill("alpha", workflows=["sample"]),
+            minimal_skill("beta"),
+        ],
+    )
+    base_wf = {
+        "schema_version": 1,
+        "id": "sample",
+        "display_name": "Sample",
+        "cadence": "daily",
+        "estimated_minutes": 15,
+        "required_skills": ["alpha"],
+        "optional_skills": [],
+        "artifacts": [
+            {"id": "art1", "produced_by_step": 1, "required": True},
+        ],
+        "steps": [
+            {
+                "step": 1,
+                "name": "Run alpha",
+                "skill": "alpha",
+                "produces": ["art1"],
+                "decision_gate": False,
+            }
+        ],
+        "journal_destination": "beta",
+    }
+    base_wf.update(wf_overrides)
+    write_workflow(tmp_path, "sample", base_wf)
+
+
+def test_wf001_workflow_file_missing(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha", workflows=["ghost"])])
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF001" in codes(findings)
+
+
+def test_wf002_workflow_id_filename_mismatch(tmp_path: Path) -> None:
+    _setup_minimal_workflow_repo(tmp_path, id="wrong-id")
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF002" in codes(findings)
+
+
+def test_wf003_step_skill_missing(tmp_path: Path) -> None:
+    _setup_minimal_workflow_repo(
+        tmp_path,
+        required_skills=["alpha"],
+        steps=[
+            {
+                "step": 1,
+                "name": "Use ghost",
+                "skill": "ghost-skill",
+                "decision_gate": False,
+            }
+        ],
+        artifacts=[],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF003" in codes(findings)
+
+
+def test_wf004_depends_on_future_step(tmp_path: Path) -> None:
+    _setup_minimal_workflow_repo(
+        tmp_path,
+        required_skills=["alpha"],
+        artifacts=[],
+        steps=[
+            {
+                "step": 1,
+                "name": "First",
+                "skill": "alpha",
+                "depends_on": [2],
+                "decision_gate": False,
+            },
+            {
+                "step": 2,
+                "name": "Second",
+                "skill": "alpha",
+                "decision_gate": False,
+            },
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF004" in codes(findings)
+
+
+def test_wf005_decision_gate_missing_question(tmp_path: Path) -> None:
+    _setup_minimal_workflow_repo(
+        tmp_path,
+        required_skills=["alpha"],
+        artifacts=[],
+        steps=[
+            {
+                "step": 1,
+                "name": "Decide",
+                "skill": "alpha",
+                "decision_gate": True,
+                # decision_question intentionally missing
+            }
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF005" in codes(findings)
+
+
+def test_wf006_journal_destination_missing(tmp_path: Path) -> None:
+    _setup_minimal_workflow_repo(tmp_path, journal_destination="ghost-skill")
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF006" in codes(findings)
+
+
+def test_wf007_artifact_consumed_before_produced(tmp_path: Path) -> None:
+    _setup_minimal_workflow_repo(
+        tmp_path,
+        required_skills=["alpha"],
+        artifacts=[
+            {"id": "late_artifact", "produced_by_step": 2, "required": True},
+        ],
+        steps=[
+            {
+                "step": 1,
+                "name": "Try to consume early",
+                "skill": "alpha",
+                "consumes": ["late_artifact"],
+                "decision_gate": False,
+            },
+            {
+                "step": 2,
+                "name": "Produce late",
+                "skill": "alpha",
+                "produces": ["late_artifact"],
+                "decision_gate": False,
+            },
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF007" in codes(findings)
+
+
+def test_wf008_deprecated_skill_required(tmp_path: Path) -> None:
+    write_skill(tmp_path, "old-skill")
+    write_skill(tmp_path, "beta")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill("old-skill", status="deprecated", workflows=["sample"]),
+            minimal_skill("beta"),
+        ],
+    )
+    write_workflow(
+        tmp_path,
+        "sample",
+        {
+            "schema_version": 1,
+            "id": "sample",
+            "required_skills": ["old-skill"],
+            "artifacts": [],
+            "steps": [
+                {
+                    "step": 1,
+                    "name": "Use deprecated",
+                    "skill": "old-skill",
+                    "decision_gate": False,
+                }
+            ],
+            "journal_destination": "beta",
+        },
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF008" in codes(findings)
+
+
+def test_wf009_required_skill_not_in_steps(tmp_path: Path) -> None:
+    _setup_minimal_workflow_repo(
+        tmp_path,
+        required_skills=["alpha", "beta"],  # beta is required but never used in a step
+        artifacts=[],
+        steps=[
+            {
+                "step": 1,
+                "name": "Use alpha only",
+                "skill": "alpha",
+                "decision_gate": False,
+            }
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF009" in codes(findings)
+
+
+def test_wf011_optional_skill_not_in_index(tmp_path: Path) -> None:
+    """optional_skills entry that does not exist in skills-index.yaml → error."""
+    write_skill(tmp_path, "alpha")
+    write_skill(tmp_path, "beta")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill("alpha", workflows=["sample"]),
+            minimal_skill("beta"),
+        ],
+    )
+    write_workflow(
+        tmp_path,
+        "sample",
+        {
+            "schema_version": 1,
+            "id": "sample",
+            "required_skills": ["alpha"],
+            "optional_skills": ["ghost-skill"],  # does not exist
+            "artifacts": [],
+            "steps": [{"step": 1, "name": "Run", "skill": "alpha", "decision_gate": False}],
+            "journal_destination": "beta",
+        },
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF011" in codes(findings)
+
+
+def test_wf012_artifact_produced_by_step_mismatch(tmp_path: Path) -> None:
+    """artifact says produced_by_step=N but step N does not list it in produces."""
+    write_skill(tmp_path, "alpha")
+    write_skill(tmp_path, "beta")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill("alpha", workflows=["sample"]),
+            minimal_skill("beta"),
+        ],
+    )
+    write_workflow(
+        tmp_path,
+        "sample",
+        {
+            "schema_version": 1,
+            "id": "sample",
+            "required_skills": ["alpha"],
+            "artifacts": [
+                {"id": "ghost_artifact", "produced_by_step": 1, "required": True},
+            ],
+            "steps": [
+                # Step 1 declares NO produces → mismatch
+                {"step": 1, "name": "Run", "skill": "alpha", "decision_gate": False}
+            ],
+            "journal_destination": "beta",
+        },
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF012" in codes(findings)
+
+
+def test_wf012_step_produces_undeclared_artifact(tmp_path: Path) -> None:
+    """step produces an artifact id that is not in artifacts: → error."""
+    write_skill(tmp_path, "alpha")
+    write_skill(tmp_path, "beta")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill("alpha", workflows=["sample"]),
+            minimal_skill("beta"),
+        ],
+    )
+    write_workflow(
+        tmp_path,
+        "sample",
+        {
+            "schema_version": 1,
+            "id": "sample",
+            "required_skills": ["alpha"],
+            "artifacts": [],  # nothing declared
+            "steps": [
+                {
+                    "step": 1,
+                    "name": "Run",
+                    "skill": "alpha",
+                    "produces": ["mystery"],
+                    "decision_gate": False,
+                }
+            ],
+            "journal_destination": "beta",
+        },
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF012" in codes(findings)
+
+
+def test_wf010_step_skill_not_in_required_skills(tmp_path: Path) -> None:
+    _setup_minimal_workflow_repo(
+        tmp_path,
+        required_skills=[],  # alpha used in step 1 (non-optional) but not in required_skills
+        artifacts=[],
+        steps=[
+            {
+                "step": 1,
+                "name": "Use alpha non-optional",
+                "skill": "alpha",
+                "decision_gate": False,
+            }
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF010" in codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: optional steps and optional artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_optional_step_skill_in_optional_skills_passes(tmp_path: Path) -> None:
+    """Optional step.skill in optional_skills (not required_skills) should pass."""
+    write_skill(tmp_path, "alpha")
+    write_skill(tmp_path, "extra")
+    write_skill(tmp_path, "beta")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill("alpha", workflows=["sample"]),
+            minimal_skill("extra"),
+            minimal_skill("beta"),
+        ],
+    )
+    write_workflow(
+        tmp_path,
+        "sample",
+        {
+            "schema_version": 1,
+            "id": "sample",
+            "required_skills": ["alpha"],
+            "optional_skills": ["extra"],
+            "artifacts": [],
+            "steps": [
+                {"step": 1, "name": "Required", "skill": "alpha", "decision_gate": False},
+                {
+                    "step": 2,
+                    "name": "Optional",
+                    "skill": "extra",
+                    "optional": True,
+                    "decision_gate": False,
+                },
+            ],
+            "journal_destination": "beta",
+        },
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert codes(findings) == [], findings
+
+
+def test_consume_optional_artifact_passes(tmp_path: Path) -> None:
+    """Consuming required: false artifact produced by an earlier step is OK."""
+    write_skill(tmp_path, "alpha")
+    write_skill(tmp_path, "beta")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill("alpha", workflows=["sample"]),
+            minimal_skill("beta"),
+        ],
+    )
+    write_workflow(
+        tmp_path,
+        "sample",
+        {
+            "schema_version": 1,
+            "id": "sample",
+            "required_skills": ["alpha"],
+            "artifacts": [
+                {"id": "opt", "produced_by_step": 1, "required": False},
+            ],
+            "steps": [
+                {
+                    "step": 1,
+                    "name": "Produce optional",
+                    "skill": "alpha",
+                    "optional": True,
+                    "produces": ["opt"],
+                    "decision_gate": False,
+                },
+                {
+                    "step": 2,
+                    "name": "Consume optional",
+                    "skill": "alpha",
+                    "consumes": ["opt"],
+                    "decision_gate": False,
+                },
+            ],
+            "journal_destination": "beta",
+        },
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert codes(findings) == [], findings
+
+
+# ---------------------------------------------------------------------------
+# strict-metadata
+# ---------------------------------------------------------------------------
+
+
+def test_strict_metadata_rejects_unknown_timeframe(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha", timeframe="unknown")])
+    findings = validate(tmp_path, strict_metadata=True)
+    assert any(f.code == "IDX-META" and f.severity == "error" for f in findings)
+
+
+def test_default_mode_warns_on_unknown_timeframe(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha", timeframe="unknown")])
+    findings = validate(tmp_path)
+    assert "IDX-META" in warning_codes(findings)
+    assert codes(findings) == []
+
+
+# ---------------------------------------------------------------------------
+# Sanity: missing index file
+# ---------------------------------------------------------------------------
+
+
+def test_missing_index_file(tmp_path: Path) -> None:
+    findings = validate(tmp_path)
+    assert any(f.code == "IDX-MISSING" for f in findings)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/scripts/validate_skills_index.py
+++ b/scripts/validate_skills_index.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""Validate skills-index.yaml against skills/ folder, frontmatter, and (optionally) workflows/.
+
+Strictness levels:
+  default              : index/folder bijection + required fields + enums
+  --strict-workflows   : also resolve workflow references and check internal-consistency
+  --strict-metadata    : also enforce timeframe/difficulty/inputs/outputs completeness
+
+Emits stable error codes (IDX001-009, WF001-010). See
+docs/dev/metadata-and-workflow-schema.md for the full catalog.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Enums (kept in sync with docs/dev/metadata-and-workflow-schema.md)
+# ---------------------------------------------------------------------------
+
+VALID_CATEGORIES = frozenset(
+    {
+        "market-regime",
+        "core-portfolio",
+        "swing-opportunity",
+        "trade-planning",
+        "trade-memory",
+        "strategy-research",
+        "advanced-satellite",
+        "meta",
+    }
+)
+
+VALID_STATUSES = frozenset({"production", "beta", "experimental", "deprecated"})
+
+VALID_INTEGRATION_TYPES = frozenset(
+    {
+        "broker",
+        "market_data",
+        "screener",
+        "web",
+        "local_file",
+        "image",
+        "mcp",
+        "calculation",
+        "none",
+        "unknown",
+    }
+)
+
+VALID_REQUIREMENTS = frozenset(
+    {
+        "required",
+        "recommended",
+        "optional",
+        "not_required",
+        "unknown",
+    }
+)
+
+VALID_TIMEFRAMES = frozenset({"daily", "weekly", "event-driven", "research", "unknown"})
+VALID_DIFFICULTIES = frozenset({"beginner", "intermediate", "advanced", "unknown"})
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser (mirrors scripts/hooks/check_skill_frontmatter.py)
+# ---------------------------------------------------------------------------
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+FIELD_RE = re.compile(r"^(\w+):\s*(.+)$", re.MULTILINE)
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+    return dict(FIELD_RE.findall(match.group(1)))
+
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Finding:
+    code: str
+    severity: str  # "error" or "warning"
+    location: str
+    message: str
+
+    def format(self) -> str:
+        return f"[{self.severity.upper():7s}] {self.code} {self.location}: {self.message}"
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _scan_skill_folders(project_root: Path) -> dict[str, Path]:
+    """Return {skill_id: SKILL.md path} for every skills/<id>/SKILL.md present."""
+    skills_dir = project_root / "skills"
+    if not skills_dir.is_dir():
+        return {}
+    folders = {}
+    for child in sorted(skills_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        skill_md = child / "SKILL.md"
+        if skill_md.is_file():
+            folders[child.name] = skill_md
+    return folders
+
+
+SUPPORTED_SCHEMA_VERSION = 1
+
+
+def _validate_index_structure(
+    index: Any, project_root: Path, *, strict_metadata: bool, strict_workflows: bool
+) -> tuple[list[Finding], dict[str, dict]]:
+    """First pass: parse skills-index.yaml structure; collect per-skill entries."""
+    findings: list[Finding] = []
+    skills_by_id: dict[str, dict] = {}
+
+    if not isinstance(index, dict):
+        findings.append(
+            Finding("IDX-PARSE", "error", "skills-index.yaml", "top-level must be a mapping")
+        )
+        return findings, skills_by_id
+
+    # IDX010: schema_version must be present and equal to SUPPORTED_SCHEMA_VERSION
+    schema_version = index.get("schema_version")
+    if schema_version != SUPPORTED_SCHEMA_VERSION:
+        findings.append(
+            Finding(
+                "IDX010",
+                "error",
+                "skills-index.yaml",
+                f"schema_version is {schema_version!r}, expected {SUPPORTED_SCHEMA_VERSION}",
+            )
+        )
+
+    # IDX011: categories block must list EXACTLY the canonical 8 (no duplicates,
+    # no missing, no extras). Length check catches duplicates that survive set().
+    categories = index.get("categories")
+    if (
+        not isinstance(categories, list)
+        or set(categories) != VALID_CATEGORIES
+        or len(categories) != len(VALID_CATEGORIES)
+    ):
+        findings.append(
+            Finding(
+                "IDX011",
+                "error",
+                "skills-index.yaml",
+                (
+                    "`categories:` block must list exactly the 8 canonical categories "
+                    f"({sorted(VALID_CATEGORIES)}) with no duplicates"
+                ),
+            )
+        )
+
+    skills = index.get("skills") or []
+    if not isinstance(skills, list):
+        findings.append(
+            Finding("IDX-PARSE", "error", "skills-index.yaml", "`skills:` must be a list")
+        )
+        return findings, skills_by_id
+
+    seen_ids: dict[str, int] = {}
+    for entry in skills:
+        if not isinstance(entry, dict):
+            findings.append(
+                Finding("IDX-PARSE", "error", "skills-index.yaml", "skill entry must be a mapping")
+            )
+            continue
+        skill_id = str(entry.get("id") or "").strip()
+        if not skill_id:
+            findings.append(
+                Finding(
+                    "IDX-PARSE",
+                    "error",
+                    "skills-index.yaml",
+                    "skill entry missing required `id`",
+                )
+            )
+            continue
+
+        if skill_id in seen_ids:
+            findings.append(
+                Finding(
+                    "IDX001",
+                    "error",
+                    f"skills-index.yaml::{skill_id}",
+                    "duplicate skill id (also seen earlier)",
+                )
+            )
+            continue
+        seen_ids[skill_id] = 1
+        skills_by_id[skill_id] = entry
+
+        loc = f"skills-index.yaml::{skill_id}"
+
+        # Required fields
+        if not str(entry.get("display_name") or "").strip():
+            findings.append(
+                Finding("IDX-PARSE", "error", loc, "missing required field `display_name`")
+            )
+
+        category = entry.get("category")
+        if category not in VALID_CATEGORIES:
+            findings.append(Finding("IDX005", "error", loc, f"invalid category {category!r}"))
+
+        status = entry.get("status")
+        if status not in VALID_STATUSES:
+            findings.append(Finding("IDX006", "error", loc, f"invalid status {status!r}"))
+
+        if not str(entry.get("summary") or "").strip():
+            findings.append(Finding("IDX009", "error", loc, "summary is empty"))
+
+        # integrations
+        for idx, integ in enumerate(entry.get("integrations") or []):
+            iloc = f"{loc}.integrations[{idx}]"
+            if not isinstance(integ, dict):
+                findings.append(Finding("IDX-PARSE", "error", iloc, "must be a mapping"))
+                continue
+            itype = integ.get("type")
+            if itype is not None and itype not in VALID_INTEGRATION_TYPES:
+                findings.append(
+                    Finding("IDX007", "error", iloc, f"invalid integration type {itype!r}")
+                )
+            ireq = integ.get("requirement")
+            if ireq is not None and ireq not in VALID_REQUIREMENTS:
+                findings.append(Finding("IDX008", "error", iloc, f"invalid requirement {ireq!r}"))
+            # IDX012: explicit `unknown` markers are warnings by default,
+            # errors under --strict-metadata. Severity is consistent with the
+            # schema spec doc (default/strict-workflows: warn; strict-metadata: error).
+            if integ.get("id") == "unknown" or itype == "unknown" or ireq == "unknown":
+                sev = "error" if strict_metadata else "warning"
+                findings.append(
+                    Finding(
+                        "IDX012",
+                        sev,
+                        iloc,
+                        "integration uses `unknown` marker — flagged for owner review",
+                    )
+                )
+
+        # Best-effort fields (warn vs error)
+        timeframe = entry.get("timeframe", "unknown")
+        if timeframe not in VALID_TIMEFRAMES:
+            sev = "error" if strict_metadata else "warning"
+            findings.append(Finding("IDX-META", sev, loc, f"invalid timeframe {timeframe!r}"))
+        elif timeframe == "unknown":
+            sev = "error" if strict_metadata else "warning"
+            findings.append(Finding("IDX-META", sev, loc, "timeframe is `unknown`"))
+
+        difficulty = entry.get("difficulty", "unknown")
+        if difficulty not in VALID_DIFFICULTIES:
+            sev = "error" if strict_metadata else "warning"
+            findings.append(Finding("IDX-META", sev, loc, f"invalid difficulty {difficulty!r}"))
+        elif difficulty == "unknown":
+            sev = "error" if strict_metadata else "warning"
+            findings.append(Finding("IDX-META", sev, loc, "difficulty is `unknown`"))
+
+        if strict_metadata and not entry.get("inputs"):
+            findings.append(Finding("IDX-META", "error", loc, "inputs is empty"))
+        if strict_metadata and not entry.get("outputs"):
+            findings.append(Finding("IDX-META", "error", loc, "outputs is empty"))
+
+    return findings, skills_by_id
+
+
+def _validate_bijection_and_frontmatter(
+    skills_by_id: dict[str, dict], folders: dict[str, Path]
+) -> list[Finding]:
+    findings: list[Finding] = []
+
+    # IDX002: index entry without folder
+    for skill_id in skills_by_id:
+        if skill_id not in folders:
+            findings.append(
+                Finding(
+                    "IDX002",
+                    "error",
+                    f"skills-index.yaml::{skill_id}",
+                    f"index entry has no skills/{skill_id}/ folder",
+                )
+            )
+
+    # IDX003: folder without index entry
+    for skill_id in folders:
+        if skill_id not in skills_by_id:
+            findings.append(
+                Finding(
+                    "IDX003",
+                    "error",
+                    f"skills/{skill_id}/SKILL.md",
+                    "skill folder has no entry in skills-index.yaml",
+                )
+            )
+
+    # IDX004: frontmatter `name` ≠ index `id`
+    for skill_id, skill_md in folders.items():
+        if skill_id not in skills_by_id:
+            continue  # already reported as IDX003
+        try:
+            text = skill_md.read_text(encoding="utf-8")
+        except OSError as e:
+            findings.append(Finding("IDX-PARSE", "error", str(skill_md), f"cannot read: {e}"))
+            continue
+        fm = parse_frontmatter(text)
+        fm_name = (fm.get("name") or "").strip().strip("'\"")
+        if fm_name != skill_id:
+            findings.append(
+                Finding(
+                    "IDX004",
+                    "error",
+                    str(skill_md),
+                    f"frontmatter name {fm_name!r} does not match index id {skill_id!r}",
+                )
+            )
+
+    return findings
+
+
+def _validate_workflow_references(
+    skills_by_id: dict[str, dict], project_root: Path, *, strict: bool
+) -> tuple[list[Finding], dict[str, Path]]:
+    """Check that each skill's workflows[] entry resolves to a workflows/<id>.yaml file.
+
+    In default mode, missing files are warnings. Under --strict-workflows they are errors.
+    Returns (findings, workflow_files_seen).
+    """
+    findings: list[Finding] = []
+    workflows_dir = project_root / "workflows"
+    available: dict[str, Path] = {}
+    if workflows_dir.is_dir():
+        for wf in workflows_dir.glob("*.yaml"):
+            available[wf.stem] = wf
+
+    for skill_id, entry in skills_by_id.items():
+        for wf_id in entry.get("workflows") or []:
+            if wf_id not in available:
+                sev = "error" if strict else "warning"
+                findings.append(
+                    Finding(
+                        "WF001",
+                        sev,
+                        f"skills-index.yaml::{skill_id}",
+                        f"workflows[] reference {wf_id!r} has no workflows/{wf_id}.yaml file",
+                    )
+                )
+    return findings, available
+
+
+def _validate_workflow_internal(
+    workflow_path: Path,
+    skills_by_id: dict[str, dict],
+) -> list[Finding]:
+    findings: list[Finding] = []
+    rel_loc = f"workflows/{workflow_path.name}"
+
+    try:
+        wf = _load_yaml(workflow_path)
+    except yaml.YAMLError as e:
+        return [Finding("WF-PARSE", "error", rel_loc, f"YAML parse error: {e}")]
+
+    if not isinstance(wf, dict):
+        return [Finding("WF-PARSE", "error", rel_loc, "top-level must be a mapping")]
+
+    wf_id = str(wf.get("id") or "")
+    if wf_id != workflow_path.stem:
+        findings.append(
+            Finding(
+                "WF002",
+                "error",
+                rel_loc,
+                f"workflow id {wf_id!r} does not match filename {workflow_path.stem!r}",
+            )
+        )
+
+    required_skills = list(wf.get("required_skills") or [])
+    optional_skills = list(wf.get("optional_skills") or [])
+
+    # WF008: deprecated skill in required_skills
+    for skill_id in required_skills:
+        entry = skills_by_id.get(skill_id)
+        if entry and entry.get("status") == "deprecated":
+            findings.append(
+                Finding(
+                    "WF008",
+                    "error",
+                    rel_loc,
+                    f"required_skills contains deprecated skill {skill_id!r}",
+                )
+            )
+
+    # WF011: every required_skills / optional_skills entry must exist in the index.
+    # required_skills missing-from-index is also caught indirectly when the same
+    # id appears as a step (WF003), but explicit checking here covers setup-only
+    # bundle suggestions where the skill never appears in any step.
+    for skill_id in required_skills + optional_skills:
+        if skill_id not in skills_by_id:
+            findings.append(
+                Finding(
+                    "WF011",
+                    "error",
+                    rel_loc,
+                    f"required_skills / optional_skills entry {skill_id!r} not in skills-index.yaml",
+                )
+            )
+
+    steps = wf.get("steps") or []
+    if not isinstance(steps, list):
+        findings.append(Finding("WF-PARSE", "error", rel_loc, "`steps` must be a list"))
+        steps = []
+
+    # Build artifact production map and step skill resolution
+    artifacts = wf.get("artifacts") or []
+    artifact_produced_by: dict[str, int] = {}
+    for art in artifacts:
+        if not isinstance(art, dict):
+            continue
+        art_id = str(art.get("id") or "")
+        produced_by = art.get("produced_by_step")
+        if art_id and isinstance(produced_by, int):
+            artifact_produced_by[art_id] = produced_by
+
+    # Build step.produces map for WF012 cross-check
+    step_produces: dict[int, set[str]] = {}
+
+    seen_step_numbers: set[int] = set()
+    non_optional_step_skills: set[str] = set()
+    for step in steps:
+        if not isinstance(step, dict):
+            findings.append(Finding("WF-PARSE", "error", rel_loc, "step must be a mapping"))
+            continue
+        step_num = step.get("step")
+        if isinstance(step_num, int):
+            seen_step_numbers.add(step_num)
+        skill_id = str(step.get("skill") or "")
+        is_optional = bool(step.get("optional", False))
+        if isinstance(step_num, int):
+            step_produces[step_num] = set(step.get("produces") or [])
+
+        # WF003: step.skill exists in index
+        if skill_id and skill_id not in skills_by_id:
+            findings.append(
+                Finding(
+                    "WF003",
+                    "error",
+                    f"{rel_loc} step {step_num}",
+                    f"step skill {skill_id!r} not in skills-index.yaml",
+                )
+            )
+
+        # WF010: non-optional step.skill must appear in required_skills
+        if not is_optional and skill_id and skill_id not in required_skills:
+            findings.append(
+                Finding(
+                    "WF010",
+                    "error",
+                    f"{rel_loc} step {step_num}",
+                    f"non-optional step skill {skill_id!r} missing from required_skills",
+                )
+            )
+        if not is_optional and skill_id:
+            non_optional_step_skills.add(skill_id)
+
+        # WF005: decision_gate true requires decision_question
+        if step.get("decision_gate") and not str(step.get("decision_question") or "").strip():
+            findings.append(
+                Finding(
+                    "WF005",
+                    "error",
+                    f"{rel_loc} step {step_num}",
+                    "decision_gate is true but decision_question is missing/empty",
+                )
+            )
+
+        # WF004: depends_on references prior steps only
+        for dep in step.get("depends_on") or []:
+            if isinstance(dep, int) and isinstance(step_num, int) and dep >= step_num:
+                findings.append(
+                    Finding(
+                        "WF004",
+                        "error",
+                        f"{rel_loc} step {step_num}",
+                        f"depends_on includes step {dep} which is not strictly earlier",
+                    )
+                )
+
+        # WF007: consumes artifact produced by an earlier step
+        for art_id in step.get("consumes") or []:
+            produced_at = artifact_produced_by.get(art_id)
+            if produced_at is None:
+                findings.append(
+                    Finding(
+                        "WF007",
+                        "error",
+                        f"{rel_loc} step {step_num}",
+                        f"consumes artifact {art_id!r} which is not declared in artifacts:",
+                    )
+                )
+            elif isinstance(step_num, int) and produced_at >= step_num:
+                findings.append(
+                    Finding(
+                        "WF007",
+                        "error",
+                        f"{rel_loc} step {step_num}",
+                        f"consumes artifact {art_id!r} produced at step {produced_at} (not earlier)",
+                    )
+                )
+
+    # WF009: every required_skills entry appears in at least one non-optional step
+    for skill_id in required_skills:
+        if skill_id not in non_optional_step_skills:
+            findings.append(
+                Finding(
+                    "WF009",
+                    "error",
+                    rel_loc,
+                    f"required_skills entry {skill_id!r} never appears in a non-optional step",
+                )
+            )
+
+    # WF012: artifacts[].produced_by_step <-> steps[N].produces parity.
+    # Both directions:
+    #   - For every artifact A: the step it claims to be produced by must list A in produces.
+    #   - For every step's `produces`: each artifact id must be declared in artifacts[].
+    for art in artifacts:
+        if not isinstance(art, dict):
+            continue
+        art_id = str(art.get("id") or "")
+        produced_by = art.get("produced_by_step")
+        if not art_id or not isinstance(produced_by, int):
+            continue
+        producing_step_outputs = step_produces.get(produced_by, set())
+        if art_id not in producing_step_outputs:
+            findings.append(
+                Finding(
+                    "WF012",
+                    "error",
+                    rel_loc,
+                    (
+                        f"artifact {art_id!r} declares produced_by_step={produced_by} "
+                        f"but step {produced_by} does not list it in produces"
+                    ),
+                )
+            )
+    declared_artifact_ids = {
+        str(a.get("id")) for a in artifacts if isinstance(a, dict) and a.get("id")
+    }
+    for step_num, produced in step_produces.items():
+        for art_id in produced:
+            if art_id not in declared_artifact_ids:
+                findings.append(
+                    Finding(
+                        "WF012",
+                        "error",
+                        f"{rel_loc} step {step_num}",
+                        f"step produces {art_id!r} which is not declared in artifacts:",
+                    )
+                )
+
+    # WF006: journal_destination resolves to a skill id
+    journal = wf.get("journal_destination")
+    if journal is not None:
+        journal = str(journal)
+        if journal and journal not in skills_by_id:
+            findings.append(
+                Finding(
+                    "WF006",
+                    "error",
+                    rel_loc,
+                    f"journal_destination {journal!r} does not resolve to a skill id",
+                )
+            )
+
+    # Track optional_skills for completeness (no current rule, but parse it)
+    _ = optional_skills
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def validate(
+    project_root: Path,
+    *,
+    strict_workflows: bool = False,
+    strict_metadata: bool = False,
+) -> list[Finding]:
+    findings: list[Finding] = []
+
+    index_path = project_root / "skills-index.yaml"
+    if not index_path.is_file():
+        findings.append(
+            Finding(
+                "IDX-MISSING",
+                "error",
+                str(index_path),
+                "skills-index.yaml not found at project root",
+            )
+        )
+        return findings
+
+    try:
+        index = _load_yaml(index_path)
+    except yaml.YAMLError as e:
+        findings.append(Finding("IDX-PARSE", "error", str(index_path), f"YAML parse error: {e}"))
+        return findings
+
+    structure_findings, skills_by_id = _validate_index_structure(
+        index,
+        project_root,
+        strict_metadata=strict_metadata,
+        strict_workflows=strict_workflows,
+    )
+    findings.extend(structure_findings)
+
+    folders = _scan_skill_folders(project_root)
+    findings.extend(_validate_bijection_and_frontmatter(skills_by_id, folders))
+
+    wf_ref_findings, available_workflows = _validate_workflow_references(
+        skills_by_id, project_root, strict=strict_workflows
+    )
+    findings.extend(wf_ref_findings)
+
+    if strict_workflows:
+        for wf_path in available_workflows.values():
+            findings.extend(_validate_workflow_internal(wf_path, skills_by_id))
+
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate skills-index.yaml and (optionally) workflow manifests."
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to the repository root (default: cwd)",
+    )
+    parser.add_argument(
+        "--strict-workflows",
+        action="store_true",
+        help="Treat missing workflow files and workflow internal-consistency as errors.",
+    )
+    parser.add_argument(
+        "--strict-metadata",
+        action="store_true",
+        help="Require timeframe/difficulty/inputs/outputs to be populated.",
+    )
+    # Hooks pass filenames as positional args; accept and ignore them since we
+    # always re-validate the entire index regardless of which file changed.
+    parser.add_argument("files", nargs="*", help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+
+    findings = validate(
+        args.project_root,
+        strict_workflows=args.strict_workflows,
+        strict_metadata=args.strict_metadata,
+    )
+
+    errors = [f for f in findings if f.severity == "error"]
+    warnings = [f for f in findings if f.severity == "warning"]
+
+    for f in findings:
+        print(f.format(), file=sys.stderr)
+
+    if errors:
+        print(
+            f"\nFAIL: {len(errors)} error(s), {len(warnings)} warning(s)",
+            file=sys.stderr,
+        )
+        return 1
+    if warnings:
+        print(f"\nOK with {len(warnings)} warning(s)", file=sys.stderr)
+    else:
+        print("OK", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills-index.yaml
+++ b/skills-index.yaml
@@ -1,0 +1,934 @@
+schema_version: 1
+categories:
+- market-regime
+- core-portfolio
+- swing-opportunity
+- trade-planning
+- trade-memory
+- strategy-research
+- advanced-satellite
+- meta
+skills:
+- id: backtest-expert
+  display_name: Backtest Expert
+  category: strategy-research
+  status: production
+  summary: Expert guidance for systematic backtesting of trading strategies.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: user_input
+    type: local_file
+    requirement: required
+    note: User provides strategy parameters
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: breadth-chart-analyst
+  display_name: Breadth Chart Analyst
+  category: market-regime
+  status: production
+  summary: This skill should be used when analyzing market breadth charts, specifically the S&P 500 Breadth
+    Index (200-Day MA based) and the US Stock Market Uptrend Stock Ratio charts.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: chart_image
+    type: image
+    requirement: required
+    note: Chart screenshot input
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: breakout-trade-planner
+  display_name: Breakout Trade Planner
+  category: swing-opportunity
+  status: production
+  summary: Generate Minervini-style breakout trade plans from VCP screener output with worst-case risk
+    calculation, portfolio heat management, and Alpaca-compatible order templates (stop-limit bracket
+    for pre-placement, limit bracket for post-confi...
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Consumes VCP screener output; pure calculation + Alpaca order templates
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: canslim-screener
+  display_name: CANSLIM Screener
+  category: swing-opportunity
+  status: production
+  summary: Screen US stocks using William O'Neil's CANSLIM growth stock methodology.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: US stock fundamentals via FMP
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: data-quality-checker
+  display_name: Data Quality Checker
+  category: meta
+  status: production
+  summary: Validate data quality in market analysis documents and blog articles before publication.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Local markdown validation; works offline
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: dividend-growth-pullback-screener
+  display_name: Dividend Growth Pullback Screener
+  category: core-portfolio
+  status: production
+  summary: Use this skill to find high-quality dividend growth stocks (12%+ annual dividend growth, 1.5%+
+    yield) that are experiencing temporary pullbacks, identified by RSI oversold conditions (RSI ≤40).
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Financial Modeling Prep API
+  - id: finviz
+    type: screener
+    requirement: recommended
+    note: FINVIZ Elite API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: downtrend-duration-analyzer
+  display_name: Downtrend Duration Analyzer
+  category: market-regime
+  status: production
+  summary: Analyze historical downtrend durations and generate interactive HTML histograms showing typical
+    correction lengths by sector and market cap.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Duration analysis from market data; pure calculation
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: dual-axis-skill-reviewer
+  display_name: Dual Axis Skill Reviewer
+  category: meta
+  status: production
+  summary: 'Review skills in any project using a dual-axis method: (1) deterministic code-based checks
+    (structure, scripts, tests, execution safety) and (2) LLM deep review findings.'
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Deterministic scoring + optional LLM review
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: earnings-calendar
+  display_name: Earnings Calendar
+  category: meta
+  status: production
+  summary: This skill retrieves upcoming earnings announcements for US stocks using the Financial Modeling
+    Prep (FMP) API.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Financial Modeling Prep API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: earnings-trade-analyzer
+  display_name: Earnings Trade Analyzer
+  category: advanced-satellite
+  status: production
+  summary: Analyze recent post-earnings stocks using a 5-factor scoring system (Gap Size, Pre-Earnings
+    Trend, Volume Trend, MA200 Position, MA50 Position).
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Financial Modeling Prep API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: economic-calendar-fetcher
+  display_name: Economic Calendar Fetcher
+  category: meta
+  status: production
+  summary: Fetch upcoming economic events and data releases using FMP API.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Financial Modeling Prep API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: edge-candidate-agent
+  display_name: Edge Candidate Agent
+  category: strategy-research
+  status: production
+  summary: Generate and prioritize US equity long-side edge research tickets from EOD observations, then
+    export pipeline-ready candidate specs for trade-strategy-pipeline Phase I.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: optional
+    note: Optional OHLCV via FMP for edge ticket export
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: edge-concept-synthesizer
+  display_name: Edge Concept Synthesizer
+  category: strategy-research
+  status: production
+  summary: Abstract detector tickets and hints into reusable edge concepts with thesis, invalidation signals,
+    and strategy playbooks before strategy design/export.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Synthesizes detector tickets and hints into edge concepts
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: edge-hint-extractor
+  display_name: Edge Hint Extractor
+  category: strategy-research
+  status: production
+  summary: Extract edge hints from daily market observations and news reactions, with optional LLM ideation,
+    and output canonical hints.yaml for downstream concept synthesis and auto detection.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Extracts hints from observations/news; pure calculation
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: edge-pipeline-orchestrator
+  display_name: Edge Pipeline Orchestrator
+  category: strategy-research
+  status: production
+  summary: Orchestrate the full edge research pipeline from candidate detection through strategy design,
+    review, revision, and export.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Orchestrates edge pipeline subskills via subprocess
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: edge-signal-aggregator
+  display_name: Edge Signal Aggregator
+  category: strategy-research
+  status: production
+  summary: Aggregate and rank signals from multiple edge-finding skills (edge-candidate-agent, theme-detector,
+    sector-analyst, institutional-flow-tracker) into a prioritized conviction dashboard with weighted
+    scoring, deduplication, and contradicti...
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Aggregates signals from edge-finding skills
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: edge-strategy-designer
+  display_name: Edge Strategy Designer
+  category: strategy-research
+  status: production
+  summary: Convert abstract edge concepts into strategy draft variants and optional exportable ticket
+    YAMLs for edge-candidate-agent export/validation.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Converts edge concepts into strategy drafts
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: edge-strategy-reviewer
+  display_name: Edge Strategy Reviewer
+  category: strategy-research
+  status: production
+  summary: '>.'
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Deterministic scoring on local YAML drafts
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: exposure-coach
+  display_name: Exposure Coach
+  category: market-regime
+  status: production
+  summary: Generate a one-page Market Posture summary with net exposure ceiling, growth-vs-value bias,
+    participation breadth, and new-entry-allowed vs cash-priority recommendation by integrating signals
+    from breadth, regime, and flow analysis skills.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Synthesizes signals from other skills; pure calculation
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: finviz-screener
+  display_name: Finviz Screener
+  category: swing-opportunity
+  status: production
+  summary: Build and open FinViz screener URLs from natural language requests.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: finviz
+    type: screener
+    requirement: optional
+    note: FINVIZ Elite API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: ftd-detector
+  display_name: FTD Detector
+  category: market-regime
+  status: production
+  summary: Detects Follow-Through Day (FTD) signals for market bottom confirmation using William O'Neil's
+    methodology.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Daily QQQ/SPY OHLCV via FMP
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: ibd-distribution-day-monitor
+  display_name: IBD Distribution Day Monitor
+  category: market-regime
+  status: production
+  summary: Detect IBD-style Distribution Days for QQQ/SPY (close down at least 0.2% on higher volume),
+    track 25-session expiration and 5% invalidation, count d5/d15/d25 clusters, classify market risk (NORMAL/CAUTION/HIGH/SEVERE),
+    and emit TQQQ/QQQ...
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Financial Modeling Prep API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: institutional-flow-tracker
+  display_name: Institutional Flow Tracker
+  category: advanced-satellite
+  status: production
+  summary: Use this skill to track institutional investor ownership changes and portfolio flows using
+    13F filings data.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Financial Modeling Prep API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: kanchi-dividend-review-monitor
+  display_name: Kanchi Dividend Review Monitor
+  category: core-portfolio
+  status: production
+  summary: Monitor dividend portfolios with Kanchi-style forced-review triggers (T1-T5) and convert anomalies
+    into OK/WARN/REVIEW states without auto-selling.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: recommended
+    note: Dividend / price monitoring via FMP
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: kanchi-dividend-sop
+  display_name: Kanchi Dividend SOP
+  category: core-portfolio
+  status: production
+  summary: Convert Kanchi-style dividend investing into a repeatable US-stock operating procedure.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: recommended
+    note: US dividend stock data via FMP
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: kanchi-dividend-us-tax-accounting
+  display_name: Kanchi Dividend US Tax Accounting
+  category: core-portfolio
+  status: production
+  summary: Provide US dividend tax and account-location workflow for Kanchi-style income portfolios.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: US tax workflow guidance; pure calculation
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: macro-regime-detector
+  display_name: Macro Regime Detector
+  category: market-regime
+  status: production
+  summary: Detect structural macro regime transitions (1-2 year horizon) using cross-asset ratio analysis.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: yfinance_or_csv
+    type: market_data
+    requirement: recommended
+    note: Cross-asset ratio data via yfinance or local CSV
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: market-breadth-analyzer
+  display_name: Market Breadth Analyzer
+  category: market-regime
+  status: production
+  summary: Quantifies market breadth health using TraderMonty's public CSV data.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: public_csv
+    type: local_file
+    requirement: required
+    note: TraderMonty public CSV; no API key required
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: market-environment-analysis
+  display_name: Market Environment Analysis
+  category: market-regime
+  status: production
+  summary: Comprehensive market environment analysis and reporting tool.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: websearch
+    type: web
+    requirement: required
+    note: Global market data via WebSearch / WebFetch
+  - id: chart_image
+    type: image
+    requirement: optional
+    note: Optional chart image inputs for technical interpretation
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: market-news-analyst
+  display_name: Market News Analyst
+  category: market-regime
+  status: production
+  summary: This skill should be used when analyzing recent market-moving news events and their impact
+    on equity markets and commodities.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: websearch
+    type: web
+    requirement: required
+    note: Web search / fetch
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: market-top-detector
+  display_name: Market Top Detector
+  category: market-regime
+  status: production
+  summary: Detects market top probability using O'Neil Distribution Days, Minervini Leading Stock Deterioration,
+    and Monty Defensive Sector Rotation.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: public_csv
+    type: local_file
+    requirement: required
+    note: Public market data CSVs; no API key required
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: options-strategy-advisor
+  display_name: Options Strategy Advisor
+  category: advanced-satellite
+  status: production
+  summary: Options trading strategy analysis and simulation tool.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: optional
+    note: Financial Modeling Prep API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: pair-trade-screener
+  display_name: Pair Trade Screener
+  category: advanced-satellite
+  status: production
+  summary: Statistical arbitrage tool for identifying and analyzing pair trading opportunities.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Financial Modeling Prep API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: parabolic-short-trade-planner
+  display_name: Parabolic Short Trade Planner
+  category: advanced-satellite
+  status: production
+  summary: Screen US equities for parabolic exhaustion patterns and generate conditional pre-market short
+    plans, then evaluate intraday trigger fires from live 5-min bars.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Financial Modeling Prep API
+  - id: alpaca
+    type: broker
+    requirement: optional
+    note: Alpaca brokerage MCP/API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: pead-screener
+  display_name: PEAD Screener
+  category: advanced-satellite
+  status: production
+  summary: Screen post-earnings gap-up stocks for PEAD (Post-Earnings Announcement Drift) patterns.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Financial Modeling Prep API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: portfolio-manager
+  display_name: Portfolio Manager
+  category: core-portfolio
+  status: production
+  summary: Comprehensive portfolio analysis using Alpaca MCP Server integration to fetch holdings and
+    positions, then analyze asset allocation, risk metrics, individual stock positions, diversification,
+    and generate rebalancing recommendations.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: alpaca
+    type: broker
+    requirement: required
+    note: Alpaca brokerage MCP/API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: position-sizer
+  display_name: Position Sizer
+  category: trade-planning
+  status: production
+  summary: Calculate risk-based position sizes for long stock trades.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Pure calculation; works offline
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: scenario-analyzer
+  display_name: Scenario Analyzer
+  category: strategy-research
+  status: production
+  summary: '|.'
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: websearch
+    type: web
+    requirement: required
+    note: Headline / news search via WebSearch
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: sector-analyst
+  display_name: Sector Analyst
+  category: market-regime
+  status: production
+  summary: This skill should be used when analyzing sector rotation patterns and market cycle positioning.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: chart_image
+    type: image
+    requirement: required
+    note: Chart screenshot input
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: signal-postmortem
+  display_name: Signal Postmortem
+  category: trade-memory
+  status: production
+  summary: Record and analyze post-trade outcomes for signals generated by edge pipeline and other skills.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Postmortem framework; pure calculation
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: skill-designer
+  display_name: Skill Designer
+  category: meta
+  status: production
+  summary: Design new Claude skills from structured idea specifications.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Generates skill scaffolding from idea specs
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: skill-idea-miner
+  display_name: Skill Idea Miner
+  category: meta
+  status: production
+  summary: Mine Claude Code session logs for skill idea candidates.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Mines session logs for skill ideas
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: skill-integration-tester
+  display_name: Skill Integration Tester
+  category: meta
+  status: production
+  summary: Validate multi-skill workflows defined in CLAUDE.md by checking skill existence, inter-skill
+    data contracts (JSON schema compatibility), file naming conventions, and handoff integrity.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Validates multi-skill workflow contracts
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: stanley-druckenmiller-investment
+  display_name: Stanley Druckenmiller Investment
+  category: strategy-research
+  status: production
+  summary: Druckenmiller Strategy Synthesizer - Integrates 8 upstream skill outputs (Market Breadth, Uptrend
+    Analysis, Market Top, Macro Regime, FTD Detector, VCP Screener, Theme Detector, CANSLIM Screener)
+    into a unified conviction score (0-100),...
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Synthesizes outputs from upstream skills; pure calculation
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: strategy-pivot-designer
+  display_name: Strategy Pivot Designer
+  category: strategy-research
+  status: production
+  summary: Detect backtest iteration stagnation and generate structurally different strategy pivot proposals
+    when parameter tuning reaches a local optimum.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Pivot proposal generator; pure calculation
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: technical-analyst
+  display_name: Technical Analyst
+  category: trade-planning
+  status: production
+  summary: This skill should be used when analyzing weekly price charts for stocks, stock indices, cryptocurrencies,
+    or forex pairs.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: chart_image
+    type: image
+    requirement: required
+    note: Chart screenshot input
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: theme-detector
+  display_name: Theme Detector
+  category: swing-opportunity
+  status: production
+  summary: Detect and analyze trending market themes across sectors.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: optional
+    note: Financial Modeling Prep API
+  - id: finviz
+    type: screener
+    requirement: recommended
+    note: FINVIZ Elite API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: trade-hypothesis-ideator
+  display_name: Trade Hypothesis Ideator
+  category: trade-memory
+  status: production
+  summary: '>.'
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: local_calculation
+    type: calculation
+    requirement: not_required
+    note: Hypothesis generation from journal/data inputs; pure calculation
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: trader-memory-core
+  display_name: Trader Memory Core
+  category: trade-memory
+  status: production
+  summary: Track investment theses across their lifecycle — from screening idea to closed position with
+    postmortem.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: optional
+    note: Financial Modeling Prep API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: uptrend-analyzer
+  display_name: Uptrend Analyzer
+  category: market-regime
+  status: production
+  summary: Analyzes market breadth using Monty's Uptrend Ratio Dashboard data to diagnose the current
+    market environment.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: public_csv
+    type: local_file
+    requirement: required
+    note: Monty Uptrend Ratio Dashboard CSV; no API key required
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: us-market-bubble-detector
+  display_name: US Market Bubble Detector
+  category: market-regime
+  status: production
+  summary: Evaluates market bubble risk through quantitative data-driven analysis using the revised Minsky/Kindleberger
+    framework v2.1.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: user_input
+    type: local_file
+    requirement: required
+    note: User provides indicators
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: us-stock-analysis
+  display_name: US Stock Analysis
+  category: trade-planning
+  status: production
+  summary: Comprehensive US stock analysis including fundamental analysis (financial metrics, business
+    quality, valuation), technical analysis (indicators, chart patterns, support/resistance), stock comparisons,
+    and investment report generation.
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: user_input
+    type: local_file
+    requirement: required
+    note: User provides data
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: value-dividend-screener
+  display_name: Value Dividend Screener
+  category: core-portfolio
+  status: production
+  summary: Screen US stocks for high-quality dividend opportunities combining value characteristics (P/E
+    ratio under 20, P/B ratio under 2), attractive yields (3% or higher), and consistent growth (dividend/revenue/EPS
+    trending up over 3 years).
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: Financial Modeling Prep API
+  - id: finviz
+    type: screener
+    requirement: recommended
+    note: FINVIZ Elite API
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false
+- id: vcp-screener
+  display_name: VCP Screener
+  category: swing-opportunity
+  status: production
+  summary: Screen S&P 500 stocks for Mark Minervini's Volatility Contraction Pattern (VCP).
+  timeframe: unknown
+  difficulty: unknown
+  integrations:
+  - id: fmp
+    type: market_data
+    requirement: required
+    note: S&P 500 OHLCV via FMP
+  inputs: []
+  outputs: []
+  workflows: []
+  hand_written_doc: false


### PR DESCRIPTION
## Summary

- Introduces `skills-index.yaml` as the single source of truth for all 54 skills' metadata (id, display_name, category, status, summary, integrations[]).
- Adds a 3-level-strictness validator (`scripts/validate_skills_index.py`) with stable error codes IDX001-012 and WF001-012, wired into `pre-commit` in default mode.
- Self-contained: passes its own validator with no `workflows/` directory present. PR2 will add the workflow manifests and flip `--strict-workflows` on.

This is **PR1 of a 3-PR plan** to move the repo from "skill catalog" → "navigable Trading OS". See `docs/dev/metadata-and-workflow-schema.md` for the full schema spec.

## What's new

| File | Role |
|---|---|
| `skills-index.yaml` (934 lines) | SSoT metadata for 54 skills, 8 canonical categories |
| `docs/dev/metadata-and-workflow-schema.md` | Schema spec — index + workflow manifest, validator strictness levels, error code catalog, governance rules |
| `scripts/validate_skills_index.py` | Validator with `--strict-workflows` / `--strict-metadata` flags |
| `scripts/dev/bootstrap_skills_index.py` | One-shot migration helper (parses CLAUDE.md API matrix). NOT a sync tool. |
| `scripts/tests/test_validate_skills_index.py` | 37 tests — one per error code + happy paths + edge cases |
| `.pre-commit-config.yaml` | `validate-skills-index` hook (default mode) |

## Category distribution

| Category | Count |
|---|---|
| market-regime | 13 |
| strategy-research | 11 |
| meta | 7 |
| advanced-satellite | 6 |
| core-portfolio | 6 |
| swing-opportunity | 5 |
| trade-memory | 3 |
| trade-planning | 3 |
| **Total** | **54** |

## Key design decisions

1. **`id` + `display_name` split** — avoids conflict with the existing `check_skill_frontmatter.py` hook that already enforces `frontmatter.name == directory`.
2. **`integrations[]` as a list from day one** — covers FMP / FINVIZ / Alpaca plus WebSearch / yfinance / CSV / image / MCP / pure-calculation. No fixed-key dict that would force a v2 migration.
3. **3-level validator strictness** — `default` (always strict on bijection + required fields), `--strict-workflows` (PR2 turns this on in CI), `--strict-metadata` (later PR; currently warn-only on `unknown` fields).
4. **Bootstrap is a one-time migration helper** — placed under `scripts/dev/` to flag non-permanent. After this PR, `skills-index.yaml` is the authoritative source; CLAUDE.md becomes a downstream consumer.
5. **`downstream_hints` is informational** — schema spec documents that the validator does NOT cross-check inter-workflow consumption, so future Navigator code can build from these hints without breaking existing manifests.

## Verification

- `python3 scripts/validate_skills_index.py` → **0 errors, 108 warnings** (timeframe / difficulty = `unknown`, expected)
- `python3 scripts/validate_skills_index.py --strict-workflows` → **0 errors** (no `workflows/` files yet — self-contained)
- `python3 scripts/validate_skills_index.py --strict-metadata` → **216 errors** (correct: rejects every `unknown` value pending follow-up)
- `python3 -m pytest scripts/tests/test_validate_skills_index.py` → **37/37 passed**
- `pre-commit run --all-files` → clean
- Deliberate violation test: orphan `skills/<id>/` without index entry → **IDX003** error, blocked

## Test plan

- [x] 37 unit tests pass (one per error code)
- [x] Pre-commit hook fires on the SSoT inputs (skills-index.yaml, SKILL.md), AND on validator script / schema doc / test file changes
- [x] Validator standalone-passes with no `workflows/` directory
- [x] Bootstrap script's `--dry-run` and `--force` semantics: refuses to overwrite existing index without `--force`
- [x] No `unknown` integrations remain in the committed `skills-index.yaml`
- [ ] (PR2) `--strict-workflows` will be enabled in CI once `workflows/*.yaml` manifests land

## Follow-ups (out of scope here)

- **PR2 (next)** — `workflows/{core-portfolio-weekly, market-regime-daily, swing-opportunity-daily, trade-memory-loop, monthly-performance-review}.yaml` + README "Recommended Starting Path" upgrade + flip CI to `--strict-workflows`.
- **PR3 (optional)** — `scripts/generate_workflow_docs.py` → `docs/{en,ja}/workflows.md`, plus `PROJECT_VISION.md` Phase 0 / Phase 3 status update.
- **Best-effort metadata fill** — 108 `timeframe` / `difficulty` warnings are intentionally deferred. They will be addressed alongside `--strict-metadata` rollout in a later PR, not blocking PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)