### PR TITLE
fix(edge-candidate-agent): sniff parquet/CSV by extension in auto_detect

### DIFF
--- a/skills/edge-candidate-agent/SKILL.md
+++ b/skills/edge-candidate-agent/SKILL.md
@@ -76,6 +76,8 @@ python3 skills/edge-candidate-agent/scripts/auto_detect_candidates.py \
   --pipeline-root /path/to/trade-strategy-pipeline
 ```
 
+`--ohlcv` accepts `.parquet` / `.pq` (requires `pyarrow` or `fastparquet`) or `.csv`. The file extension is used to pick the loader; columns required are `symbol, timestamp, open, high, low, close, volume`.
+
 Create a candidate directory from a ticket:
 
 ```bash

--- a/skills/edge-candidate-agent/scripts/auto_detect_candidates.py
+++ b/skills/edge-candidate-agent/scripts/auto_detect_candidates.py
@@ -602,13 +602,33 @@ def _require_pandas() -> tuple[Any, Any]:
     return pd, np
 
 
+def _load_ohlcv_table(ohlcv_path: Path) -> Any:
+    """Load OHLCV table, sniffing parquet/CSV by extension."""
+    pd, _ = _require_pandas()
+    suffix = ohlcv_path.suffix.lower()
+    if suffix == ".csv":
+        return pd.read_csv(ohlcv_path)
+    if suffix in {".parquet", ".pq"}:
+        try:
+            return pd.read_parquet(ohlcv_path)
+        except ImportError as exc:  # pragma: no cover - depends on runtime environment
+            raise AutoDetectError(
+                f"reading parquet requires pyarrow or fastparquet; install one "
+                f"(e.g. `uv add pyarrow`) or convert {ohlcv_path.name} to CSV."
+            ) from exc
+    raise AutoDetectError(
+        f"unsupported OHLCV format: {suffix or '(none)'} for {ohlcv_path.name} "
+        f"(expected .parquet, .pq, or .csv)"
+    )
+
+
 def compute_features(
     ohlcv_path: Path,
     as_of_date: date | None,
 ) -> tuple[Any, Any, date]:
-    """Load OHLCV parquet and compute per-symbol features."""
+    """Load OHLCV (parquet or CSV) and compute per-symbol features."""
     pd, np = _require_pandas()
-    df = pd.read_parquet(ohlcv_path)
+    df = _load_ohlcv_table(ohlcv_path)
     df.columns = [str(col).lower() for col in df.columns]
 
     missing = sorted(REQUIRED_OHLCV_COLUMNS - set(df.columns))

--- a/skills/edge-candidate-agent/scripts/tests/test_auto_detect_candidates.py
+++ b/skills/edge-candidate-agent/scripts/tests/test_auto_detect_candidates.py
@@ -1,6 +1,7 @@
 """Unit tests for auto_detect_candidates.py (pandas-independent parts)."""
 
 from datetime import date
+from pathlib import Path
 from subprocess import CompletedProcess
 
 import auto_detect_candidates as adc
@@ -245,6 +246,47 @@ def test_scan_news_reaction_candidates_with_tradable_join() -> None:
     assert len(candidates) == 1
     assert candidates[0]["symbol"] == "AAPL"
     assert candidates[0]["entry_family"] == "news_reaction"
+
+
+def test_load_ohlcv_table_reads_csv(tmp_path: Path) -> None:
+    """_load_ohlcv_table sniffs .csv extension and uses pd.read_csv."""
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    csv_path = tmp_path / "tiny.csv"
+    pd.DataFrame(
+        {
+            "symbol": ["AAPL", "AAPL"],
+            "timestamp": ["2026-02-19", "2026-02-20"],
+            "open": [180.0, 181.0],
+            "high": [182.0, 183.0],
+            "low": [179.0, 180.5],
+            "close": [181.0, 182.5],
+            "volume": [1_000_000, 1_100_000],
+        }
+    ).to_csv(csv_path, index=False)
+
+    df = adc._load_ohlcv_table(csv_path)
+    assert list(df.columns) == ["symbol", "timestamp", "open", "high", "low", "close", "volume"]
+    assert len(df) == 2
+
+
+def test_load_ohlcv_table_rejects_unknown_extension(tmp_path: Path) -> None:
+    """_load_ohlcv_table raises AutoDetectError for unsupported extensions."""
+    pytest.importorskip("pandas")
+    bogus = tmp_path / "ohlcv.xlsx"
+    bogus.write_text("not really xlsx")
+    with pytest.raises(adc.AutoDetectError, match="unsupported OHLCV format"):
+        adc._load_ohlcv_table(bogus)
+
+
+def test_load_ohlcv_table_rejects_no_extension(tmp_path: Path) -> None:
+    """_load_ohlcv_table raises AutoDetectError for files without extensions."""
+    pytest.importorskip("pandas")
+    bogus = tmp_path / "ohlcv"
+    bogus.write_text("symbol,timestamp\n")
+    with pytest.raises(adc.AutoDetectError, match="unsupported OHLCV format"):
+        adc._load_ohlcv_table(bogus)
 
 
 def test_generate_llm_hints_raises_on_failure(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

`auto_detect_candidates.compute_features` hardcoded `pd.read_parquet(ohlcv_path)`, so passing a CSV file to `--ohlcv` failed with an opaque pyarrow error (and on systems without `pyarrow` installed, even a `.parquet` path failed with a confusing engine error).

This change:

- Extracts `_load_ohlcv_table(path)` that sniffs the file extension and routes to `pd.read_csv` for `.csv` or `pd.read_parquet` for `.parquet` / `.pq`.
- Wraps the parquet branch's `ImportError` to emit a clear "install pyarrow or convert to CSV" message instead of pandas' raw engine-resolution traceback.
- Raises `AutoDetectError` for unsupported extensions.
- Documents the supported `--ohlcv` formats in SKILL.md.

The helper mirrors the existing `read_optional_table` helper at `auto_detect_candidates.py:1304`, which already sniffs CSV vs parquet for optional inputs — this just brings the required OHLCV path in line.

## Test plan

- [x] Added 3 unit tests covering: CSV path (round-trips through pandas), unknown-extension rejection, no-extension rejection.
- [x] Full `pytest skills/edge-candidate-agent/scripts/tests/` — 43/43 passing.
- [x] `pre-commit run` — all hooks pass (ruff, ruff-format, codespell, detect-secrets, no-absolute-paths, skill-frontmatter, docs-completeness).

## Notes

Surfaced during a trial run feeding the orchestrator a CSV-only OHLCV; the friction was the ~5 min spent diagnosing the parquet-hardcode + the unrelated pyarrow setup. The friction-log entry behind this PR is in a downstream fork's trial journal — happy to elaborate if useful.