### PR TITLE
ci(metadata): add GitHub Actions job for validator + workflow-docs drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,41 @@ jobs:
           path: htmlcov/
           retention-days: 7
 
+  metadata:
+    name: Metadata + Workflow checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install minimal deps
+        run: pip install pyyaml
+
+      # 1. Validate skills-index.yaml structure + bijection with skills/.
+      # Default mode is what pre-commit runs on each commit.
+      - name: Validate skills-index (default)
+        run: python3 scripts/validate_skills_index.py
+
+      # 2. Strict workflow validation — workflow files exist, schema rules
+      # pass (artifact parity, required_skills coverage, decision-gate
+      # questions, no deprecated skills in required_skills, etc.).
+      # This is what pre-push enforces locally.
+      - name: Validate skills-index (--strict-workflows)
+        run: python3 scripts/validate_skills_index.py --strict-workflows
+
+      # 3. Drift check: docs/{en,ja}/workflows.md must match what the
+      # generator would produce from workflows/*.yaml. Catches manual edits
+      # to the docs and stale docs after manifest changes.
+      - name: Workflow docs drift check
+        run: python3 scripts/generate_workflow_docs.py --check
+
+      # Note: the validator + generator unit tests already run under the
+      # 'Test repo-level scripts' step in the test job above.
+
   security:
     name: Security
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a **metadata** job to `.github/workflows/ci.yml` that runs the three checks the local `pre-commit` / `pre-push` hooks already enforce, so a committer who bypasses hooks (`--no-verify` or fresh clone) cannot push drift to `main`.

**Stacked on** [#86](https://github.com/tradermonty/claude-trading-skills/pull/86). GitHub will auto-rebase the base when PR3 merges.

## What the new job does

| Step | Command | Mirrors |
|---|---|---|
| 1 | `python3 scripts/validate_skills_index.py` | pre-commit (default) |
| 2 | `python3 scripts/validate_skills_index.py --strict-workflows` | pre-push |
| 3 | `python3 scripts/generate_workflow_docs.py --check` | pre-commit (workflow-docs-drift) |

The validator + generator unit tests already run under the existing `test` job (`Test repo-level scripts` step). No duplication.

## Why a separate `metadata` job

Three reasons:

1. **Bypass-resistant.** Local hooks can be skipped with `git commit --no-verify` or by committers who haven't run `pre-commit install`. CI is the safety net.
2. **Reviewable signal.** PRs that touch `skills-index.yaml`, `workflows/*.yaml`, or the generator should fail loudly when drift sneaks in — separate from lint/test/security so reviewers see exactly which check broke.
3. **Cheap.** Only `pyyaml` is needed; the job sets up Python 3.11 and runs 3 commands. Total runtime expected ~30s.

## Verification (locally)

- `python3 scripts/validate_skills_index.py` → exit 0
- `python3 scripts/validate_skills_index.py --strict-workflows` → exit 0
- `python3 scripts/generate_workflow_docs.py --check` → OK matches both langs
- ci.yml YAML syntax → parses

GitHub Actions will run the actual job on this PR's checks tab once the workflow is recognized.

## Out of scope

- Wiring `--strict-metadata` into CI (deferred — still expects `unknown` values from PR1 best-effort tier; will activate after timeframe/difficulty fill-in PR).
- Adding the schema doc and validator script changes to the existing `Lint` job (already covered by ruff/codespell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)