### PR TITLE
feat(skills-index): fill timeframe/difficulty/inputs/outputs + activate --strict-metadata (PR6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,13 @@ jobs:
       - name: Validate skills-index (--strict-workflows)
         run: python3 scripts/validate_skills_index.py --strict-workflows
 
+      # 2b. Strict metadata validation — every skill has populated
+      # timeframe / difficulty / inputs / outputs (no `unknown` markers,
+      # no empty lists). Now safe to enforce because the corresponding
+      # fill-in PR populated these fields for all 54 skills.
+      - name: Validate skills-index (--strict-metadata)
+        run: python3 scripts/validate_skills_index.py --strict-metadata
+
       # 3. Drift check: docs/{en,ja}/workflows.md must match what the
       # generator would produce from workflows/*.yaml. Catches manual edits
       # to the docs and stale docs after manifest changes.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,12 +88,13 @@ repos:
         files: '^(skills-index\.yaml|scripts/generate_catalog_from_index\.py|README\.md|README\.ja\.md)$'
         pass_filenames: false
 
-      # Pre-push hook: run validator in --strict-workflows mode (workflow file
-      # existence + workflow internal-consistency). Pre-commit stays in default
-      # mode so commits during workflow drafting are not blocked.
+      # Pre-push hook: run validator in --strict-workflows + --strict-metadata
+      # mode. Pre-commit stays in default mode so quick edits aren't blocked,
+      # but pushes must satisfy the stricter contract (workflow internal
+      # consistency + populated metadata fields).
       - id: validate-skills-index-strict
-        name: Validate skills-index.yaml + workflows (strict)
-        entry: python3 scripts/validate_skills_index.py --strict-workflows
+        name: Validate skills-index.yaml + workflows + metadata (strict)
+        entry: python3 scripts/validate_skills_index.py --strict-workflows --strict-metadata
         language: system
         stages: [pre-push]
         pass_filenames: false

--- a/docs/dev/metadata-and-workflow-schema.md
+++ b/docs/dev/metadata-and-workflow-schema.md
@@ -67,13 +67,15 @@ skills:
 
 | Field | Rule |
 |---|---|
-| `timeframe` | One of the enum values; `unknown` allowed by default. |
-| `difficulty` | One of the enum values; `unknown` allowed by default. |
+| `timeframe` | One of the enum values. `unknown` allowed under `default` / `--strict-workflows` (warn); rejected under `--strict-metadata`. |
+| `difficulty` | One of the enum values. `unknown` allowed under `default` / `--strict-workflows` (warn); rejected under `--strict-metadata`. |
 | `integrations` | List form (see §1.3). May be empty for skills with no dependencies, but prefer `[{id: local_calculation, type: calculation, requirement: not_required}]`. |
-| `inputs` | List of strings. May be `[]`. |
-| `outputs` | List of strings. May be `[]`. |
+| `inputs` | List of strings. Empty list (`[]`) allowed under `default` / `--strict-workflows` (warn); `--strict-metadata` requires at least one entry. |
+| `outputs` | List of strings. Empty list (`[]`) allowed under `default` / `--strict-workflows` (warn); `--strict-metadata` requires at least one entry. |
 | `workflows` | List of workflow IDs. Default mode warns on missing files; `--strict-workflows` errors. |
 | `hand_written_doc` | Boolean. Defaults to `false`. |
+
+As of 2026-05-12 the canonical `skills-index.yaml` populates `timeframe`, `difficulty`, `inputs`, and `outputs` for all 54 skills, and `--strict-metadata` is enforced in CI + the pre-push hook. New skill entries must satisfy `--strict-metadata` to merge.
 
 ### 1.3 `integrations` schema
 

--- a/skills-index.yaml
+++ b/skills-index.yaml
@@ -14,8 +14,8 @@ skills:
   category: strategy-research
   status: production
   summary: Expert guidance for systematic backtesting of trading strategies.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: advanced
   integrations:
   - id: user_input
     type: local_file
@@ -33,8 +33,8 @@ skills:
   status: production
   summary: This skill should be used when analyzing market breadth charts, specifically the S&P 500 Breadth
     Index (200-Day MA based) and the US Stock Market Uptrend Stock Ratio charts.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: daily
+  difficulty: intermediate
   integrations:
   - id: chart_image
     type: image
@@ -51,8 +51,8 @@ skills:
   summary: Generate Minervini-style breakout trade plans from VCP screener output with worst-case risk
     calculation, portfolio heat management, and Alpaca-compatible order templates (stop-limit bracket
     for pre-placement, limit bracket for post-confi...
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: intermediate
   integrations:
   - id: local_calculation
     type: calculation
@@ -68,8 +68,8 @@ skills:
   category: swing-opportunity
   status: production
   summary: Screen US stocks using William O'Neil's CANSLIM growth stock methodology.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data
@@ -85,8 +85,8 @@ skills:
   category: meta
   status: production
   summary: Validate data quality in market analysis documents and blog articles before publication.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: beginner
   integrations:
   - id: local_calculation
     type: calculation
@@ -102,8 +102,8 @@ skills:
   status: production
   summary: Use this skill to find high-quality dividend growth stocks (12%+ annual dividend growth, 1.5%+
     yield) that are experiencing temporary pullbacks, identified by RSI oversold conditions (RSI ≤40).
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data
@@ -123,8 +123,8 @@ skills:
   status: production
   summary: Analyze historical downtrend durations and generate interactive HTML histograms showing typical
     correction lengths by sector and market cap.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: intermediate
   integrations:
   - id: local_calculation
     type: calculation
@@ -140,8 +140,8 @@ skills:
   status: production
   summary: 'Review skills in any project using a dual-axis method: (1) deterministic code-based checks
     (structure, scripts, tests, execution safety) and (2) LLM deep review findings.'
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: intermediate
   integrations:
   - id: local_calculation
     type: calculation
@@ -158,8 +158,8 @@ skills:
   status: production
   summary: This skill retrieves upcoming earnings announcements for US stocks using the Financial Modeling
     Prep (FMP) API.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: beginner
   integrations:
   - id: fmp
     type: market_data
@@ -175,8 +175,8 @@ skills:
   status: production
   summary: Analyze recent post-earnings stocks using a 5-factor scoring system (Gap Size, Pre-Earnings
     Trend, Volume Trend, MA200 Position, MA50 Position).
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data
@@ -191,8 +191,8 @@ skills:
   category: meta
   status: production
   summary: Fetch upcoming economic events and data releases using FMP API.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: beginner
   integrations:
   - id: fmp
     type: market_data
@@ -208,8 +208,8 @@ skills:
   status: production
   summary: Generate and prioritize US equity long-side edge research tickets from EOD observations, then
     export pipeline-ready candidate specs for trade-strategy-pipeline Phase I.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: advanced
   integrations:
   - id: fmp
     type: market_data
@@ -225,8 +225,8 @@ skills:
   status: production
   summary: Abstract detector tickets and hints into reusable edge concepts with thesis, invalidation signals,
     and strategy playbooks before strategy design/export.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: advanced
   integrations:
   - id: local_calculation
     type: calculation
@@ -242,8 +242,8 @@ skills:
   status: production
   summary: Extract edge hints from daily market observations and news reactions, with optional LLM ideation,
     and output canonical hints.yaml for downstream concept synthesis and auto detection.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: intermediate
   integrations:
   - id: local_calculation
     type: calculation
@@ -259,8 +259,8 @@ skills:
   status: production
   summary: Orchestrate the full edge research pipeline from candidate detection through strategy design,
     review, revision, and export.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: advanced
   integrations:
   - id: local_calculation
     type: calculation
@@ -277,8 +277,8 @@ skills:
   summary: Aggregate and rank signals from multiple edge-finding skills (edge-candidate-agent, theme-detector,
     sector-analyst, institutional-flow-tracker) into a prioritized conviction dashboard with weighted
     scoring, deduplication, and contradicti...
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: advanced
   integrations:
   - id: local_calculation
     type: calculation
@@ -294,8 +294,8 @@ skills:
   status: production
   summary: Convert abstract edge concepts into strategy draft variants and optional exportable ticket
     YAMLs for edge-candidate-agent export/validation.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: advanced
   integrations:
   - id: local_calculation
     type: calculation
@@ -309,9 +309,10 @@ skills:
   display_name: Edge Strategy Reviewer
   category: strategy-research
   status: production
-  summary: Critically review strategy drafts from edge-strategy-designer for edge plausibility, overfitting risk, sample size adequacy, and execution realism.
-  timeframe: unknown
-  difficulty: unknown
+  summary: Critically review strategy drafts from edge-strategy-designer for edge plausibility, overfitting
+    risk, sample size adequacy, and execution realism.
+  timeframe: research
+  difficulty: advanced
   integrations:
   - id: local_calculation
     type: calculation
@@ -328,8 +329,8 @@ skills:
   summary: Generate a one-page Market Posture summary with net exposure ceiling, growth-vs-value bias,
     participation breadth, and new-entry-allowed vs cash-priority recommendation by integrating signals
     from breadth, regime, and flow analysis skills.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: daily
+  difficulty: beginner
   integrations:
   - id: local_calculation
     type: calculation
@@ -345,8 +346,8 @@ skills:
   category: swing-opportunity
   status: production
   summary: Build and open FinViz screener URLs from natural language requests.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: beginner
   integrations:
   - id: finviz
     type: screener
@@ -362,8 +363,8 @@ skills:
   status: production
   summary: Detects Follow-Through Day (FTD) signals for market bottom confirmation using William O'Neil's
     methodology.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: daily
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data
@@ -380,8 +381,8 @@ skills:
   summary: Detect IBD-style Distribution Days for QQQ/SPY (close down at least 0.2% on higher volume),
     track 25-session expiration and 5% invalidation, count d5/d15/d25 clusters, classify market risk (NORMAL/CAUTION/HIGH/SEVERE),
     and emit TQQQ/QQQ...
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: daily
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data
@@ -397,8 +398,8 @@ skills:
   status: production
   summary: Use this skill to track institutional investor ownership changes and portfolio flows using
     13F filings data.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data
@@ -414,8 +415,8 @@ skills:
   status: production
   summary: Monitor dividend portfolios with Kanchi-style forced-review triggers (T1-T5) and convert anomalies
     into OK/WARN/REVIEW states without auto-selling.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: beginner
   integrations:
   - id: fmp
     type: market_data
@@ -431,8 +432,8 @@ skills:
   category: core-portfolio
   status: production
   summary: Convert Kanchi-style dividend investing into a repeatable US-stock operating procedure.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data
@@ -447,8 +448,8 @@ skills:
   category: core-portfolio
   status: production
   summary: Provide US dividend tax and account-location workflow for Kanchi-style income portfolios.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: intermediate
   integrations:
   - id: local_calculation
     type: calculation
@@ -464,8 +465,8 @@ skills:
   category: market-regime
   status: production
   summary: Detect structural macro regime transitions (1-2 year horizon) using cross-asset ratio analysis.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: advanced
   integrations:
   - id: yfinance_or_csv
     type: market_data
@@ -481,8 +482,8 @@ skills:
   category: market-regime
   status: production
   summary: Quantifies market breadth health using TraderMonty's public CSV data.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: daily
+  difficulty: beginner
   integrations:
   - id: public_csv
     type: local_file
@@ -498,8 +499,8 @@ skills:
   category: market-regime
   status: production
   summary: Comprehensive market environment analysis and reporting tool.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: daily
+  difficulty: intermediate
   integrations:
   - id: websearch
     type: web
@@ -519,8 +520,8 @@ skills:
   status: production
   summary: This skill should be used when analyzing recent market-moving news events and their impact
     on equity markets and commodities.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: daily
+  difficulty: intermediate
   integrations:
   - id: websearch
     type: web
@@ -536,8 +537,8 @@ skills:
   status: production
   summary: Detects market top probability using O'Neil Distribution Days, Minervini Leading Stock Deterioration,
     and Monty Defensive Sector Rotation.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: daily
+  difficulty: intermediate
   integrations:
   - id: public_csv
     type: local_file
@@ -553,8 +554,8 @@ skills:
   category: advanced-satellite
   status: production
   summary: Options trading strategy analysis and simulation tool.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: advanced
   integrations:
   - id: fmp
     type: market_data
@@ -569,8 +570,8 @@ skills:
   category: advanced-satellite
   status: production
   summary: Statistical arbitrage tool for identifying and analyzing pair trading opportunities.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: advanced
   integrations:
   - id: fmp
     type: market_data
@@ -586,8 +587,8 @@ skills:
   status: production
   summary: Screen US equities for parabolic exhaustion patterns and generate conditional pre-market short
     plans, then evaluate intraday trigger fires from live 5-min bars.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: advanced
   integrations:
   - id: fmp
     type: market_data
@@ -606,8 +607,8 @@ skills:
   category: advanced-satellite
   status: production
   summary: Screen post-earnings gap-up stocks for PEAD (Post-Earnings Announcement Drift) patterns.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data
@@ -624,8 +625,8 @@ skills:
   summary: Comprehensive portfolio analysis using Alpaca MCP Server integration to fetch holdings and
     positions, then analyze asset allocation, risk metrics, individual stock positions, diversification,
     and generate rebalancing recommendations.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: intermediate
   integrations:
   - id: alpaca
     type: broker
@@ -641,8 +642,8 @@ skills:
   category: trade-planning
   status: production
   summary: Calculate risk-based position sizes for long stock trades.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: beginner
   integrations:
   - id: local_calculation
     type: calculation
@@ -657,9 +658,10 @@ skills:
   display_name: Scenario Analyzer
   category: strategy-research
   status: production
-  summary: Analyze 18-month scenarios from news headlines via scenario-analyst agent with strategy-reviewer second opinion; outputs primary/secondary/tertiary impact analysis and stock picks in Japanese.
-  timeframe: unknown
-  difficulty: unknown
+  summary: Analyze 18-month scenarios from news headlines via scenario-analyst agent with strategy-reviewer
+    second opinion; outputs primary/secondary/tertiary impact analysis and stock picks in Japanese.
+  timeframe: event-driven
+  difficulty: advanced
   integrations:
   - id: websearch
     type: web
@@ -674,8 +676,8 @@ skills:
   category: market-regime
   status: production
   summary: This skill should be used when analyzing sector rotation patterns and market cycle positioning.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: intermediate
   integrations:
   - id: chart_image
     type: image
@@ -690,8 +692,8 @@ skills:
   category: trade-memory
   status: production
   summary: Record and analyze post-trade outcomes for signals generated by edge pipeline and other skills.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: beginner
   integrations:
   - id: local_calculation
     type: calculation
@@ -708,8 +710,8 @@ skills:
   category: meta
   status: production
   summary: Design new Claude skills from structured idea specifications.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: intermediate
   integrations:
   - id: local_calculation
     type: calculation
@@ -724,8 +726,8 @@ skills:
   category: meta
   status: production
   summary: Mine Claude Code session logs for skill idea candidates.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: intermediate
   integrations:
   - id: local_calculation
     type: calculation
@@ -741,8 +743,8 @@ skills:
   status: production
   summary: Validate multi-skill workflows defined in CLAUDE.md by checking skill existence, inter-skill
     data contracts (JSON schema compatibility), file naming conventions, and handoff integrity.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: intermediate
   integrations:
   - id: local_calculation
     type: calculation
@@ -759,8 +761,8 @@ skills:
   summary: Druckenmiller Strategy Synthesizer - Integrates 8 upstream skill outputs (Market Breadth, Uptrend
     Analysis, Market Top, Macro Regime, FTD Detector, VCP Screener, Theme Detector, CANSLIM Screener)
     into a unified conviction score (0-100),...
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: advanced
   integrations:
   - id: local_calculation
     type: calculation
@@ -776,8 +778,8 @@ skills:
   status: production
   summary: Detect backtest iteration stagnation and generate structurally different strategy pivot proposals
     when parameter tuning reaches a local optimum.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: research
+  difficulty: advanced
   integrations:
   - id: local_calculation
     type: calculation
@@ -793,8 +795,8 @@ skills:
   status: production
   summary: This skill should be used when analyzing weekly price charts for stocks, stock indices, cryptocurrencies,
     or forex pairs.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: intermediate
   integrations:
   - id: chart_image
     type: image
@@ -810,8 +812,8 @@ skills:
   category: swing-opportunity
   status: production
   summary: Detect and analyze trending market themes across sectors.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data
@@ -830,9 +832,10 @@ skills:
   display_name: Trade Hypothesis Ideator
   category: trade-memory
   status: production
-  summary: Generate falsifiable trade strategy hypotheses from market data, trade logs, and journal snippets with ranked hypothesis cards and optional strategy.yaml export.
-  timeframe: unknown
-  difficulty: unknown
+  summary: Generate falsifiable trade strategy hypotheses from market data, trade logs, and journal snippets
+    with ranked hypothesis cards and optional strategy.yaml export.
+  timeframe: research
+  difficulty: advanced
   integrations:
   - id: local_calculation
     type: calculation
@@ -848,8 +851,8 @@ skills:
   status: production
   summary: Track investment theses across their lifecycle — from screening idea to closed position with
     postmortem.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: beginner
   integrations:
   - id: fmp
     type: market_data
@@ -869,8 +872,8 @@ skills:
   status: production
   summary: Analyzes market breadth using Monty's Uptrend Ratio Dashboard data to diagnose the current
     market environment.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: daily
+  difficulty: beginner
   integrations:
   - id: public_csv
     type: local_file
@@ -887,8 +890,8 @@ skills:
   status: production
   summary: Evaluates market bubble risk through quantitative data-driven analysis using the revised Minsky/Kindleberger
     framework v2.1.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: intermediate
   integrations:
   - id: user_input
     type: local_file
@@ -905,8 +908,8 @@ skills:
   summary: Comprehensive US stock analysis including fundamental analysis (financial metrics, business
     quality, valuation), technical analysis (indicators, chart patterns, support/resistance), stock comparisons,
     and investment report generation.
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: event-driven
+  difficulty: intermediate
   integrations:
   - id: user_input
     type: local_file
@@ -923,8 +926,8 @@ skills:
   summary: Screen US stocks for high-quality dividend opportunities combining value characteristics (P/E
     ratio under 20, P/B ratio under 2), attractive yields (3% or higher), and consistent growth (dividend/revenue/EPS
     trending up over 3 years).
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: weekly
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data
@@ -944,8 +947,8 @@ skills:
   category: swing-opportunity
   status: production
   summary: Screen S&P 500 stocks for Mark Minervini's Volatility Contraction Pattern (VCP).
-  timeframe: unknown
-  difficulty: unknown
+  timeframe: daily
+  difficulty: intermediate
   integrations:
   - id: fmp
     type: market_data

--- a/skills-index.yaml
+++ b/skills-index.yaml
@@ -21,8 +21,12 @@ skills:
     type: local_file
     requirement: required
     note: User provides strategy parameters
-  inputs: []
-  outputs: []
+  inputs:
+  - strategy_parameters
+  - historical_ohlcv
+  outputs:
+  - backtest_report
+  - performance_metrics
   workflows:
   - trade-memory-loop
   - monthly-performance-review
@@ -40,8 +44,10 @@ skills:
     type: image
     requirement: required
     note: Chart screenshot input
-  inputs: []
-  outputs: []
+  inputs:
+  - breadth_chart_image
+  outputs:
+  - breadth_assessment_report
   workflows: []
   hand_written_doc: false
 - id: breakout-trade-planner
@@ -58,8 +64,12 @@ skills:
     type: calculation
     requirement: not_required
     note: Consumes VCP screener output; pure calculation + Alpaca order templates
-  inputs: []
-  outputs: []
+  inputs:
+  - vcp_candidates
+  - account_size
+  outputs:
+  - entry_plan
+  - alpaca_order_template
   workflows:
   - swing-opportunity-daily
   hand_written_doc: false
@@ -75,8 +85,12 @@ skills:
     type: market_data
     requirement: required
     note: US stock fundamentals via FMP
-  inputs: []
-  outputs: []
+  inputs:
+  - screener_universe
+  - fundamentals_data
+  outputs:
+  - canslim_candidates
+  - composite_scores
   workflows:
   - swing-opportunity-daily
   hand_written_doc: false
@@ -92,8 +106,11 @@ skills:
     type: calculation
     requirement: not_required
     note: Local markdown validation; works offline
-  inputs: []
-  outputs: []
+  inputs:
+  - markdown_document
+  outputs:
+  - quality_report
+  - issue_list
   workflows: []
   hand_written_doc: false
 - id: dividend-growth-pullback-screener
@@ -113,8 +130,12 @@ skills:
     type: screener
     requirement: recommended
     note: FINVIZ Elite API
-  inputs: []
-  outputs: []
+  inputs:
+  - dividend_universe
+  - rsi_thresholds
+  outputs:
+  - pullback_candidates
+  - yield_growth_metrics
   workflows: []
   hand_written_doc: false
 - id: downtrend-duration-analyzer
@@ -130,8 +151,11 @@ skills:
     type: calculation
     requirement: not_required
     note: Duration analysis from market data; pure calculation
-  inputs: []
-  outputs: []
+  inputs:
+  - historical_correction_data
+  outputs:
+  - duration_histogram_html
+  - sector_breakdown
   workflows: []
   hand_written_doc: false
 - id: dual-axis-skill-reviewer
@@ -147,8 +171,10 @@ skills:
     type: calculation
     requirement: not_required
     note: Deterministic scoring + optional LLM review
-  inputs: []
-  outputs: []
+  inputs:
+  - skill_source_tree
+  outputs:
+  - dual_axis_score_report
   workflows:
   - monthly-performance-review
   hand_written_doc: false
@@ -165,8 +191,11 @@ skills:
     type: market_data
     requirement: required
     note: Financial Modeling Prep API
-  inputs: []
-  outputs: []
+  inputs:
+  - date_range
+  - market_cap_filter
+  outputs:
+  - earnings_calendar_report
   workflows: []
   hand_written_doc: false
 - id: earnings-trade-analyzer
@@ -182,8 +211,11 @@ skills:
     type: market_data
     requirement: required
     note: Financial Modeling Prep API
-  inputs: []
-  outputs: []
+  inputs:
+  - recent_earnings_universe
+  outputs:
+  - scored_candidates
+  - five_factor_grades
   workflows: []
   hand_written_doc: false
 - id: economic-calendar-fetcher
@@ -198,8 +230,10 @@ skills:
     type: market_data
     requirement: required
     note: Financial Modeling Prep API
-  inputs: []
-  outputs: []
+  inputs:
+  - date_range
+  outputs:
+  - economic_events_report
   workflows: []
   hand_written_doc: false
 - id: edge-candidate-agent
@@ -215,8 +249,12 @@ skills:
     type: market_data
     requirement: optional
     note: Optional OHLCV via FMP for edge ticket export
-  inputs: []
-  outputs: []
+  inputs:
+  - eod_observations
+  outputs:
+  - market_summary_json
+  - anomalies_json
+  - tickets_dir
   workflows: []
   hand_written_doc: false
 - id: edge-concept-synthesizer
@@ -232,8 +270,11 @@ skills:
     type: calculation
     requirement: not_required
     note: Synthesizes detector tickets and hints into edge concepts
-  inputs: []
-  outputs: []
+  inputs:
+  - tickets_dir
+  - hints_yaml
+  outputs:
+  - edge_concepts_yaml
   workflows: []
   hand_written_doc: false
 - id: edge-hint-extractor
@@ -249,8 +290,11 @@ skills:
     type: calculation
     requirement: not_required
     note: Extracts hints from observations/news; pure calculation
-  inputs: []
-  outputs: []
+  inputs:
+  - market_summary_json
+  - anomalies_json
+  outputs:
+  - hints_yaml
   workflows: []
   hand_written_doc: false
 - id: edge-pipeline-orchestrator
@@ -266,8 +310,13 @@ skills:
     type: calculation
     requirement: not_required
     note: Orchestrates edge pipeline subskills via subprocess
-  inputs: []
-  outputs: []
+  inputs:
+  - tickets_dir
+  - market_summary
+  - anomalies
+  outputs:
+  - pipeline_report
+  - exported_strategies
   workflows: []
   hand_written_doc: false
 - id: edge-signal-aggregator
@@ -284,8 +333,12 @@ skills:
     type: calculation
     requirement: not_required
     note: Aggregates signals from edge-finding skills
-  inputs: []
-  outputs: []
+  inputs:
+  - edge_candidate_outputs
+  - theme_outputs
+  - sector_outputs
+  outputs:
+  - conviction_dashboard
   workflows: []
   hand_written_doc: false
 - id: edge-strategy-designer
@@ -301,8 +354,10 @@ skills:
     type: calculation
     requirement: not_required
     note: Converts edge concepts into strategy drafts
-  inputs: []
-  outputs: []
+  inputs:
+  - edge_concepts_yaml
+  outputs:
+  - strategy_drafts_yaml
   workflows: []
   hand_written_doc: false
 - id: edge-strategy-reviewer
@@ -318,8 +373,11 @@ skills:
     type: calculation
     requirement: not_required
     note: Deterministic scoring on local YAML drafts
-  inputs: []
-  outputs: []
+  inputs:
+  - strategy_drafts_yaml
+  outputs:
+  - review_yaml
+  - verdict_list
   workflows: []
   hand_written_doc: false
 - id: exposure-coach
@@ -336,8 +394,12 @@ skills:
     type: calculation
     requirement: not_required
     note: Synthesizes signals from other skills; pure calculation
-  inputs: []
-  outputs: []
+  inputs:
+  - market_breadth_report
+  - uptrend_report
+  - top_risk_report
+  outputs:
+  - exposure_decision
   workflows:
   - market-regime-daily
   hand_written_doc: false
@@ -353,8 +415,11 @@ skills:
     type: screener
     requirement: optional
     note: FINVIZ Elite API
-  inputs: []
-  outputs: []
+  inputs:
+  - natural_language_query
+  outputs:
+  - finviz_url
+  - filter_codes
   workflows: []
   hand_written_doc: false
 - id: ftd-detector
@@ -370,8 +435,11 @@ skills:
     type: market_data
     requirement: required
     note: Daily QQQ/SPY OHLCV via FMP
-  inputs: []
-  outputs: []
+  inputs:
+  - sp500_ohlcv
+  - nasdaq_ohlcv
+  outputs:
+  - ftd_signal_report
   workflows: []
   hand_written_doc: false
 - id: ibd-distribution-day-monitor
@@ -388,8 +456,11 @@ skills:
     type: market_data
     requirement: required
     note: Financial Modeling Prep API
-  inputs: []
-  outputs: []
+  inputs:
+  - qqq_ohlcv
+  - spy_ohlcv
+  outputs:
+  - distribution_day_count_report
   workflows: []
   hand_written_doc: false
 - id: institutional-flow-tracker
@@ -405,8 +476,11 @@ skills:
     type: market_data
     requirement: required
     note: Financial Modeling Prep API
-  inputs: []
-  outputs: []
+  inputs:
+  - 13f_filings
+  - fund_universe
+  outputs:
+  - flow_analysis_report
   workflows: []
   hand_written_doc: false
 - id: kanchi-dividend-review-monitor
@@ -422,8 +496,11 @@ skills:
     type: market_data
     requirement: recommended
     note: Dividend / price monitoring via FMP
-  inputs: []
-  outputs: []
+  inputs:
+  - holdings_snapshot
+  outputs:
+  - t1_t5_anomaly_findings
+  - review_queue
   workflows:
   - core-portfolio-weekly
   hand_written_doc: false
@@ -439,8 +516,12 @@ skills:
     type: market_data
     requirement: recommended
     note: US dividend stock data via FMP
-  inputs: []
-  outputs: []
+  inputs:
+  - screener_universe
+  - sector_filter
+  outputs:
+  - kanchi_candidates
+  - stock_memo
   workflows: []
   hand_written_doc: false
 - id: kanchi-dividend-us-tax-accounting
@@ -455,8 +536,12 @@ skills:
     type: calculation
     requirement: not_required
     note: US tax workflow guidance; pure calculation
-  inputs: []
-  outputs: []
+  inputs:
+  - dividend_distributions
+  - 1099_div
+  outputs:
+  - qualified_ordinary_classification
+  - account_location_advice
   workflows:
   - core-portfolio-weekly
   hand_written_doc: false
@@ -472,8 +557,11 @@ skills:
     type: market_data
     requirement: recommended
     note: Cross-asset ratio data via yfinance or local CSV
-  inputs: []
-  outputs: []
+  inputs:
+  - cross_asset_ratios
+  - yield_curve_data
+  outputs:
+  - regime_transition_report
   workflows:
   - market-regime-daily
   hand_written_doc: false
@@ -489,8 +577,11 @@ skills:
     type: local_file
     requirement: required
     note: TraderMonty public CSV; no API key required
-  inputs: []
-  outputs: []
+  inputs:
+  - public_breadth_csv
+  outputs:
+  - breadth_composite_score
+  - component_breakdown
   workflows:
   - market-regime-daily
   hand_written_doc: false
@@ -510,8 +601,11 @@ skills:
     type: image
     requirement: optional
     note: Optional chart image inputs for technical interpretation
-  inputs: []
-  outputs: []
+  inputs:
+  - global_market_data
+  - chart_image
+  outputs:
+  - market_environment_report
   workflows: []
   hand_written_doc: false
 - id: market-news-analyst
@@ -527,8 +621,11 @@ skills:
     type: web
     requirement: required
     note: Web search / fetch
-  inputs: []
-  outputs: []
+  inputs:
+  - news_search_query
+  - date_range
+  outputs:
+  - news_impact_report
   workflows: []
   hand_written_doc: false
 - id: market-top-detector
@@ -544,8 +641,10 @@ skills:
     type: local_file
     requirement: required
     note: Public market data CSVs; no API key required
-  inputs: []
-  outputs: []
+  inputs:
+  - public_market_data_csv
+  outputs:
+  - market_top_composite_score
   workflows:
   - market-regime-daily
   hand_written_doc: false
@@ -561,8 +660,14 @@ skills:
     type: market_data
     requirement: optional
     note: Financial Modeling Prep API
-  inputs: []
-  outputs: []
+  inputs:
+  - ticker
+  - strategy_type
+  - stock_data
+  outputs:
+  - greeks
+  - pnl_simulation
+  - strategy_comparison
   workflows: []
   hand_written_doc: false
 - id: pair-trade-screener
@@ -577,8 +682,12 @@ skills:
     type: market_data
     requirement: required
     note: Financial Modeling Prep API
-  inputs: []
-  outputs: []
+  inputs:
+  - sector_universe
+  - lookback_period
+  outputs:
+  - cointegrated_pairs
+  - zscore_signals
   workflows: []
   hand_written_doc: false
 - id: parabolic-short-trade-planner
@@ -598,8 +707,12 @@ skills:
     type: broker
     requirement: optional
     note: Alpaca brokerage MCP/API
-  inputs: []
-  outputs: []
+  inputs:
+  - screener_universe
+  - alpaca_inventory
+  outputs:
+  - pre_market_plan
+  - intraday_trigger_state
   workflows: []
   hand_written_doc: false
 - id: pead-screener
@@ -614,8 +727,12 @@ skills:
     type: market_data
     requirement: required
     note: Financial Modeling Prep API
-  inputs: []
-  outputs: []
+  inputs:
+  - earnings_candidates
+  - weekly_ohlcv
+  outputs:
+  - pead_signal_list
+  - breakout_triggers
   workflows: []
   hand_written_doc: false
 - id: portfolio-manager
@@ -632,8 +749,11 @@ skills:
     type: broker
     requirement: required
     note: Alpaca brokerage MCP/API
-  inputs: []
-  outputs: []
+  inputs:
+  - alpaca_holdings_or_csv
+  outputs:
+  - allocation_report
+  - rebalance_actions
   workflows:
   - core-portfolio-weekly
   hand_written_doc: false
@@ -649,8 +769,13 @@ skills:
     type: calculation
     requirement: not_required
     note: Pure calculation; works offline
-  inputs: []
-  outputs: []
+  inputs:
+  - entry_price
+  - stop_price
+  - account_size
+  outputs:
+  - share_count
+  - risk_amount
   workflows:
   - swing-opportunity-daily
   hand_written_doc: false
@@ -667,8 +792,12 @@ skills:
     type: web
     requirement: required
     note: Headline / news search via WebSearch
-  inputs: []
-  outputs: []
+  inputs:
+  - news_headline
+  outputs:
+  - scenario_report_ja
+  - stock_picks
+  - review_yaml
   workflows: []
   hand_written_doc: false
 - id: sector-analyst
@@ -683,8 +812,11 @@ skills:
     type: image
     requirement: required
     note: Chart screenshot input
-  inputs: []
-  outputs: []
+  inputs:
+  - sector_uptrend_csv
+  - chart_image
+  outputs:
+  - rotation_assessment_report
   workflows: []
   hand_written_doc: false
 - id: signal-postmortem
@@ -699,8 +831,10 @@ skills:
     type: calculation
     requirement: not_required
     note: Postmortem framework; pure calculation
-  inputs: []
-  outputs: []
+  inputs:
+  - closed_thesis_record
+  outputs:
+  - postmortem_findings
   workflows:
   - trade-memory-loop
   - monthly-performance-review
@@ -717,8 +851,10 @@ skills:
     type: calculation
     requirement: not_required
     note: Generates skill scaffolding from idea specs
-  inputs: []
-  outputs: []
+  inputs:
+  - idea_specification
+  outputs:
+  - skill_scaffolding
   workflows: []
   hand_written_doc: false
 - id: skill-idea-miner
@@ -733,8 +869,10 @@ skills:
     type: calculation
     requirement: not_required
     note: Mines session logs for skill ideas
-  inputs: []
-  outputs: []
+  inputs:
+  - session_logs
+  outputs:
+  - skill_idea_backlog_yaml
   workflows: []
   hand_written_doc: false
 - id: skill-integration-tester
@@ -750,8 +888,11 @@ skills:
     type: calculation
     requirement: not_required
     note: Validates multi-skill workflow contracts
-  inputs: []
-  outputs: []
+  inputs:
+  - claude_md
+  - skill_outputs
+  outputs:
+  - workflow_validation_report
   workflows: []
   hand_written_doc: false
 - id: stanley-druckenmiller-investment
@@ -768,8 +909,11 @@ skills:
     type: calculation
     requirement: not_required
     note: Synthesizes outputs from upstream skills; pure calculation
-  inputs: []
-  outputs: []
+  inputs:
+  - upstream_skill_outputs
+  - exposure_decision
+  outputs:
+  - druckenmiller_synthesis_report
   workflows: []
   hand_written_doc: false
 - id: strategy-pivot-designer
@@ -785,8 +929,10 @@ skills:
     type: calculation
     requirement: not_required
     note: Pivot proposal generator; pure calculation
-  inputs: []
-  outputs: []
+  inputs:
+  - backtest_iteration_history
+  outputs:
+  - pivot_proposals
   workflows: []
   hand_written_doc: false
 - id: technical-analyst
@@ -802,8 +948,10 @@ skills:
     type: image
     requirement: required
     note: Chart screenshot input
-  inputs: []
-  outputs: []
+  inputs:
+  - weekly_chart_image
+  outputs:
+  - technical_assessment_report
   workflows:
   - swing-opportunity-daily
   hand_written_doc: false
@@ -823,8 +971,12 @@ skills:
     type: screener
     requirement: recommended
     note: FINVIZ Elite API
-  inputs: []
-  outputs: []
+  inputs:
+  - theme_universe
+  - sector_data
+  outputs:
+  - theme_heat_scores
+  - trending_themes
   workflows:
   - swing-opportunity-daily
   hand_written_doc: false
@@ -841,8 +993,12 @@ skills:
     type: calculation
     requirement: not_required
     note: Hypothesis generation from journal/data inputs; pure calculation
-  inputs: []
-  outputs: []
+  inputs:
+  - market_data_bundle
+  - journal_snippets
+  outputs:
+  - hypothesis_cards
+  - strategy_yaml
   workflows: []
   hand_written_doc: false
 - id: trader-memory-core
@@ -858,8 +1014,12 @@ skills:
     type: market_data
     requirement: optional
     note: Financial Modeling Prep API
-  inputs: []
-  outputs: []
+  inputs:
+  - screener_report
+  - trade_actions
+  outputs:
+  - thesis_record
+  - journal_entry
   workflows:
   - core-portfolio-weekly
   - swing-opportunity-daily
@@ -879,8 +1039,10 @@ skills:
     type: local_file
     requirement: required
     note: Monty Uptrend Ratio Dashboard CSV; no API key required
-  inputs: []
-  outputs: []
+  inputs:
+  - uptrend_ratio_csv
+  outputs:
+  - uptrend_composite_score
   workflows:
   - market-regime-daily
   hand_written_doc: false
@@ -897,8 +1059,10 @@ skills:
     type: local_file
     requirement: required
     note: User provides indicators
-  inputs: []
-  outputs: []
+  inputs:
+  - bubble_indicators_data
+  outputs:
+  - bubble_risk_score
   workflows: []
   hand_written_doc: false
 - id: us-stock-analysis
@@ -915,8 +1079,12 @@ skills:
     type: local_file
     requirement: required
     note: User provides data
-  inputs: []
-  outputs: []
+  inputs:
+  - ticker
+  - fundamentals_data
+  - chart_image
+  outputs:
+  - stock_analysis_report
   workflows: []
   hand_written_doc: false
 - id: value-dividend-screener
@@ -937,8 +1105,11 @@ skills:
     type: screener
     requirement: recommended
     note: FINVIZ Elite API
-  inputs: []
-  outputs: []
+  inputs:
+  - dividend_universe
+  - value_filters
+  outputs:
+  - high_yield_candidates
   workflows:
   - core-portfolio-weekly
   hand_written_doc: false
@@ -954,8 +1125,11 @@ skills:
     type: market_data
     requirement: required
     note: S&P 500 OHLCV via FMP
-  inputs: []
-  outputs: []
+  inputs:
+  - sp500_ohlcv
+  outputs:
+  - vcp_candidates
+  - pivot_points
   workflows:
   - swing-opportunity-daily
   hand_written_doc: false


### PR DESCRIPTION
## Summary

- Hand-curated **`timeframe` / `difficulty` / `inputs` / `outputs`** for every one of the 54 skills in `skills-index.yaml`.
- Activated `--strict-metadata` mode in both CI and the pre-push hook. All three validator strictness levels (default / `--strict-workflows` / `--strict-metadata`) now have green builds.
- Drives default-mode warnings from **108 → 0**. The SSoT is now complete for schema v1 fields.

**Stacked on** [#89](https://github.com/tradermonty/claude-trading-skills/pull/89). GitHub will auto-rebase the base when PR5 merges.

## Two commits

| SHA | Scope |
|---|---|
| `07c59da` | Hand-curate `timeframe` + `difficulty` for all 54 skills (108 default-mode warnings → 0) |
| `b3e0237` | Hand-curate `inputs` + `outputs` for all 54 skills; activate `--strict-metadata` in CI + pre-push |

## Classification distributions

**timeframe** (54 skills):

| Value | Count | Examples |
|---|---|---|
| `daily` | 10 | market-breadth-analyzer, uptrend-analyzer, market-top-detector, ftd-detector |
| `weekly` | 11 | portfolio-manager, kanchi-dividend-sop, sector-analyst, theme-detector |
| `event-driven` | 16 | earnings-trade-analyzer, position-sizer, signal-postmortem, options-strategy-advisor |
| `research` | 17 | backtest-expert, edge-pipeline-orchestrator, scenario-analyzer, strategy-pivot-designer |

**difficulty** (54 skills):

| Value | Count | Examples |
|---|---|---|
| `beginner` | 11 | position-sizer, trader-memory-core, earnings-calendar, exposure-coach |
| `intermediate` | 28 | vcp-screener, technical-analyst, portfolio-manager, market-breadth-analyzer |
| `advanced` | 15 | parabolic-short-trade-planner, edge-pipeline-orchestrator, options-strategy-advisor |

Classification logic: `timeframe` reflects operational cadence (daily monitoring vs research-time exploration); `difficulty` reflects cognitive load of interpreting output correctly (direct numeric vs chart interpretation vs multi-skill strategy synthesis).

## `inputs` / `outputs` examples

Each skill now declares its primary I/O artifacts. Examples:

- `portfolio-manager` — inputs: `[alpaca_holdings_or_csv]`, outputs: `[allocation_report, rebalance_actions]`
- `position-sizer` — inputs: `[entry_price, stop_price, account_size]`, outputs: `[share_count, risk_amount]`
- `vcp-screener` — inputs: `[sp500_ohlcv]`, outputs: `[vcp_candidates, pivot_points]`
- `exposure-coach` — inputs: `[market_breadth_report, uptrend_report, top_risk_report]`, outputs: `[exposure_decision]`

The I/O lists feed forward into the future Trading Skills Navigator: artifact-flow can be inferred without re-reading SKILL.md prose.

## Validator state after this PR

- `python3 scripts/validate_skills_index.py` → **OK** (0 warnings, 0 errors)
- `python3 scripts/validate_skills_index.py --strict-workflows` → **OK**
- `python3 scripts/validate_skills_index.py --strict-metadata` → **OK**
- `pre-commit run --all-files` → clean
- `pre-push` hook (now includes `--strict-metadata`) → clean
- `pytest scripts/tests/` → **245/245 passed**

## Why both commits in one PR

Splitting would have left the codebase in a state where `--strict-metadata` was advertised as "next" but couldn't actually be activated (empty I/O lists still blocking). Doing both together delivers the full "metadata SSoT complete" milestone in one merge.

## Follow-ups

- Trading Skills Navigator (vision Phase 1) — now has structured I/O metadata to consume.
- Delete the legacy `<details>` catalog block in README (Promised after PR #89 merge).
- Consider auto-generating CLAUDE.md API Requirements Matrix from `integrations[]` (sentinel pattern from PR #89 is reusable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)