### PR TITLE
fix(tests): isolate ftd-detector / market-top-detector FMPClient patches for bulk pytest

### DIFF
--- a/skills/ftd-detector/scripts/tests/test_fmp_client.py
+++ b/skills/ftd-detector/scripts/tests/test_fmp_client.py
@@ -283,6 +283,16 @@ class TestSymbolMismatch:
 class TestCallerRegression:
     """Tier C: Verify ftd_detector.main() handles FMPClient failures correctly."""
 
+    # IMPORTANT: patch `ftd_detector.FMPClient` (the symbol AS USED by main()),
+    # not the module-level `FMPClient` imported at the top of this file.
+    # When pytest runs both ftd-detector and market-top-detector test files in
+    # the same session, conftest evicts and re-imports `fmp_client` during
+    # skill switches. This produces multiple class objects from the same source
+    # file. Patching the test-file-level `FMPClient` reference would miss the
+    # class that `ftd_detector.main()` actually uses. Patching via
+    # `ftd_detector.FMPClient` always hits the class bound inside ftd_detector
+    # at the time main() executes.
+
     def test_ftd_detector_exits_on_historical_failure(self):
         """get_historical_prices -> None => main() calls sys.exit(1) (fatal)."""
         with (
@@ -293,9 +303,9 @@ class TestCallerRegression:
             import ftd_detector
 
             with (
-                patch.object(FMPClient, "get_historical_prices", return_value=None),
+                patch.object(ftd_detector.FMPClient, "get_historical_prices", return_value=None),
                 patch.object(
-                    FMPClient,
+                    ftd_detector.FMPClient,
                     "get_quote",
                     return_value=[{"symbol": "^GSPC", "price": 5000.0}],
                 ),
@@ -347,8 +357,10 @@ class TestCallerRegression:
                 return None
 
             with (
-                patch.object(FMPClient, "get_historical_prices", side_effect=mock_hist),
-                patch.object(FMPClient, "get_quote", return_value=None),
+                patch.object(
+                    ftd_detector.FMPClient, "get_historical_prices", side_effect=mock_hist
+                ),
+                patch.object(ftd_detector.FMPClient, "get_quote", return_value=None),
                 patch.object(ftd_detector, "generate_json_report"),
                 patch.object(ftd_detector, "generate_markdown_report"),
             ):

--- a/skills/market-top-detector/scripts/tests/test_fmp_client.py
+++ b/skills/market-top-detector/scripts/tests/test_fmp_client.py
@@ -336,25 +336,18 @@ class TestEndpointFallback:
         assert result["ratio"] == 0.9
 
     def test_market_top_exits_on_sp500_failure(self):
-        """main() exits with code 1 when S&P 500 data unavailable."""
-        from fmp_client import FMPClient
+        """main() exits with code 1 when S&P 500 data unavailable.
 
-        with (
-            patch.object(FMPClient, "__init__", lambda self, **kw: None),
-            patch.object(FMPClient, "get_quote", return_value=None),
-            patch.object(FMPClient, "get_historical_prices", return_value=None),
-            patch.object(
-                FMPClient,
-                "get_api_stats",
-                return_value={
-                    "cache_entries": 0,
-                    "api_calls_made": 0,
-                    "rate_limit_reached": False,
-                },
-            ),
-            patch("sys.argv", ["market_top_detector.py"]),
-        ):
-            # Need to set required attributes that __init__ would set
+        NOTE: patches `market_top_detector.FMPClient` (the symbol AS USED by
+        main()), not the test-file-local FMPClient. When pytest runs multiple
+        detector skills in the same session, conftest evicts and re-imports
+        `fmp_client` on skill switch, which produces multiple class objects
+        from the same source file. Patching the test-local FMPClient would
+        miss the class that main() actually uses.
+        """
+        with patch("sys.argv", ["market_top_detector.py"]):
+            import market_top_detector
+
             def fake_init(self, **kw):
                 self.api_key = "test"  # pragma: allowlist secret
                 self.session = MagicMock()
@@ -365,16 +358,28 @@ class TestEndpointFallback:
                 self.max_retries = 1
                 self.api_calls_made = 0
 
-            with patch.object(FMPClient, "__init__", fake_init):
-                import market_top_detector
-
+            with (
+                patch.object(market_top_detector.FMPClient, "__init__", fake_init),
+                patch.object(market_top_detector.FMPClient, "get_quote", return_value=None),
+                patch.object(
+                    market_top_detector.FMPClient, "get_historical_prices", return_value=None
+                ),
+                patch.object(
+                    market_top_detector.FMPClient,
+                    "get_api_stats",
+                    return_value={
+                        "cache_entries": 0,
+                        "api_calls_made": 0,
+                        "rate_limit_reached": False,
+                    },
+                ),
+            ):
                 with pytest.raises(SystemExit) as exc_info:
                     market_top_detector.main()
                 assert exc_info.value.code == 1
 
     def test_market_top_continues_on_vix_failure(self, capsys):
         """main() continues with warning when VIX unavailable (non-fatal)."""
-        from fmp_client import FMPClient
 
         sp500_quote = [{"symbol": "^GSPC", "price": 5500.0, "yearHigh": 5600.0}]
         sp500_hist = {
@@ -488,20 +493,36 @@ class TestEndpointFallback:
                     ],
                 ),
             ):
-                from fmp_client import FMPClient
+                import importlib
 
+                import market_top_detector
+
+                importlib.reload(market_top_detector)
+
+                # Patch market_top_detector.FMPClient (the symbol used by main())
+                # rather than a test-file-local fmp_client import. See
+                # test_market_top_exits_on_sp500_failure docstring for the
+                # cross-skill conftest eviction context.
                 with (
-                    patch.object(FMPClient, "get_quote", side_effect=mock_quote),
-                    patch.object(FMPClient, "get_historical_prices", side_effect=mock_hist),
-                    patch.object(FMPClient, "get_batch_quotes", side_effect=mock_batch_quotes),
-                    patch.object(FMPClient, "get_batch_historical", side_effect=mock_batch_hist),
+                    patch.object(
+                        market_top_detector.FMPClient, "get_quote", side_effect=mock_quote
+                    ),
+                    patch.object(
+                        market_top_detector.FMPClient,
+                        "get_historical_prices",
+                        side_effect=mock_hist,
+                    ),
+                    patch.object(
+                        market_top_detector.FMPClient,
+                        "get_batch_quotes",
+                        side_effect=mock_batch_quotes,
+                    ),
+                    patch.object(
+                        market_top_detector.FMPClient,
+                        "get_batch_historical",
+                        side_effect=mock_batch_hist,
+                    ),
                 ):
-                    import importlib
-
-                    import market_top_detector
-
-                    importlib.reload(market_top_detector)
-
                     # Should NOT raise SystemExit — VIX failure is non-fatal
                     try:
                         market_top_detector.main()


### PR DESCRIPTION
## Summary

Fixes the **2 pre-existing bulk-pytest failures** that the reviewer flagged during PR #90 (the metadata fill-in PR). Root cause has nothing to do with metadata — it is a long-standing test-patching mistake that surfaces only when multiple detector skills are collected in the same pytest session.

Before this PR:
```
uv run --extra dev pytest -q  →  2963 passed, 2 failed, 17 skipped
```

After this PR:
```
uv run --extra dev pytest -q  →  2965 passed, 0 failed, 17 skipped
```

## Root cause

When pytest collects multiple detector skills (`ftd-detector` + `market-top-detector`, both ship `test_fmp_client.py`), `conftest.py` evicts and re-imports `fmp_client` on every skill switch to keep skill-local modules isolated. Each re-import produces a **new class object** from the same source file. The test-file-level `from fmp_client import FMPClient` binding is captured at one moment in time, while the detector module's own `from fmp_client import FMPClient` may resolve to a freshly-imported class. Result: two `FMPClient` class objects coexist in the same process, and `patch.object(FMPClient, ...)` modifies the wrong one. The real (un-mocked) method then fires a live FMP API request that returns 401, causing `main()` to exit and the test to fail.

The single-test run works because there is no skill switch to trigger the eviction, so only one `FMPClient` class exists.

## Fix

Canonical "patch where it is used" pattern. Patches now target `<detector_module>.FMPClient` instead of the test-file's local `FMPClient` reference:

```python
# Before (fragile under bulk pytest)
from fmp_client import FMPClient
...
with patch.object(FMPClient, "get_historical_prices", side_effect=mock_hist):
    ftd_detector.main()

# After (always patches the class main() actually uses)
import ftd_detector
...
with patch.object(ftd_detector.FMPClient, "get_historical_prices", side_effect=mock_hist):
    ftd_detector.main()
```

## Tests updated

| File | Tests |
|---|---|
| `skills/ftd-detector/scripts/tests/test_fmp_client.py` | `test_ftd_detector_exits_on_historical_failure`, `test_ftd_detector_continues_on_quote_failure` |
| `skills/market-top-detector/scripts/tests/test_fmp_client.py` | `test_market_top_exits_on_sp500_failure`, `test_market_top_continues_on_vix_failure` |

Each updated test gets an inline comment explaining the patch-target choice so future contributors do not re-introduce the bug.

## Verification

- `python3 -m pytest skills/ftd-detector/scripts/tests/test_fmp_client.py skills/market-top-detector/scripts/tests/test_fmp_client.py -v` → **38/38 passed**
- `uv run --extra dev pytest -q --ignore=skills/canslim-screener --ignore=skills/theme-detector` → **2965 passed, 0 failed, 17 skipped** (was 2 failed)
- `bash scripts/run_all_tests.sh` (per-skill isolated runs) → still green
- Single-test isolation runs → still pass

## What this does NOT touch

- No production code changes — only test patching.
- No conftest.py changes — the cross-skill eviction logic still serves its purpose; tests just need to play by the canonical patch rules.
- No CI / pre-commit / generator changes — orthogonal to the SSoT layering work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)