### PR TITLE
fix(exposure-coach): handle nested composite/regime dict from upstream skills

### DIFF
--- a/skills/exposure-coach/scripts/calculate_exposure.py
+++ b/skills/exposure-coach/scripts/calculate_exposure.py
@@ -73,48 +73,82 @@ def extract_breadth_score(data: Optional[dict]) -> Optional[int]:
     return None
 
 
+def _uptrend_pct_to_score(pct: float) -> int:
+    """Convert an uptrend participation percentage to a 0-100 score."""
+    if pct > 50:
+        return min(100, int(50 + pct))
+    elif pct >= 35:
+        return int(35 + pct)
+    elif pct >= 20:
+        return int(20 + pct)
+    else:
+        return int(pct)
+
+
 def extract_uptrend_score(data: Optional[dict]) -> Optional[int]:
-    """Extract uptrend participation score."""
+    """Extract uptrend participation score.
+
+    Supports both the flat shape (``uptrend_score`` / ``uptrend_pct`` at the
+    top level) and the nested shape emitted by uptrend-analyzer, which stores
+    its result under a ``composite`` sub-object.
+    """
     if data is None:
         return None
     if "uptrend_score" in data:
         return int(data["uptrend_score"])
+    # uptrend-analyzer nests its score under "composite"
+    composite = data.get("composite")
+    if isinstance(composite, dict):
+        if "composite_score" in composite:
+            return int(composite["composite_score"])
+        if "uptrend_pct" in composite:
+            return _uptrend_pct_to_score(composite["uptrend_pct"])
     if "uptrend_pct" in data:
-        pct = data["uptrend_pct"]
-        if pct > 50:
-            return min(100, int(50 + pct))
-        elif pct >= 35:
-            return int(35 + pct)
-        elif pct >= 20:
-            return int(20 + pct)
-        else:
-            return int(pct)
+        return _uptrend_pct_to_score(data["uptrend_pct"])
     return None
 
 
 def extract_regime_score(data: Optional[dict]) -> Optional[int]:
-    """Extract regime score from macro-regime-detector output."""
+    """Extract regime score from macro-regime-detector output.
+
+    ``regime`` may be a flat string (legacy) or a nested object
+    (``{"regime": {"current_regime": ...}}``) as emitted by
+    macro-regime-detector.
+    """
     if data is None:
         return None
     if "regime_score" in data:
         return int(data["regime_score"])
-    if "regime" in data:
-        regime = data["regime"].lower().strip()
-        return REGIME_SCORES.get(regime, 50)
+    regime = data.get("regime")
+    if isinstance(regime, dict):
+        name = regime.get("current_regime")
+        if name:
+            return REGIME_SCORES.get(str(name).lower().strip(), 50)
+    elif isinstance(regime, str):
+        return REGIME_SCORES.get(regime.lower().strip(), 50)
     if "current_regime" in data:
-        regime = data["current_regime"].lower().strip()
-        return REGIME_SCORES.get(regime, 50)
+        return REGIME_SCORES.get(str(data["current_regime"]).lower().strip(), 50)
     return None
 
 
 def extract_regime_name(data: Optional[dict]) -> str:
-    """Extract regime name from data."""
+    """Extract regime name from data.
+
+    Handles the legacy flat string form and the nested object form
+    (``{"regime": {"regime_label": ..., "current_regime": ...}}``). For the
+    nested form ``regime_label`` is preferred, falling back to
+    ``current_regime``.
+    """
     if data is None:
         return "Unknown"
-    if "regime" in data:
-        return data["regime"].capitalize()
+    regime = data.get("regime")
+    if isinstance(regime, dict):
+        label = regime.get("regime_label") or regime.get("current_regime")
+        return str(label).capitalize() if label else "Unknown"
+    if isinstance(regime, str):
+        return regime.capitalize()
     if "current_regime" in data:
-        return data["current_regime"].capitalize()
+        return str(data["current_regime"]).capitalize()
     return "Unknown"
 
 

--- a/skills/exposure-coach/scripts/tests/test_calculate_exposure.py
+++ b/skills/exposure-coach/scripts/tests/test_calculate_exposure.py
@@ -12,6 +12,7 @@ from calculate_exposure import (
     determine_participation,
     determine_recommendation,
     extract_breadth_score,
+    extract_regime_name,
     extract_regime_score,
     extract_top_risk_score,
     extract_uptrend_score,
@@ -73,6 +74,30 @@ class TestExtractUptrendScore:
         score = extract_uptrend_score(data)
         assert score < 30
 
+    def test_nested_composite_score(self):
+        # uptrend-analyzer stores its score under "composite"
+        data = {"composite": {"composite_score": 72}}
+        assert extract_uptrend_score(data) == 72
+
+    def test_nested_composite_uptrend_pct(self):
+        data = {"composite": {"uptrend_pct": 60}}
+        assert extract_uptrend_score(data) >= 75
+
+    def test_flat_takes_priority_over_nested(self):
+        data = {"uptrend_score": 80, "composite": {"composite_score": 10}}
+        assert extract_uptrend_score(data) == 80
+
+    def test_non_dict_composite_ignored(self):
+        data = {"composite": "n/a", "uptrend_pct": 40}
+        score = extract_uptrend_score(data)
+        assert 50 <= score <= 80
+
+    def test_none_input(self):
+        assert extract_uptrend_score(None) is None
+
+    def test_empty_dict(self):
+        assert extract_uptrend_score({}) is None
+
 
 class TestExtractRegimeScore:
     """Tests for regime score extraction."""
@@ -92,6 +117,58 @@ class TestExtractRegimeScore:
     def test_direct_regime_score(self):
         data = {"regime_score": 65}
         assert extract_regime_score(data) == 65
+
+    def test_nested_regime_dict_current_regime(self):
+        # macro-regime-detector emits regime as a nested object
+        data = {"regime": {"current_regime": "Broadening"}}
+        assert extract_regime_score(data) == 80
+
+    def test_nested_regime_dict_unknown_defaults_50(self):
+        data = {"regime": {"current_regime": "Sideways"}}
+        assert extract_regime_score(data) == 50
+
+    def test_nested_regime_dict_no_current_regime(self):
+        data = {"regime": {"regime_label": "Risk-On"}}
+        assert extract_regime_score(data) is None
+
+    def test_none_input(self):
+        assert extract_regime_score(None) is None
+
+    def test_empty_dict(self):
+        assert extract_regime_score({}) is None
+
+
+class TestExtractRegimeName:
+    """Tests for regime name extraction (incl. nested dict regression)."""
+
+    def test_flat_string_regime(self):
+        assert extract_regime_name({"regime": "broadening"}) == "Broadening"
+
+    def test_flat_current_regime(self):
+        assert extract_regime_name({"current_regime": "contraction"}) == "Contraction"
+
+    def test_nested_label_preferred(self):
+        data = {"regime": {"regime_label": "Risk-On", "current_regime": "broadening"}}
+        assert extract_regime_name(data) == "Risk-on"
+
+    def test_nested_current_regime_fallback(self):
+        data = {"regime": {"current_regime": "transitional"}}
+        assert extract_regime_name(data) == "Transitional"
+
+    def test_nested_empty_dict_returns_unknown(self):
+        assert extract_regime_name({"regime": {}}) == "Unknown"
+
+    def test_dict_input_does_not_raise(self):
+        # Regression: previously data["regime"].capitalize() raised on dict
+        data = {"regime": {"current_regime": "broadening"}}
+        result = extract_regime_name(data)
+        assert isinstance(result, str)
+
+    def test_none_input(self):
+        assert extract_regime_name(None) == "Unknown"
+
+    def test_empty_dict(self):
+        assert extract_regime_name({}) == "Unknown"
 
 
 class TestExtractTopRiskScore:


### PR DESCRIPTION
## Summary

`exposure-coach`'s `calculate_exposure.py` only parsed the **flat** input shape from upstream skills. But:

- **uptrend-analyzer** nests its score under a `composite` object (`{"composite": {"composite_score": N}}`)
- **macro-regime-detector** emits `regime` as a nested object (`{"regime": {"current_regime": ..., "regime_label": ...}}`)

So exposure-coach silently dropped those upstream scores. Worse, `extract_regime_name` did `data["regime"].capitalize()` which **raised `AttributeError` on dict input**.

## Changes

- `extract_uptrend_score`: read `composite.composite_score`, else `composite.uptrend_pct` via a shared `_uptrend_pct_to_score` helper (de-duplicates the pct→score ladder).
- `extract_regime_score`: read `regime.current_regime` when `regime` is a dict.
- `extract_regime_name`: prefer `regime.regime_label`, fall back to `regime.current_regime`; never `.capitalize()` a dict.
- Flat legacy shapes (`uptrend_score` / `uptrend_pct` / `regime` string / `current_regime`) are **unchanged — fully backward compatible**.
- Added full test coverage including `extract_regime_name` (previously **not imported/tested at all**) and an explicit dict-input regression test.

## Why this PR exists (decomposition)

This is **decomposed from the obsolete stacked PR #83** (auto skill-improvement loop on a stale base, now `CONFLICTING`). PR #83's diff did not apply to current `main` (which diverged via the #84–#91 rollup), so this is a clean **re-implementation of the intent** against current `main`, isolated to the exposure-coach files only. None of PR #83's obsolete skills-index parallel implementation is included.

## Test plan

- [x] `uv run --extra dev pytest skills/exposure-coach/scripts/tests/ -v` → **74 passed**
- [x] `ruff check` + `ruff format --check` clean
- [x] pre-commit hooks pass on commit
- Backward-compat assertions retained: existing flat-shape tests unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)