### PR TITLE
docs(breadth-chart-analyst): use skill-relative paths for asset references

### DIFF
--- a/skills/breadth-chart-analyst/SKILL.md
+++ b/skills/breadth-chart-analyst/SKILL.md
@@ -222,8 +222,8 @@ This reference contains detailed guidance on:
 To understand the chart format and visual elements, review the sample charts included in this skill:
 
 ```
-View: skills/breadth-chart-analyst/assets/SP500_Breadth_Index_200MA_8MA.jpeg
-View: skills/breadth-chart-analyst/assets/US_Stock_Market_Uptrend_Ratio.jpeg
+View: assets/SP500_Breadth_Index_200MA_8MA.jpeg
+View: assets/US_Stock_Market_Uptrend_Ratio.jpeg
 ```
 
 These samples demonstrate:
@@ -495,7 +495,7 @@ Address any conflicts between charts and explain resolution.
 Create a comprehensive markdown report using the template structure:
 
 ```
-Read and use as template: skills/breadth-chart-analyst/assets/breadth_analysis_template.md
+Read and use as template: assets/breadth_analysis_template.md
 ```
 
 **IMPORTANT**: All analysis and output must be in English.


### PR DESCRIPTION
## Summary

`skills/breadth-chart-analyst/SKILL.md` was **internally inconsistent**: `references/...` lines used skill-relative paths, but the `View:` / `Read and use as template:` resource references used repo-root-relative `skills/breadth-chart-analyst/assets/...`. Every other skill (10+ surveyed: exposure-coach, macro-regime-detector, vcp-screener, market-breadth-analyzer, uptrend-analyzer, …) uses skill-relative paths exclusively, matching the self-contained skill-directory structure documented in `CLAUDE.md`.

## Changes

Relativize **only the 3 resource-reference lines** (L225, L226, L498) from `skills/breadth-chart-analyst/assets/...` → `assets/...`.

**Deliberately NOT changed:** the `python3 skills/breadth-chart-analyst/scripts/...` execution examples (6 occurrences). Those are run from the repo root and follow the cross-skill convention — rewriting them to `python3 scripts/...` would break execution context. This PR keeps resource references and execution commands as the two distinct categories they are.

## Why this PR exists (decomposition)

Decomposed from the obsolete stacked **PR #83** (auto skill-improvement loop, now `CONFLICTING`). This is exactly PR #83's intent for breadth-chart-analyst, applied cleanly to current `main`, scoped to this one doc-only file.

## Test plan

- [x] All 3 referenced files exist under the skill dir (`assets/SP500_Breadth_Index_200MA_8MA.jpeg`, `assets/US_Stock_Market_Uptrend_Ratio.jpeg`, `assets/breadth_analysis_template.md`)
- [x] Zero repo-root-relative resource refs remain (`grep -nE '^(View:|Read and use as template:) skills/breadth-chart-analyst/'` → 0)
- [x] All 6 `python3 skills/breadth-chart-analyst/scripts/` execution examples preserved
- [x] Diff = exactly 3 lines changed; pre-commit hooks pass

doc-only, no code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)