### PR TITLE
Follow-up B: skill-docs ownership guard + drift-gate parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,14 @@ jobs:
       - name: Skillset docs drift check
         run: python3 scripts/generate_skillset_docs.py --check
 
+      # 3a. Skill docs drift check: generator-owned pages (frontmatter
+      # `generated: true`) must match generator output, and every skill must
+      # have EN+JA pages. Hand-maintained pages (generated:false/absent or
+      # HAND_WRITTEN) are existence/marker-checked only — never content-
+      # compared, never reverted.
+      - name: Skill docs drift check
+        run: python3 scripts/generate_skill_docs.py --check
+
       # 3. Drift check: docs/{en,ja}/workflows.md must match what the
       # generator would produce from workflows/*.yaml. Catches manual edits
       # to the docs and stale docs after manifest changes.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,6 +98,19 @@ repos:
         files: '^(skillsets/.*\.yaml|scripts/generate_skillset_docs\.py|docs/(en|ja)/skillsets\.md)$'
         pass_filenames: false
 
+      - id: skill-docs-drift
+        name: Skill docs drift check (generator-owned pages only)
+        entry: python3 scripts/generate_skill_docs.py --check
+        language: system
+        # Content-compares ONLY generator-owned pages (frontmatter
+        # `generated: true`); hand-maintained pages (generated:false/absent
+        # or HAND_WRITTEN) are existence/marker-checked only, never reverted.
+        # Fire on every generator input: SKILL.md, references/scripts (resource
+        # list), CLAUDE.md (API/CLI parse), skill-packages/*.skill (download
+        # button), the generator, and the rendered docs themselves.
+        files: '^(skills/[^/]+/SKILL\.md|skills/[^/]+/references/.*|skills/[^/]+/scripts/.*\.py|scripts/generate_skill_docs\.py|CLAUDE\.md|skill-packages/.*\.skill|docs/(en|ja)/skills/[^/]+\.md)$'
+        pass_filenames: false
+
       - id: catalog-drift
         name: README + CLAUDE.md catalog drift check (regenerate from skills-index.yaml)
         entry: python3 scripts/generate_catalog_from_index.py --check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,19 @@ Generate documentation pages for the Jekyll site at `docs/`.
 # Also updates docs/en/skills/index.md and docs/ja/skills/index.md automatically
 python3 scripts/generate_skill_docs.py --skill <skill-name>
 
-# Regenerate all auto-generated pages
+# Regenerate all auto-generated pages (ONLY pages marked `generated: true`;
+# hand-maintained pages are refused — use --force to override, never in CI)
 python3 scripts/generate_skill_docs.py --overwrite
 ```
+
+> **Skill doc ownership / drift gate:** Committed `docs/{en,ja}/skills/*.md` are
+> source-of-truth. A page is generator-owned only if its frontmatter has
+> `generated: true`; `generated: false` or an absent marker (and any
+> `HAND_WRITTEN` skill) is hand-maintained and **protected** — `--overwrite`
+> refuses it (`--force` is the CI-forbidden escape hatch). The
+> `skill-docs-drift` pre-commit hook + CI step run `generate_skill_docs.py
+> --check`, which content-compares **only** `generated: true` pages and never
+> reverts hand-maintained docs. See `docs/README.md` → "Skill Doc Ownership".
 
 **Hand-written ★ guides (for key skills):**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,33 @@ Hand-written guides are marked with ★ in `en/skills/index.md` and `ja/skills/i
 
 ---
 
+## Skill Doc Ownership
+
+The committed `docs/{en,ja}/skills/*.md` pages are the **source of truth** — the
+generator does not own them retroactively (most pages, especially the JA
+translations, were hand-curated after first generation).
+
+- A page declares ownership via a `generated:` frontmatter key:
+  `generated: true` = generator-owned (drift-gated); `generated: false` **or the
+  key absent** = hand-maintained & protected. Skills in the generator's
+  `HAND_WRITTEN` set are always protected.
+- `generate_skill_docs.py --overwrite` **refuses** hand-maintained pages.
+  `--force` is the only override and is **never** used in CI/pre-commit.
+- The `skill-docs-drift` pre-commit hook + CI step run
+  `generate_skill_docs.py --check`, which content-compares **only**
+  `generated: true` pages and verifies every skill has EN+JA pages with a valid
+  marker. It **never** reverts hand-maintained pages.
+- A brand-new auto page created by the generator is stamped `generated: true`
+  (gate-owned until a human hand-edits it and flips the marker to `false` /
+  removes it). After adding or removing skills, re-run the generator to refresh
+  `nav_order` on generator-owned pages.
+
+> The unused per-skill `hand_written_doc` field in `skills-index.yaml` is
+> superseded by this per-page marker for doc ownership; reconciling/removing it
+> is a separate cleanup.
+
+---
+
 ## YAML Frontmatter Reference
 
 Every page requires YAML frontmatter. Fields vary by page type.

--- a/scripts/generate_skill_docs.py
+++ b/scripts/generate_skill_docs.py
@@ -101,6 +101,71 @@ def _split_sections(body: str) -> dict[str, str]:
 
 
 # ---------------------------------------------------------------------------
+# Doc-page ownership marker
+# ---------------------------------------------------------------------------
+#
+# A rendered page declares ownership via a `generated:` frontmatter key:
+#   generated: true   -> generator-owned (drift-checked, --overwrite may rewrite)
+#   generated: false  -> hand-maintained (protected; existence/marker only)
+#   (key absent)      -> hand-maintained (protected) -- the safe default
+# Hand-maintained pages are NEVER content-reverted by --check, and --overwrite
+# refuses them unless --force. See docs/README.md "Skill doc ownership".
+
+
+def _read_generated_marker(path: Path) -> str | None:
+    """Return the raw `generated:` value from a page's frontmatter.
+
+    Returns the stripped raw token (e.g. "true", "false", "maybe") if the key
+    is present in the leading YAML frontmatter, or ``None`` if the file is
+    missing/unreadable, has no frontmatter, or has no ``generated:`` key.
+
+    Uses a line scan rather than ``yaml.safe_load`` for the same reason
+    ``parse_skill_md`` keeps a manual fallback: page titles/descriptions can
+    contain unquoted colons that break a strict YAML load.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return None
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+    for line in parts[1].splitlines():
+        stripped = line.strip()
+        if stripped.startswith("generated:"):
+            return stripped.split(":", 1)[1].strip()
+    return None
+
+
+def _doc_is_generated(path: Path) -> bool | None:
+    """Ownership of a rendered page.
+
+    ``True``  -> generator-owned (literal ``generated: true``).
+    ``False`` -> explicitly hand-maintained (literal ``generated: false``).
+    ``None``  -> marker absent / file missing / malformed.
+
+    Callers treat both ``False`` and ``None`` as "protected"; only ``True``
+    opts a page into overwrite + content drift checking.
+    """
+    raw = _read_generated_marker(path)
+    if raw is None:
+        return None
+    if raw == "true":
+        return True
+    if raw == "false":
+        return False
+    return None
+
+
+def _marker_present_but_invalid(path: Path) -> bool:
+    """True if a `generated:` key is present but is neither `true` nor `false`."""
+    raw = _read_generated_marker(path)
+    return raw is not None and raw not in ("true", "false")
+
+
+# ---------------------------------------------------------------------------
 # CLAUDE.md API requirements parser
 # ---------------------------------------------------------------------------
 
@@ -344,6 +409,7 @@ parent: Skill Guides
 nav_order: {nav_order}
 lang_peer: /ja/skills/{skill_name}/
 permalink: /en/skills/{skill_name}/
+generated: true
 ---
 
 # {title}
@@ -446,6 +512,7 @@ parent: スキルガイド
 nav_order: {nav_order}
 lang_peer: /en/skills/{skill_name}/
 permalink: /ja/skills/{skill_name}/
+generated: true
 ---
 
 # {title}
@@ -527,6 +594,7 @@ parent: Skill Guides
 nav_order: {nav_order}
 lang_peer: /ja/skills/{skill_name}/
 permalink: /en/skills/{skill_name}/
+generated: true
 ---
 
 # {title}
@@ -667,6 +735,7 @@ parent: スキルガイド
 nav_order: {nav_order}
 lang_peer: /en/skills/{skill_name}/
 permalink: /ja/skills/{skill_name}/
+generated: true
 ---
 
 # {title}
@@ -1139,6 +1208,176 @@ def update_catalog_api_matrix(
 
 
 # ---------------------------------------------------------------------------
+# Ownership-aware write/check helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_nav_orders(skill_dirs: list[Path], overwrite: bool) -> dict[str, int]:
+    """Assign nav_order: hand-written keep 1-10, the rest start at NAV_ORDER_START.
+
+    Shared by the write path and ``--check`` so expected output cannot diverge
+    from what a real generation would write.
+    """
+    new_skills: list[str] = []
+    for d in skill_dirs:
+        if not d.is_dir() or not (d / "SKILL.md").exists():
+            continue
+        name = d.name
+        if name in HAND_WRITTEN and not overwrite:
+            continue
+        new_skills.append(name)
+    new_skills.sort()
+    return {name: NAV_ORDER_START + i for i, name in enumerate(new_skills)}
+
+
+def _render_skill_pages(
+    d: Path,
+    name: str,
+    nav_order: int,
+    api_reqs: dict,
+    cli_examples: dict,
+    skill_packages_dir: Path | None,
+    mode: str,
+) -> tuple[str, str]:
+    """Render (en, ja) page content exactly as the write loop would."""
+    skill_data = parse_skill_md(d / "SKILL.md")
+    api_info = api_reqs.get(name)
+    cli_example = cli_examples.get(name)
+    resources = _list_skill_resources(d)
+    if mode == "full":
+        en = generate_en_full_page(
+            name,
+            skill_data,
+            api_info,
+            cli_example,
+            nav_order,
+            resources,
+            skill_packages_dir=skill_packages_dir,
+        )
+        ja = generate_ja_full_page(
+            name,
+            skill_data,
+            api_info,
+            cli_example,
+            nav_order,
+            resources,
+            skill_packages_dir=skill_packages_dir,
+        )
+    else:
+        en = generate_en_page(
+            name,
+            skill_data,
+            api_info,
+            cli_example,
+            nav_order,
+            resources,
+            skill_packages_dir=skill_packages_dir,
+        )
+        ja = generate_ja_page(
+            name,
+            skill_data,
+            api_info,
+            nav_order,
+            skill_packages_dir=skill_packages_dir,
+        )
+    return en, ja
+
+
+def _may_write(path: Path, name: str, args: argparse.Namespace) -> bool:
+    """Per-page write decision (EN and JA decided independently).
+
+    HAND_WRITTEN ★ guides are always protected (missing OR existing) unless
+    --force; this preserves the existing ``test_skips_hand_written`` contract.
+    Brand-new (non-HAND_WRITTEN) pages are created. Existing pages are only
+    rewritten when --force, or under --overwrite when the page is explicitly
+    generator-owned (``generated: true``). Hand-maintained pages
+    (generated:false/absent) are never destroyed without --force.
+    """
+    if name in HAND_WRITTEN and not args.force:
+        return False
+    if not path.exists():
+        return True
+    if not args.overwrite:
+        return False
+    if args.force:
+        return True
+    return _doc_is_generated(path) is True
+
+
+def _check_drift(
+    skill_dirs: list[Path],
+    en_dir: Path,
+    ja_dir: Path,
+    api_reqs: dict,
+    cli_examples: dict,
+    skill_packages_dir: Path | None,
+    args: argparse.Namespace,
+) -> int:
+    """Pure read/compare drift gate (no mkdir, no writes, no index/catalog).
+
+    Mirrors the sibling generators (generate_workflow_docs / generate_skillset_docs):
+    print ``DRIFT:``/``OK:`` to stderr and return 1 iff any drift. Existence +
+    marker-validity are checked for every page; CONTENT is compared ONLY for
+    pages explicitly marked ``generated: true``. Hand-maintained pages
+    (generated:false/absent/HAND_WRITTEN) are never content-compared and never
+    reverted.
+    """
+    nav_orders = _compute_nav_orders(skill_dirs, overwrite=False)
+    drift = False
+    for d in skill_dirs:
+        if not d.is_dir() or not (d / "SKILL.md").exists():
+            continue
+        name = d.name
+        en_path = en_dir / f"{name}.md"
+        ja_path = ja_dir / f"{name}.md"
+
+        # 1. Existence: every skill must have EN + JA pages.
+        for p in (en_path, ja_path):
+            if not p.is_file():
+                print(f"DRIFT: {p} does not exist", file=sys.stderr)
+                drift = True
+
+        # 2. Marker validity: present-but-invalid generated: value.
+        for p in (en_path, ja_path):
+            if p.is_file() and _marker_present_but_invalid(p):
+                print(
+                    f"DRIFT: {p} has invalid 'generated:' marker (must be true or false)",
+                    file=sys.stderr,
+                )
+                drift = True
+
+        # 3. Content compare ONLY generator-owned (generated: true) pages.
+        # HAND_WRITTEN is always protected regardless of marker (a generated:
+        # true stamped via --force must NOT become drift-checked afterwards).
+        en_owned = (
+            name not in HAND_WRITTEN and en_path.is_file() and _doc_is_generated(en_path) is True
+        )
+        ja_owned = (
+            name not in HAND_WRITTEN and ja_path.is_file() and _doc_is_generated(ja_path) is True
+        )
+        if not (en_owned or ja_owned):
+            continue
+        nav_order = nav_orders.get(name, NAV_ORDER_START)
+        expected_en, expected_ja = _render_skill_pages(
+            d, name, nav_order, api_reqs, cli_examples, skill_packages_dir, args.mode
+        )
+        if en_owned:
+            if en_path.read_text(encoding="utf-8") != expected_en.rstrip("\n") + "\n":
+                print(f"DRIFT: {en_path} differs from regenerated output", file=sys.stderr)
+                drift = True
+            else:
+                print(f"OK: {en_path} matches", file=sys.stderr)
+        if ja_owned:
+            if ja_path.read_text(encoding="utf-8") != expected_ja.rstrip("\n") + "\n":
+                print(f"DRIFT: {ja_path} differs from regenerated output", file=sys.stderr)
+                drift = True
+            else:
+                print(f"OK: {ja_path} matches", file=sys.stderr)
+
+    return 1 if drift else 0
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -1168,6 +1407,17 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help='Category for catalog insertion, e.g. "4. Portfolio & Execution"',
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite hand-maintained pages (generated:false/absent or HAND_WRITTEN). "
+        "Never used in CI/pre-commit.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Compare regenerated output against on-disk files; exit non-zero if they differ.",
+    )
     args = parser.parse_args(argv)
 
     # Parse CLAUDE.md
@@ -1184,21 +1434,19 @@ def main(argv: list[str] | None = None) -> int:
 
     en_dir = args.docs_dir / "en" / "skills"
     ja_dir = args.docs_dir / "ja" / "skills"
+
+    # --check is a pure read/compare gate: return BEFORE any mkdir/write so it
+    # never touches the tree or runs the index/catalog updaters.
+    if args.check:
+        return _check_drift(
+            skill_dirs, en_dir, ja_dir, api_reqs, cli_examples, skill_packages_dir, args
+        )
+
     en_dir.mkdir(parents=True, exist_ok=True)
     ja_dir.mkdir(parents=True, exist_ok=True)
 
-    # Assign nav_orders: existing hand-written keep 1-10, new start at 11+
-    new_skills = []
-    for d in skill_dirs:
-        if not d.is_dir() or not (d / "SKILL.md").exists():
-            continue
-        name = d.name
-        if name in HAND_WRITTEN and not args.overwrite:
-            continue
-        new_skills.append(name)
-
-    new_skills.sort()
-    nav_orders = {name: NAV_ORDER_START + i for i, name in enumerate(new_skills)}
+    # Assign nav_orders (shared with --check via _compute_nav_orders).
+    nav_orders = _compute_nav_orders(skill_dirs, args.overwrite)
 
     generated_en = 0
     generated_ja = 0
@@ -1209,70 +1457,39 @@ def main(argv: list[str] | None = None) -> int:
             continue
 
         name = d.name
-
-        if name in HAND_WRITTEN and not args.overwrite:
-            skipped += 1
-            continue
-
         en_path = en_dir / f"{name}.md"
         ja_path = ja_dir / f"{name}.md"
 
-        if en_path.exists() and not args.overwrite:
+        # Per-page ownership guard (EN and JA decided independently).
+        write_en = _may_write(en_path, name, args)
+        write_ja = _may_write(ja_path, name, args)
+        if not write_en and not write_ja:
             skipped += 1
             continue
 
-        skill_data = parse_skill_md(d / "SKILL.md")
-        api_info = api_reqs.get(name)
-        cli_example = cli_examples.get(name)
         nav_order = nav_orders.get(name, NAV_ORDER_START)
-        resources = _list_skill_resources(d)
+        en_content, ja_content = _render_skill_pages(
+            d, name, nav_order, api_reqs, cli_examples, skill_packages_dir, args.mode
+        )
 
-        if args.mode == "full":
-            # Generate 10-section skeleton pages
-            en_content = generate_en_full_page(
-                name,
-                skill_data,
-                api_info,
-                cli_example,
-                nav_order,
-                resources,
-                skill_packages_dir=skill_packages_dir,
-            )
-            ja_content = generate_ja_full_page(
-                name,
-                skill_data,
-                api_info,
-                cli_example,
-                nav_order,
-                resources,
-                skill_packages_dir=skill_packages_dir,
-            )
-        else:
-            # Generate 6-section auto pages
-            en_content = generate_en_page(
-                name,
-                skill_data,
-                api_info,
-                cli_example,
-                nav_order,
-                resources,
-                skill_packages_dir=skill_packages_dir,
-            )
-            ja_content = generate_ja_page(
-                name,
-                skill_data,
-                api_info,
-                nav_order,
-                skill_packages_dir=skill_packages_dir,
-            )
+        if write_en:
+            en_path.write_text(en_content, encoding="utf-8")
+            generated_en += 1
+        elif args.overwrite:
+            print(f"  Protected, EN skipped: {name} (use --force)", file=sys.stderr)
 
-        en_path.write_text(en_content, encoding="utf-8")
-        generated_en += 1
+        if write_ja:
+            ja_path.write_text(ja_content, encoding="utf-8")
+            generated_ja += 1
+        elif args.overwrite:
+            print(f"  Protected, JA skipped: {name} (use --force)", file=sys.stderr)
 
-        ja_path.write_text(ja_content, encoding="utf-8")
-        generated_ja += 1
-
-        print(f"  Generated: {name} (EN + JA, mode={args.mode})")
+        wrote = []
+        if write_en:
+            wrote.append("EN")
+        if write_ja:
+            wrote.append("JA")
+        print(f"  Generated: {name} ({' + '.join(wrote)}, mode={args.mode})")
 
     print(f"\nDone: {generated_en} EN + {generated_ja} JA generated, {skipped} skipped")
 

--- a/scripts/tests/test_generate_skill_docs.py
+++ b/scripts/tests/test_generate_skill_docs.py
@@ -12,8 +12,10 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from generate_skill_docs import (
     HAND_WRITTEN,
+    _doc_is_generated,
     _extract_catalog_slugs,
     _generate_buttons,
+    _marker_present_but_invalid,
     _slugify,
     _split_sections,
     _title_case,
@@ -393,12 +395,16 @@ class TestMain:
         # backtest-expert should not be generated (hand-written)
         assert not (docs_dir / "en" / "skills" / "backtest-expert.md").exists()
 
-    def test_overwrite_regenerates(self, tmp_skill, tmp_claude_md):
+    def test_overwrite_skips_protected_absent_marker(self, tmp_skill, tmp_claude_md):
+        # BEHAVIOR CHANGE (Follow-up B): a page with no `generated:` marker is
+        # hand-maintained/protected. --overwrite (without --force) must NOT
+        # destroy it. (Previously this test asserted --overwrite regenerated a
+        # markerless page; the ownership guard intentionally flips that.)
         docs_dir = tmp_skill / "docs"
         en_path = docs_dir / "en" / "skills" / "test-skill.md"
         en_path.parent.mkdir(parents=True)
         (docs_dir / "ja" / "skills").mkdir(parents=True)
-        en_path.write_text("old content")
+        en_path.write_text("old hand-maintained content")
 
         main(
             [
@@ -411,8 +417,7 @@ class TestMain:
                 "--overwrite",
             ]
         )
-        assert "old content" not in en_path.read_text()
-        assert "Test Skill" in en_path.read_text()
+        assert en_path.read_text() == "old hand-maintained content"
 
     def test_main_updates_index(self, tmp_skill, tmp_claude_md):
         docs_dir = tmp_skill / "docs"
@@ -464,6 +469,233 @@ class TestMain:
             ]
         )
         assert not (docs_dir / "en" / "skills" / "empty-skill.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: ownership guard + --check (Follow-up B)
+# ---------------------------------------------------------------------------
+
+
+def _base_args(tmp_skill, tmp_claude_md):
+    return [
+        "--skills-dir",
+        str(tmp_skill / "skills"),
+        "--docs-dir",
+        str(tmp_skill / "docs"),
+        "--claude-md",
+        str(tmp_claude_md),
+    ]
+
+
+class TestOwnershipGuardAndCheck:
+    def test_new_page_stamped_generated_true(self, tmp_skill, tmp_claude_md):
+        docs_dir = tmp_skill / "docs"
+        (docs_dir / "en" / "skills").mkdir(parents=True)
+        (docs_dir / "ja" / "skills").mkdir(parents=True)
+        main(_base_args(tmp_skill, tmp_claude_md))
+        en = docs_dir / "en" / "skills" / "test-skill.md"
+        ja = docs_dir / "ja" / "skills" / "test-skill.md"
+        assert _doc_is_generated(en) is True
+        assert _doc_is_generated(ja) is True
+
+    def test_overwrite_skips_protected_generated_false(self, tmp_skill, tmp_claude_md):
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "test-skill.md"
+        en.parent.mkdir(parents=True)
+        (docs_dir / "ja" / "skills").mkdir(parents=True)
+        body = "---\ntitle: x\ngenerated: false\n---\nhand body\n"
+        en.write_text(body)
+        main(_base_args(tmp_skill, tmp_claude_md) + ["--overwrite"])
+        assert en.read_text() == body
+
+    def test_overwrite_rewrites_generated_true(self, tmp_skill, tmp_claude_md):
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "test-skill.md"
+        en.parent.mkdir(parents=True)
+        (docs_dir / "ja" / "skills").mkdir(parents=True)
+        en.write_text("---\ntitle: x\ngenerated: true\n---\nstale generated body\n")
+        main(_base_args(tmp_skill, tmp_claude_md) + ["--overwrite"])
+        out = en.read_text()
+        assert "stale generated body" not in out
+        assert "Test Skill" in out
+        assert _doc_is_generated(en) is True
+
+    def test_force_overrides_protection(self, tmp_skill, tmp_claude_md):
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "test-skill.md"
+        en.parent.mkdir(parents=True)
+        (docs_dir / "ja" / "skills").mkdir(parents=True)
+        en.write_text("hand body, no marker")
+        main(_base_args(tmp_skill, tmp_claude_md) + ["--overwrite", "--force"])
+        out = en.read_text()
+        assert "hand body, no marker" not in out
+        assert "Test Skill" in out
+
+    def test_hand_written_missing_not_generated_normal(self, tmp_skill, tmp_claude_md):
+        hw = tmp_skill / "skills" / "backtest-expert"
+        hw.mkdir()
+        (hw / "SKILL.md").write_text("---\nname: backtest-expert\ndescription: t\n---\n")
+        docs_dir = tmp_skill / "docs"
+        (docs_dir / "en" / "skills").mkdir(parents=True)
+        (docs_dir / "ja" / "skills").mkdir(parents=True)
+        main(_base_args(tmp_skill, tmp_claude_md))
+        assert not (docs_dir / "en" / "skills" / "backtest-expert.md").exists()
+
+    def test_hand_written_missing_generated_with_force(self, tmp_skill, tmp_claude_md):
+        hw = tmp_skill / "skills" / "backtest-expert"
+        hw.mkdir()
+        (hw / "SKILL.md").write_text("---\nname: backtest-expert\ndescription: t\n---\n")
+        docs_dir = tmp_skill / "docs"
+        (docs_dir / "en" / "skills").mkdir(parents=True)
+        (docs_dir / "ja" / "skills").mkdir(parents=True)
+        main(_base_args(tmp_skill, tmp_claude_md) + ["--force"])
+        assert (docs_dir / "en" / "skills" / "backtest-expert.md").exists()
+
+    def test_hand_written_existing_protected_under_overwrite(self, tmp_skill, tmp_claude_md):
+        hw = tmp_skill / "skills" / "backtest-expert"
+        hw.mkdir()
+        (hw / "SKILL.md").write_text("---\nname: backtest-expert\ndescription: t\n---\n")
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "backtest-expert.md"
+        en.parent.mkdir(parents=True)
+        (docs_dir / "ja" / "skills").mkdir(parents=True)
+        en.write_text("hand-written guide body")
+        main(_base_args(tmp_skill, tmp_claude_md) + ["--overwrite"])
+        assert en.read_text() == "hand-written guide body"
+
+    def test_mixed_ownership_en_owned_ja_protected(self, tmp_skill, tmp_claude_md):
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "test-skill.md"
+        ja = docs_dir / "ja" / "skills" / "test-skill.md"
+        en.parent.mkdir(parents=True)
+        ja.parent.mkdir(parents=True)
+        en.write_text("---\ntitle: x\ngenerated: true\n---\nstale en\n")
+        ja_body = "---\ntitle: x\n---\n# 手動翻訳された日本語ページ\n"
+        ja.write_text(ja_body)
+        main(_base_args(tmp_skill, tmp_claude_md) + ["--overwrite"])
+        assert "stale en" not in en.read_text()
+        assert "Test Skill" in en.read_text()
+        assert ja.read_text() == ja_body  # JA hand-translation byte-unchanged
+
+    def test_brand_new_one_side_non_hand_written(self, tmp_skill, tmp_claude_md):
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "test-skill.md"
+        ja = docs_dir / "ja" / "skills" / "test-skill.md"
+        en.parent.mkdir(parents=True)
+        ja.parent.mkdir(parents=True)
+        ja_body = "---\ntitle: x\n---\n# 既存の手動翻訳\n"
+        ja.write_text(ja_body)
+        # EN missing, JA exists & protected, NORMAL run (no --overwrite)
+        main(_base_args(tmp_skill, tmp_claude_md))
+        assert en.exists()
+        assert _doc_is_generated(en) is True
+        assert ja.read_text() == ja_body  # JA untouched
+
+    def test_check_protects_hand_written_even_with_generated_true(self, tmp_skill, tmp_claude_md):
+        # A HAND_WRITTEN page is ALWAYS protected, even if it carries
+        # generated: true (e.g. stamped earlier via --force). --check must NOT
+        # content-compare it.
+        hw = tmp_skill / "skills" / "backtest-expert"
+        hw.mkdir()
+        (hw / "SKILL.md").write_text("---\nname: backtest-expert\ndescription: t\n---\n")
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "backtest-expert.md"
+        ja = docs_dir / "ja" / "skills" / "backtest-expert.md"
+        en.parent.mkdir(parents=True)
+        ja.parent.mkdir(parents=True)
+        en.write_text("---\ntitle: x\ngenerated: true\n---\nwildly divergent hand body\n")
+        ja.write_text("---\ntitle: x\ngenerated: true\n---\n手動の全く違う本文\n")
+        # tmp_skill always creates skills/test-skill too; give it protected
+        # pages so existence checks don't trip (focus is the HW assertion).
+        (docs_dir / "en" / "skills" / "test-skill.md").write_text("protected en\n")
+        (docs_dir / "ja" / "skills" / "test-skill.md").write_text("protected ja\n")
+        rc = main(_base_args(tmp_skill, tmp_claude_md) + ["--check"])
+        assert rc == 0
+
+    def test_check_passes_when_protected_body_differs(self, tmp_skill, tmp_claude_md):
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "test-skill.md"
+        ja = docs_dir / "ja" / "skills" / "test-skill.md"
+        en.parent.mkdir(parents=True)
+        ja.parent.mkdir(parents=True)
+        en.write_text("wildly different EN, no marker\n")
+        ja.write_text("全く違う日本語、マーカーなし\n")
+        rc = main(_base_args(tmp_skill, tmp_claude_md) + ["--check"])
+        assert rc == 0
+
+    def test_check_fails_on_generated_true_drift(self, tmp_skill, tmp_claude_md, capsys):
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "test-skill.md"
+        ja = docs_dir / "ja" / "skills" / "test-skill.md"
+        en.parent.mkdir(parents=True)
+        ja.parent.mkdir(parents=True)
+        en.write_text("---\ntitle: x\ngenerated: true\n---\nstale owned body\n")
+        ja.write_text("---\ntitle: x\n---\nhand ja\n")
+        rc = main(_base_args(tmp_skill, tmp_claude_md) + ["--check"])
+        assert rc == 1
+        assert "DRIFT:" in capsys.readouterr().err
+
+    def test_check_fails_on_missing_page(self, tmp_skill, tmp_claude_md, capsys):
+        docs_dir = tmp_skill / "docs"
+        (docs_dir / "en" / "skills").mkdir(parents=True)
+        (docs_dir / "ja" / "skills").mkdir(parents=True)
+        # neither EN nor JA exists for test-skill
+        rc = main(_base_args(tmp_skill, tmp_claude_md) + ["--check"])
+        assert rc == 1
+        assert "does not exist" in capsys.readouterr().err
+
+    def test_check_reports_invalid_marker(self, tmp_skill, tmp_claude_md, capsys):
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "test-skill.md"
+        ja = docs_dir / "ja" / "skills" / "test-skill.md"
+        en.parent.mkdir(parents=True)
+        ja.parent.mkdir(parents=True)
+        en.write_text("---\ntitle: x\ngenerated: maybe\n---\nbody\n")
+        ja.write_text("---\ntitle: x\n---\nbody\n")
+        rc = main(_base_args(tmp_skill, tmp_claude_md) + ["--check"])
+        assert rc == 1
+        assert "invalid 'generated:' marker" in capsys.readouterr().err
+
+    def test_check_passes_clean_after_generate(self, tmp_skill, tmp_claude_md):
+        docs_dir = tmp_skill / "docs"
+        (docs_dir / "en" / "skills").mkdir(parents=True)
+        (docs_dir / "ja" / "skills").mkdir(parents=True)
+        main(_base_args(tmp_skill, tmp_claude_md))
+        rc = main(_base_args(tmp_skill, tmp_claude_md) + ["--check"])
+        assert rc == 0
+
+    def test_check_performs_no_writes(self, tmp_skill, tmp_claude_md):
+        docs_dir = tmp_skill / "docs"
+        en = docs_dir / "en" / "skills" / "test-skill.md"
+        ja = docs_dir / "ja" / "skills" / "test-skill.md"
+        en.parent.mkdir(parents=True)
+        ja.parent.mkdir(parents=True)
+        en.write_text("protected en\n")
+        ja.write_text("protected ja\n")
+        before = (en.read_text(), ja.read_text(), en.stat().st_mtime_ns)
+        main(_base_args(tmp_skill, tmp_claude_md) + ["--check"])
+        assert (en.read_text(), ja.read_text(), en.stat().st_mtime_ns) == before
+        # No index/catalog created as a side effect of --check
+        assert not (docs_dir / "en" / "skills" / "index.md").exists()
+
+    def test_doc_is_generated_helper(self, tmp_path):
+        true_p = tmp_path / "t.md"
+        true_p.write_text("---\ntitle: a: b\ngenerated: true\n---\nx")
+        false_p = tmp_path / "f.md"
+        false_p.write_text("---\ngenerated: false\n---\nx")
+        absent_p = tmp_path / "a.md"
+        absent_p.write_text("---\ntitle: x\n---\nx")
+        invalid_p = tmp_path / "i.md"
+        invalid_p.write_text("---\ngenerated: maybe\n---\nx")
+        missing_p = tmp_path / "nope.md"
+        assert _doc_is_generated(true_p) is True
+        assert _doc_is_generated(false_p) is False
+        assert _doc_is_generated(absent_p) is None
+        assert _doc_is_generated(invalid_p) is None
+        assert _doc_is_generated(missing_p) is None
+        assert _marker_present_but_invalid(invalid_p) is True
+        assert _marker_present_but_invalid(true_p) is False
+        assert _marker_present_but_invalid(absent_p) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The committed `docs/{en,ja}/skills/*.md` have **diverged from generator output by design** — ~50/55 JA pages are real hand-translations (the generator only emits an English stub), and several EN pages carry hand-authored content. `generate_skill_docs.py` was also the **only** generated-docs family with **no drift gate** (workflows / skillsets / catalog / navigator-snapshot all have `--check` + pre-commit + CI). An accidental `--overwrite` silently destroyed ~11k lines of curated work across 110 files.

**This is an ownership-guard PR, not a docs regeneration. Zero doc-body changes.**

## What changed

- **Per-page frontmatter marker `generated:`**
  - `generated: true` → generator-owned (drift-checked; `--overwrite` may rewrite)
  - `generated: false` / key absent → hand-maintained & **protected** (safe default — absence is the protection, so the diff stays minimal)
  - Skills in the `HAND_WRITTEN` set are **always** protected, regardless of marker
  - Initial generator-owned set is **empty** (no existing page is stamped) → the gate is forward-looking and trivially green on the current tree
- The 4 frontmatter emitters stamp `generated: true` on **newly created** pages (gate-owned until a human hand-edits and flips/removes the marker).
- **Per-page write guard `_may_write()`** (shared by the loop and `--skill`): EN and JA decided **independently**, `HAND_WRITTEN`-and-not-`--force` checked first. `--overwrite` refuses hand-maintained pages; `--force` is the only override and is **never** used in CI/pre-commit. This closes the EN-owned / JA-hand-translation destruction hole.
- **New `--check` mode** mirrors `generate_skillset_docs.py`: pure read/compare (returns **before** any `mkdir`/write; never runs the index/catalog updaters). Validates EN+JA existence + marker validity for every skill, and content-compares **only** generator-owned (`generated: true`, non-`HAND_WRITTEN`) pages. It **never** reverts hand-maintained docs.
- **Full parity**: `skill-docs-drift` pre-commit hook (`files:` covers `SKILL.md`, references, scripts, `CLAUDE.md`, `skill-packages`, rendered docs) + a CI step in the *Metadata + Workflow checks* job.
- Policy documented in `docs/README.md` ("Skill Doc Ownership") and `CLAUDE.md` — both **outside** the catalog sentinel region (`catalog-drift` unaffected).

## ⚠️ Intentional behavior change (test contract flip)

`test_overwrite_regenerates` is replaced by `test_overwrite_skips_protected_absent_marker`. **A markerless page is now hand-maintained/protected**, so `--overwrite` (without `--force`) must **NOT** destroy it — the inverse of the old contract, and the entire point of this PR. Reviewers should expect this test delta.

## Verification

| Check | Result |
|---|---|
| `generate_skill_docs.py --check` (current tree) | **exit 0**, zero doc churn |
| `--overwrite` alone | **0 files changed** (all protected); `--overwrite --force` → rewrites (escape hatch works) |
| `uv run pytest -q` | **3196 passed, 17 skipped, 0 failed** (generator suite: 78 passed) |
| `pre-commit run --all-files` | all hooks pass (incl. new `skill-docs-drift`, `catalog-drift`, `docs-completeness`) |
| `scripts/run_all_tests.sh` | **46/46 passed** |
| Diff scope | **6 files only**; `docs/{en,ja}/skills`, `skill-catalog.md`, `skills-index.yaml` byte-unchanged |

Boundary tests lock the invariants: protected page with wildly different body → `--check` passes; `HAND_WRITTEN` + `generated:true` → still protected (not content-compared); mixed ownership (EN owned + JA hand) under `--overwrite` → EN rewritten, JA byte-unchanged; `--check` performs no writes.

Standalone follow-up (not tied to #80); completes the generated-docs drift-gate parity work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
