### PR TITLE
Follow-up F: correct portfolio-manager input label + README Alpaca/CSV wording (no integration change)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -43,7 +43,7 @@ English README is available at [`README.md`](README.md).
 | 目的 | ワークフロー | 主要スキル | API プロファイル |
 | --- | --- | --- | --- |
 | 毎朝15分で相場を確認したい | [`market-regime-daily`](workflows/market-regime-daily.yaml) | market-breadth-analyzer, uptrend-analyzer, exposure-coach | API なし可 |
-| 長期ポートフォリオを週次で見直したい | [`core-portfolio-weekly`](workflows/core-portfolio-weekly.yaml) | portfolio-manager, kanchi-dividend-review-monitor, trader-memory-core | Alpaca（または手動 CSV） |
+| 長期ポートフォリオを週次で見直したい | [`core-portfolio-weekly`](workflows/core-portfolio-weekly.yaml) | portfolio-manager, kanchi-dividend-review-monitor, trader-memory-core | Alpaca 必須。手動 CSV は劣後フォールバック |
 | 相場環境が許すときだけスイング候補を探す | [`swing-opportunity-daily`](workflows/swing-opportunity-daily.yaml) | vcp-screener, technical-analyst, position-sizer | FMP 必須 |
 | 約定後にトレードを記録して学ぶ | [`trade-memory-loop`](workflows/trade-memory-loop.yaml) | trader-memory-core, signal-postmortem | API なし可 |
 | 月次でパフォーマンスとルールを見直す | [`monthly-performance-review`](workflows/monthly-performance-review.yaml) | trader-memory-core, signal-postmortem, backtest-expert | API なし可 |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ New users should start with one of these operational workflows. Each link points
 | Goal | Workflow | Anchor Skills | API Profile |
 | --- | --- | --- | --- |
 | 15-minute daily market check | [`market-regime-daily`](workflows/market-regime-daily.yaml) | market-breadth-analyzer, uptrend-analyzer, exposure-coach | No API for basic path |
-| Weekly long-term portfolio review | [`core-portfolio-weekly`](workflows/core-portfolio-weekly.yaml) | portfolio-manager, kanchi-dividend-review-monitor, trader-memory-core | Alpaca optional/required by input |
+| Weekly long-term portfolio review | [`core-portfolio-weekly`](workflows/core-portfolio-weekly.yaml) | portfolio-manager, kanchi-dividend-review-monitor, trader-memory-core | Alpaca required; manual CSV is a degraded fallback |
 | Find swing candidates only when risk is allowed | [`swing-opportunity-daily`](workflows/swing-opportunity-daily.yaml) | vcp-screener, technical-analyst, position-sizer | FMP for screeners |
 | Record and learn from every closed trade | [`trade-memory-loop`](workflows/trade-memory-loop.yaml) | trader-memory-core, signal-postmortem | No API for manual path |
 | Review monthly performance and adjust rules | [`monthly-performance-review`](workflows/monthly-performance-review.yaml) | trader-memory-core, signal-postmortem, backtest-expert | No API for manual path |

--- a/skills-index.yaml
+++ b/skills-index.yaml
@@ -715,7 +715,7 @@ skills:
     requirement: required
     note: Alpaca brokerage MCP/API
   inputs:
-  - alpaca_holdings_or_csv
+  - alpaca_holdings
   outputs:
   - allocation_report
   - rebalance_actions


### PR DESCRIPTION
## Summary

`skills-index.yaml` had `portfolio-manager` `inputs: [alpaca_holdings_or_csv]` and README described the `core-portfolio-weekly` API profile as "Alpaca optional/required by input" — both imply a CSV input path that **has no code**.

**Label + prose only. 3 files. No `integrations` change, no behavior/Navigator change, no catalog/snapshot regeneration, no test changes.**

## Verified ground truth

- No script parses CSV — `check_alpaca_connection.py` is Alpaca-only; no holdings-file argument anywhere.
- `references/alpaca-mcp-setup.md` shows a CSV *example* under "Alternative: Manual Data Entry" with explicit limitations.
- `SKILL.md`: manual entry is "less ideal"; analysis is "based on actual current positions **rather than manually entered data**".
- **Verdict:** the CSV path is a degraded human-paste fallback (a supported workflow note), **not a machine-readable integration**.

> The CSV fallback is a supported workflow note, not an integration model; `alpaca` stays `required` (truthful, and it preserves the Navigator's no-API exclusion of `core-portfolio-weekly`).

`holdings_csv optional` and demoting `alpaca` were **deliberately rejected**: there is no code path, and either change would re-skew the Navigator/catalog or make the Navigator wrongly advertise core-portfolio as no-API.

## Changes

| File | Change |
|---|---|
| `skills-index.yaml` | `portfolio-manager` `inputs: [alpaca_holdings_or_csv]` → `[alpaca_holdings]` (integrations/summary byte-unchanged) |
| `README.md` | `core-portfolio-weekly` API cell → `Alpaca required; manual CSV is a degraded fallback` (outside catalog sentinels) |
| `README.ja.md` | same cell → `Alpaca 必須。手動 CSV は劣後フォールバック` (EN/JA now consistent, matches SSoT + Navigator no-API exclusion) |

## Verification

| Check | Result |
|---|---|
| `git grep alpaca_holdings_or_csv` | no output |
| `generate_catalog_from_index.py --check` | pass, **no diff** (inputs rename does not propagate) |
| `build_snapshot.py --check` | pass, **no diff** |
| `validate_skills_index.py --strict-workflows --strict-metadata` / `validate_skillsets.py` | pass |
| `test_recommend.py` | **63 passed** — no-API CONTRACT (Q3/Q4 `no_api_path=False`, `test_no_api_excludes_alpaca_required_core_portfolio`) unchanged |
| `uv run pytest -q` | **3283 passed, 17 skipped, 0 failed** |
| `pre-commit run --all-files` | all hooks pass (no regeneration) |
| `scripts/run_all_tests.sh` | **46/46 passed**, 2 known skips |
| Diff scope | exactly `README.md`, `README.ja.md`, `skills-index.yaml`; no catalog-sentinel lines in README diffs; `metadata_snapshot.json` / `CLAUDE.md` / `docs` / `workflows` / `skillsets` / `test_recommend.py` byte-unchanged |

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
