### PR TITLE
PR-G: canonical example runs for market-regime-daily + trade-memory-loop (examples/workflows/, additive)

### DIFF
--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -1,0 +1,59 @@
+# Workflow Examples
+
+Canonical, hand-authored **sample runs** for the multi-skill workflows defined
+in [`workflows/*.yaml`](../../workflows/). Each sub-directory shows the exact
+prompt you would give Claude, plus the artifact each required step contributes
+to the workflow's data flow, plus a machine-readable `manifest.yaml` that a
+future fixture/replay harness can consume.
+
+> ⚠️ **Illustrative only — not investment advice.** Every artifact here uses
+> **fictional / hand-authored data** (the trade example uses the fictional
+> ticker `EXMPL`; the market-regime example uses a fictional market snapshot
+> with **no individual tickers**). These files are teaching/reference samples,
+> **not** live signals, recommendations, or real skill output captured from a
+> real account. Do not trade off them.
+
+## Available examples
+
+| Example | Workflow | Cadence | Skills (required) |
+|---|---|---|---|
+| [`market-regime-daily/`](market-regime-daily/) | [`market-regime-daily.yaml`](../../workflows/market-regime-daily.yaml) | daily | market-breadth-analyzer → uptrend-analyzer → exposure-coach |
+| [`trade-memory-loop/`](trade-memory-loop/) | [`trade-memory-loop.yaml`](../../workflows/trade-memory-loop.yaml) | per closed trade | trader-memory-core → signal-postmortem → trader-memory-core |
+
+Each example is **required-only**: it exercises just the required steps. The
+one optional step in each workflow is intentionally skipped and documented in
+that example's `README.md` and `manifest.yaml` (`optional_steps_skipped`). A
+full-path sample (including optional steps) may be added later in a separate
+change.
+
+## Artifact convention: `raw-plus-handoff`
+
+The sample JSON artifacts are **workflow hand-off artifacts**, not byte-for-byte
+copies of raw skill stdout:
+
+- The nested `composite { … }` block **mirrors the real skill output
+  structure** (e.g. `market-breadth-analyzer` and `uptrend-analyzer` both nest
+  their score at `composite.composite_score`).
+- A **top-level hand-off field** (`breadth_score` / `uptrend_score`) is added
+  alongside it. This is the field the Claude-orchestrated next step actually
+  consumes when it hands a score to `exposure-coach`.
+
+This convention is deliberate and also **documents a real, known
+`exposure-coach` parser asymmetry**: `extract_uptrend_score()` already reads
+the nested `composite` shape, but `extract_breadth_score()` reads **only** the
+top-level field — so raw breadth output (nested only) is silently dropped by
+`exposure-coach` today. That parser gap is **not fixed here** (this is a
+docs/sample-only change); it is tracked as a separate code issue and linked
+from the pull request that introduced these examples. The sample is authored
+so that running the **real** `exposure-coach` extractors over these files
+reproduces exactly the scores shown in `04_exposure_decision.json` (see each
+example's verification notes).
+
+## Coupling
+
+These files are intentionally **decoupled** from the generated-docs / drift-gate
+machinery: no generator, validator, snapshot builder, catalog, CI metadata
+job, or pytest path reads `examples/`. Editing or extending them cannot cause
+catalog/snapshot/docs drift. (They are still subject to the standard
+hygiene pre-commit hooks — whitespace, YAML syntax, `detect-secrets`,
+`no-absolute-paths`, etc.)

--- a/examples/workflows/market-regime-daily/README.md
+++ b/examples/workflows/market-regime-daily/README.md
@@ -1,0 +1,104 @@
+# Example: `market-regime-daily` (required-only)
+
+A canonical sample run of the
+[`market-regime-daily`](../../../workflows/market-regime-daily.yaml) workflow:
+a daily, no-API market-posture check that decides whether new swing-trade risk
+is allowed before the session.
+
+> ⚠️ **Illustrative only — not investment advice.** This sample uses a
+> **fictional market snapshot** for a fixed date (`2026-01-15`) with **no
+> individual tickers**. The numbers are hand-authored to be internally
+> consistent and code-faithful, **not** captured from a live run.
+
+## Steps in this sample
+
+| Step | Skill | Artifact | In this sample |
+|---|---|---|---|
+| 1 | `market-breadth-analyzer` | `market_breadth_report` | ✅ included |
+| 2 | `uptrend-analyzer` | `uptrend_report` | ✅ included |
+| 3 | `market-top-detector` | `top_risk_report` | ⏭️ **skipped** (optional) |
+| 4 | `exposure-coach` | `exposure_decision` | ✅ included |
+
+Step 3 is the workflow's one optional step. This is the **required-only**
+canonical sample, so it is intentionally skipped (recorded in
+[`sample-run/manifest.yaml`](sample-run/manifest.yaml) under
+`optional_steps_skipped`). A full-path sample including the optional satellites
+may be added later in a separate change.
+
+## Files
+
+```
+sample-run/
+  prompt.md                       # the prompt you give Claude
+  manifest.yaml                   # machine-readable step → artifact → file map
+  01_market_breadth_report.json   # step 1 canonical (raw composite{} + breadth_score)
+  01_market_breadth_report.md     # step 1 companion (human report)
+  02_uptrend_report.json          # step 2 canonical (raw composite{} + uptrend_score)
+  02_uptrend_report.md            # step 2 companion
+  04_exposure_decision.json       # step 4 canonical (exposure-coach output)
+  04_exposure_decision.md         # step 4 companion (one-page posture)
+```
+
+## The `raw-plus-handoff` artifact convention
+
+`01`/`02` JSON each carry **both**:
+
+- the real nested `composite { composite_score, zone, … }` block — exactly the
+  structure `market-breadth-analyzer` / `uptrend-analyzer` emit; and
+- a **top-level hand-off field** (`breadth_score` / `uptrend_score`) equal to
+  `composite.composite_score`.
+
+The top-level field exists because of a **real, known `exposure-coach` parser
+asymmetry**:
+
+- `extract_uptrend_score()` already reads the nested `composite` shape, so raw
+  uptrend output is consumable as-is.
+- `extract_breadth_score()` reads **only** the top-level field — it has **no**
+  nested-`composite` fallback — so *raw* breadth output (nested only) is
+  silently dropped, becoming a missing **critical** input.
+
+This sample documents that gap rather than hiding it. It is **not fixed here**
+(this is a docs/sample-only change); the parser fix is tracked as a separate
+code issue, linked from the pull request that introduced this example. The
+sample is authored so the **real** extractors reproduce the exact scores in
+`04_exposure_decision.json` (`breadth_score == 66`, `uptrend_score == 72`).
+
+## Why the posture is `REDUCE_ONLY / LOW` (this is correct)
+
+`exposure-coach` treats `regime`, `top_risk`, and `breadth` as **critical
+inputs** and applies a **−10 composite haircut per missing critical input**.
+In the required-only path, both `regime` (`macro-regime-detector`) and
+`top_risk` (`market-top-detector`) are absent → a −20 haircut. With breadth 66
+and uptrend 72 the pre-haircut composite is `(66+72)/2 = 69.0`, haircut to
+`49.0`, which maps to a **48% exposure ceiling, REDUCE_ONLY recommendation,
+LOW confidence** — even though internal participation is `BROAD`.
+
+This is the **honest, code-faithful** output of the required-only path, and it
+is exactly *why the optional satellites exist*: adding `macro-regime-detector`
+and `market-top-detector` clears the critical-input haircut and lets the
+posture rise toward `NEW_ENTRY_ALLOWED` when internals support it. The
+required-only sample deliberately shows the conservative floor.
+
+## Reproduce / verify
+
+From the repo root (read-only; writes only to a temp dir):
+
+```bash
+python3 - <<'PY'
+import json, sys
+sys.path.insert(0, "skills/exposure-coach/scripts")
+import calculate_exposure as ce
+d = "examples/workflows/market-regime-daily/sample-run"
+b = json.load(open(f"{d}/01_market_breadth_report.json"))
+u = json.load(open(f"{d}/02_uptrend_report.json"))
+dec = json.load(open(f"{d}/04_exposure_decision.json"))
+assert ce.extract_breadth_score(b) == dec["component_scores"]["breadth_score"] == 66
+assert ce.extract_uptrend_score(u) == dec["component_scores"]["uptrend_score"] == 72
+print("OK: real exposure-coach extractors reproduce the sample scores")
+PY
+```
+
+## Run it for real
+
+See [`sample-run/prompt.md`](sample-run/prompt.md). The skills fetch public
+CSVs (no API key); your live numbers will differ from this fixed sample.

--- a/examples/workflows/market-regime-daily/sample-run/01_market_breadth_report.json
+++ b/examples/workflows/market-regime-daily/sample-run/01_market_breadth_report.json
@@ -1,0 +1,158 @@
+{
+  "metadata": {
+    "generated_at": "2026-01-15 07:05:00",
+    "data_source": "TraderMonty Market Breadth CSV (public, no API key)",
+    "detail_url": "https://tradermonty.github.io/market-breadth-analysis/",
+    "summary_url": "https://tradermonty.github.io/market-breadth-analysis/",
+    "total_rows": 2480,
+    "data_freshness": {
+      "latest_date": "2026-01-14",
+      "days_old": 1,
+      "warning": null,
+      "last_modified": null
+    }
+  },
+  "composite": {
+    "composite_score": 66,
+    "zone": "Healthy",
+    "zone_color": "blue",
+    "exposure_guidance": "75-90%",
+    "guidance": "Normal operations. Broad participation, but watch the S&P 500 vs breadth divergence.",
+    "actions": [
+      "Maintain core exposure",
+      "Monitor divergence component"
+    ],
+    "strongest_health": {
+      "component": "bearish_signal",
+      "label": "Bearish Signal Status",
+      "score": 80
+    },
+    "weakest_health": {
+      "component": "divergence",
+      "label": "S&P 500 vs Breadth Divergence",
+      "score": 50
+    },
+    "excluded_components": [],
+    "data_quality": {
+      "available_count": 6,
+      "total_components": 6,
+      "label": "Complete (6/6 components)",
+      "missing_components": []
+    },
+    "component_scores": {
+      "breadth_level_trend": {
+        "score": 72,
+        "weight": 0.25,
+        "effective_weight": 0.25,
+        "weighted_contribution": 18.0,
+        "data_available": true,
+        "label": "Current Breadth Level & Trend"
+      },
+      "ma_crossover": {
+        "score": 68,
+        "weight": 0.2,
+        "effective_weight": 0.2,
+        "weighted_contribution": 13.6,
+        "data_available": true,
+        "label": "8MA vs 200MA Crossover"
+      },
+      "cycle_position": {
+        "score": 60,
+        "weight": 0.2,
+        "effective_weight": 0.2,
+        "weighted_contribution": 12.0,
+        "data_available": true,
+        "label": "Peak/Trough Cycle Position"
+      },
+      "bearish_signal": {
+        "score": 80,
+        "weight": 0.15,
+        "effective_weight": 0.15,
+        "weighted_contribution": 12.0,
+        "data_available": true,
+        "label": "Bearish Signal Status"
+      },
+      "historical_percentile": {
+        "score": 55,
+        "weight": 0.1,
+        "effective_weight": 0.1,
+        "weighted_contribution": 5.5,
+        "data_available": true,
+        "label": "Historical Percentile"
+      },
+      "divergence": {
+        "score": 50,
+        "weight": 0.1,
+        "effective_weight": 0.1,
+        "weighted_contribution": 5.0,
+        "data_available": true,
+        "label": "S&P 500 vs Breadth Divergence"
+      }
+    }
+  },
+  "components": {
+    "breadth_level_trend": {
+      "score": 72,
+      "signal": "HEALTHY: 8MA above 200MA, rising",
+      "data_available": true,
+      "current_8ma": 0.61,
+      "current_200ma": 0.54,
+      "trend": 1,
+      "level_score": 70,
+      "trend_score": 74,
+      "ma8_direction": "rising",
+      "direction_modifier": 0
+    },
+    "ma_crossover": {
+      "score": 68,
+      "signal": "POSITIVE: 8MA > 200MA",
+      "data_available": true,
+      "gap": 0.07,
+      "gap_score": 72,
+      "ma8_direction": "rising",
+      "direction_modifier": 0
+    },
+    "cycle_position": {
+      "score": 60,
+      "signal": "NEUTRAL: mid-cycle",
+      "data_available": true,
+      "latest_marker_type": "trough",
+      "days_since_marker": 34,
+      "ma8_trend": "rising",
+      "extreme_trough": false
+    },
+    "bearish_signal": {
+      "score": 80,
+      "signal": "CLEAR: no active bearish signal",
+      "data_available": true,
+      "signal_active": false,
+      "trend": 1,
+      "current_8ma": 0.61,
+      "in_pink_zone": false,
+      "pink_zone_days": 0,
+      "base_score": 90,
+      "context_adjustment": -10,
+      "pink_zone_adjustment": 0
+    },
+    "historical_percentile": {
+      "score": 55,
+      "signal": "NORMAL: 55th percentile",
+      "data_available": true,
+      "current_8ma": 0.61,
+      "percentile_rank": 55.0,
+      "avg_peak": 0.68,
+      "avg_trough": 0.34,
+      "adjustment": 0
+    },
+    "divergence": {
+      "score": 50,
+      "signal": "MILD: price slightly ahead of breadth",
+      "data_available": true,
+      "sp500_pct_change": 3.1,
+      "breadth_change": 0.012,
+      "divergence_type": "mild_bearish",
+      "early_warning": false
+    }
+  },
+  "breadth_score": 66
+}

--- a/examples/workflows/market-regime-daily/sample-run/01_market_breadth_report.md
+++ b/examples/workflows/market-regime-daily/sample-run/01_market_breadth_report.md
@@ -1,0 +1,119 @@
+# Market Breadth Analyzer Report
+
+**Generated:** 2026-01-15 07:05:00
+**Data Source:** TraderMonty Market Breadth CSV (no API key required)
+**Latest Data:** 2026-01-14 (1 days old)
+**Live Dashboard:** [Interactive Chart](https://tradermonty.github.io/market-breadth-analysis/)
+
+---
+
+## Overall Assessment
+
+| Metric | Value |
+|--------|-------|
+| **Composite Score** | **66/100** |
+| **Health Zone** | 🔵 Healthy |
+| **Equity Exposure** | 75-90% |
+| **Strongest** | Bearish Signal Status (80/100) |
+| **Weakest** | S&P 500 vs Breadth Divergence (50/100) |
+| **Data Quality** | Complete (6/6 components) |
+
+> **Guidance:** Normal operations. Broad participation, but watch the S&P 500 vs breadth divergence.
+
+---
+
+## Component Scores
+
+| # | Component | Weight | Eff. Weight | Score | Contribution | Signal |
+|---|-----------|--------|-------------|-------|--------------|--------|
+| 1 | **Current Breadth Level & Trend** | 25% | 25% | ███░ 72 | 18.0 | HEALTHY: 8MA above 200MA, rising |
+| 2 | **8MA vs 200MA Crossover** | 20% | 20% | ███░ 68 | 13.6 | POSITIVE: 8MA > 200MA |
+| 3 | **Peak/Trough Cycle Position** | 20% | 20% | ███░ 60 | 12.0 | NEUTRAL: mid-cycle |
+| 4 | **Bearish Signal Status** | 15% | 15% | ████ 80 | 12.0 | CLEAR: no active bearish signal |
+| 5 | **Historical Percentile** | 10% | 10% | ██░░ 55 | 5.5 | NORMAL: 55th percentile |
+| 6 | **S&P 500 vs Breadth Divergence** | 10% | 10% | ██░░ 50 | 5.0 | MILD: price slightly ahead of breadth |
+
+---
+
+## Component Details
+
+### 1. Current Breadth Level & Trend
+
+- **8MA Level:** 0.6100
+- **200MA Level:** 0.5400
+- **200MA Trend:** Uptrend
+- **Level Score:** 70
+- **Trend Score:** 74
+- **8MA Direction (5d):** rising
+
+### 2. 8MA vs 200MA Crossover Dynamics
+
+- **Gap (8MA - 200MA):** +0.0700
+- **Gap Score:** 72
+- **8MA Direction (5d):** rising
+- **Direction Modifier:** +0
+
+### 3. Peak/Trough Cycle Position
+
+- **Latest Marker:** trough
+- **Days Since Marker:** 34
+- **8MA Trend:** rising
+
+### 4. Bearish Signal Status
+
+- **Bearish Signal Active:** No
+- **200MA Trend:** Uptrend
+- **Current 8MA:** 0.6100
+- **Pink Zone:** No (outside bearish region)
+- **Base Score:** 90
+- **Context Adjustment:** -10
+
+### 5. Historical Percentile
+
+- **Current 8MA:** 0.6100
+- **Percentile Rank:** 55.0%
+- **Avg Peak (200MA):** 0.68
+- **Avg Trough (8MA<0.4):** 0.34
+
+### 6. S&P 500 vs Breadth Divergence
+
+- **S&P 500 60d Change:** +3.10%
+- **Breadth 8MA 60d Change:** +0.0120
+- **Divergence Type:** mild_bearish
+
+---
+
+## Key Levels to Watch
+
+*No key levels computed.*
+
+---
+
+## Recommended Actions
+
+**Health Zone:** Healthy
+**Equity Exposure:** 75-90%
+
+- Maintain core exposure
+- Monitor divergence component
+
+---
+
+## Methodology
+
+This analysis uses TraderMonty's market breadth dataset to quantify market participation health across 6 dimensions:
+
+1. **Breadth Level & Trend (25%):** Current 8MA level and 200MA trend direction
+2. **MA Crossover (20%):** Gap between 8MA and 200MA with momentum detection
+3. **Cycle Position (20%):** Position relative to recent peaks/troughs
+4. **Bearish Signal (15%):** Backtested bearish signal flag from dataset
+5. **Historical Percentile (10%):** Current level vs full history distribution
+6. **Divergence (10%):** S&P 500 price vs breadth directional agreement
+
+Composite score: 0-100 (100 = maximum health). No API key required - uses freely available CSV data.
+
+For detailed methodology, see `references/breadth_analysis_methodology.md`.
+
+---
+
+**Disclaimer:** This analysis is for educational and informational purposes only. Not investment advice. Past patterns may not predict future outcomes. Conduct your own research and consult a financial advisor before making investment decisions.

--- a/examples/workflows/market-regime-daily/sample-run/02_uptrend_report.json
+++ b/examples/workflows/market-regime-daily/sample-run/02_uptrend_report.json
@@ -1,0 +1,266 @@
+{
+  "metadata": {
+    "generated_at": "2026-01-15 07:06:00",
+    "data_source": "Monty's Uptrend Ratio Dashboard CSV (public, no API key)",
+    "api_key_required": false,
+    "latest_data_date": "2026-01-14",
+    "timeseries_rows": 2390,
+    "sectors_available": 11
+  },
+  "composite": {
+    "composite_score": 72,
+    "composite_score_raw": 75,
+    "zone": "Bull",
+    "zone_detail": "Bull-Upper",
+    "zone_color": "light_green",
+    "zone_proximity": {
+      "at_boundary": false
+    },
+    "exposure_guidance": "Normal Exposure (80-100%)",
+    "warning_penalty": -3,
+    "active_warnings": [
+      {
+        "label": "Momentum Cooling",
+        "description": "Ratio still rising but slope is flattening.",
+        "actions": [
+          "Watch momentum component",
+          "Tighten trailing stops"
+        ]
+      }
+    ],
+    "strongest_component": {
+      "label": "Market Breadth",
+      "score": 85
+    },
+    "weakest_component": {
+      "label": "Sector Rotation",
+      "score": 66
+    },
+    "data_quality": {
+      "label": "Good"
+    },
+    "guidance": "Breadth participation is healthy; momentum is cooling but not negative.",
+    "actions": [
+      "Maintain positions",
+      "Watch momentum"
+    ],
+    "component_scores": {
+      "market_breadth": {
+        "label": "Market Breadth",
+        "score": 85,
+        "weight": 0.3,
+        "weighted_contribution": 25.5
+      },
+      "sector_participation": {
+        "label": "Sector Participation",
+        "score": 74,
+        "weight": 0.25,
+        "weighted_contribution": 18.5
+      },
+      "sector_rotation": {
+        "label": "Sector Rotation",
+        "score": 66,
+        "weight": 0.15,
+        "weighted_contribution": 9.9
+      },
+      "momentum": {
+        "label": "Momentum",
+        "score": 68,
+        "weight": 0.2,
+        "weighted_contribution": 13.6
+      },
+      "historical_context": {
+        "label": "Historical Context",
+        "score": 72,
+        "weight": 0.1,
+        "weighted_contribution": 7.2
+      }
+    }
+  },
+  "components": {
+    "market_breadth": {
+      "data_available": true,
+      "ratio_pct": 58.0,
+      "ma_10_pct": 55.5,
+      "trend": "Up",
+      "slope": 0.0014,
+      "trend_adjustment": 2,
+      "distance_from_upper": 0.21,
+      "distance_from_lower": 0.48,
+      "date": "2026-01-14",
+      "signal": "HEALTHY: 58% of stocks in an uptrend, above the 10-day MA"
+    },
+    "sector_participation": {
+      "data_available": true,
+      "uptrend_count": 8,
+      "total_sectors": 11,
+      "count_score": 73,
+      "spread_pct": 24.0,
+      "spread_score": 75,
+      "overbought_count": 1,
+      "overbought_sectors": [
+        "Technology"
+      ],
+      "oversold_count": 0,
+      "oversold_sectors": [],
+      "signal": "BROAD: 8 of 11 sectors participating",
+      "sector_details": [
+        {
+          "sector": "Technology",
+          "ratio_pct": 41.0,
+          "count": 58,
+          "total": 70,
+          "ma_10": 0.39,
+          "trend": "Up",
+          "slope": 0.0021,
+          "status": "Overbought"
+        },
+        {
+          "sector": "Industrials",
+          "ratio_pct": 33.0,
+          "count": 22,
+          "total": 34,
+          "ma_10": 0.31,
+          "trend": "Up",
+          "slope": 0.0015,
+          "status": "Normal"
+        },
+        {
+          "sector": "Financials",
+          "ratio_pct": 31.0,
+          "count": 20,
+          "total": 33,
+          "ma_10": 0.29,
+          "trend": "Up",
+          "slope": 0.0012,
+          "status": "Normal"
+        },
+        {
+          "sector": "Consumer Discretionary",
+          "ratio_pct": 30.0,
+          "count": 17,
+          "total": 30,
+          "ma_10": 0.28,
+          "trend": "Up",
+          "slope": 0.0011,
+          "status": "Normal"
+        },
+        {
+          "sector": "Communication Services",
+          "ratio_pct": 29.0,
+          "count": 7,
+          "total": 12,
+          "ma_10": 0.27,
+          "trend": "Up",
+          "slope": 0.001,
+          "status": "Normal"
+        },
+        {
+          "sector": "Materials",
+          "ratio_pct": 27.0,
+          "count": 8,
+          "total": 17,
+          "ma_10": 0.26,
+          "trend": "Up",
+          "slope": 0.0008,
+          "status": "Normal"
+        },
+        {
+          "sector": "Energy",
+          "ratio_pct": 26.0,
+          "count": 6,
+          "total": 12,
+          "ma_10": 0.25,
+          "trend": "Up",
+          "slope": 0.0007,
+          "status": "Normal"
+        },
+        {
+          "sector": "Health Care",
+          "ratio_pct": 24.0,
+          "count": 14,
+          "total": 30,
+          "ma_10": 0.24,
+          "trend": "Up",
+          "slope": 0.0005,
+          "status": "Normal"
+        },
+        {
+          "sector": "Consumer Staples",
+          "ratio_pct": 19.0,
+          "count": 6,
+          "total": 17,
+          "ma_10": 0.21,
+          "trend": "Down",
+          "slope": -0.0004,
+          "status": "Normal"
+        },
+        {
+          "sector": "Utilities",
+          "ratio_pct": 17.0,
+          "count": 5,
+          "total": 16,
+          "ma_10": 0.19,
+          "trend": "Down",
+          "slope": -0.0006,
+          "status": "Normal"
+        },
+        {
+          "sector": "Real Estate",
+          "ratio_pct": 16.0,
+          "count": 4,
+          "total": 15,
+          "ma_10": 0.18,
+          "trend": "Down",
+          "slope": -0.0007,
+          "status": "Normal"
+        }
+      ]
+    },
+    "sector_rotation": {
+      "data_available": true,
+      "cyclical_avg_pct": 61.0,
+      "defensive_avg_pct": 49.0,
+      "commodity_avg_pct": 52.0,
+      "difference_pct": 12.0,
+      "late_cycle_flag": false,
+      "divergence_flag": false,
+      "signal": "CONSTRUCTIVE: cyclicals leading defensives"
+    },
+    "momentum": {
+      "data_available": true,
+      "slope": 0.0009,
+      "slope_smoothing": "EMA(3)",
+      "slope_smoothed": 0.0008,
+      "slope_score": 64,
+      "acceleration_window": "10v10",
+      "acceleration": -0.0002,
+      "acceleration_label": "Cooling",
+      "acceleration_score": 55,
+      "sector_positive_slope_count": 7,
+      "sector_total": 11,
+      "sector_slope_breadth_score": 64,
+      "signal": "COOLING: still positive but slope flattening"
+    },
+    "historical_context": {
+      "data_available": true,
+      "current_ratio_pct": 58.0,
+      "percentile": 68,
+      "historical_min_pct": 4.0,
+      "historical_max_pct": 79.0,
+      "historical_median_pct": 47.0,
+      "avg_30d_pct": 55.0,
+      "avg_90d_pct": 51.0,
+      "data_points": 2390,
+      "date_range": "2016-2026",
+      "signal": "NORMAL: 68th percentile vs full history",
+      "confidence": {
+        "confidence_level": "Medium",
+        "sample_label": "n=2390",
+        "regime_coverage": "good",
+        "recency_label": "recent"
+      }
+    }
+  },
+  "uptrend_score": 72
+}

--- a/examples/workflows/market-regime-daily/sample-run/02_uptrend_report.md
+++ b/examples/workflows/market-regime-daily/sample-run/02_uptrend_report.md
@@ -1,0 +1,159 @@
+# Uptrend Analyzer Report
+
+**Generated:** 2026-01-15 07:06:00
+**Data Source:** Monty's Uptrend Ratio Dashboard (GitHub CSV)
+**API Key Required:** No
+
+---
+
+## Overall Assessment
+
+| Metric | Value |
+|--------|-------|
+| **Composite Score** | **72/100** |
+| **Zone** | 🟢 Bull |
+| **Zone Detail** | Bull-Upper |
+| **Exposure Guidance** | Normal Exposure (80-100%) |
+| **Warning Penalty** | -3 (raw: 75/100) |
+| **Active Warnings** | 1: Momentum Cooling |
+| **Strongest Component** | Market Breadth (85/100) |
+| **Weakest Component** | Sector Rotation (66/100) |
+| **Data Quality** | Good |
+| **Confidence** | Medium (n=2390, good regime coverage) |
+
+> **Guidance:** Breadth participation is healthy; momentum is cooling but not negative.
+>
+> Note: Score is in the Bull zone, but 1 warning(s) are active.
+> Exposure guidance has been tightened. See Active Warnings below.
+
+---
+
+## Active Warnings
+
+### Momentum Cooling
+> Ratio still rising but slope is flattening.
+
+- Watch momentum component
+- Tighten trailing stops
+
+---
+
+## Current Market Snapshot
+
+| Metric | Value |
+|--------|-------|
+| Uptrend Ratio | 58.0% |
+| 10-Day MA | 55.5% |
+| Trend | Up |
+| Slope | +0.0014 |
+| Distance from 37% (Overbought) | +21.0pp |
+| Distance from 9.7% (Oversold) | +48.0pp |
+| Date | 2026-01-14 |
+
+---
+
+## Component Scores
+
+| # | Component | Weight | Score | Contribution | Signal |
+|---|-----------|--------|-------|--------------|--------|
+| 1 | **Market Breadth** | 30% | ████ 85 | 25.5 | HEALTHY: 58% of stocks in an uptrend, above the 10-day MA |
+| 2 | **Sector Participation** | 25% | ███░ 74 | 18.5 | BROAD: 8 of 11 sectors participating |
+| 3 | **Sector Rotation** | 15% | ███░ 66 | 9.9 | CONSTRUCTIVE: cyclicals leading defensives |
+| 4 | **Momentum** | 20% | ███░ 68 | 13.6 | COOLING: still positive but slope flattening |
+| 5 | **Historical Context** | 10% | ███░ 72 | 7.2 | NORMAL: 68th percentile vs full history |
+
+---
+
+## Component Details
+
+### 1. Market Breadth (Overall)
+
+- **Uptrend Ratio:** 58.0%
+- **10-Day MA:** 55.5%
+- **Trend:** Up
+- **Slope:** +0.0014
+- **Trend Adjustment:** +2
+
+### 2. Sector Participation
+
+- **Uptrending Sectors:** 8/11
+- **Count Score:** 73/100
+- **Spread:** 24.0% (score: 75/100)
+- **Overbought (>37%):** 1 sectors (Technology)
+- **Oversold (<9.7%):** 0 sectors ()
+
+### 3. Sector Rotation
+
+- **Cyclical Avg:** 61.0%
+- **Defensive Avg:** 49.0%
+- **Commodity Avg:** 52.0%
+- **Cyclical-Defensive Gap:** 12.0pp
+
+### 4. Momentum
+
+- **Raw Slope:** +0.0009
+- **Smoothed Slope (EMA(3)):** +0.0008 (score: 64/100)
+- **Acceleration (10v10):** -0.0002 (Cooling, score: 55/100)
+- **Sector Slope Breadth:** 7/11 positive (score: 64/100)
+
+### 5. Historical Context
+
+- **Current Ratio:** 58.0%
+- **Percentile Rank:** 68th
+- **Historical Range:** 4.0% - 79.0%
+- **Historical Median:** 47.0%
+- **30-Day Avg:** 55.0%
+- **90-Day Avg:** 51.0%
+- **Data Points:** 2390 (2016-2026)
+- **Confidence:** Medium (sample: n=2390, regime: good, recency: recent)
+
+---
+
+## Sector Heatmap
+
+| Rank | Sector | Ratio | Count/Total | 10MA | Trend | Slope | Status |
+|------|--------|-------|-------------|------|-------|-------|--------|
+| 1 | Technology | 41.0% | 58/70 | 39.0% | Up | +0.0021 | Overbought |
+| 2 | Industrials | 33.0% | 22/34 | 31.0% | Up | +0.0015 | Normal |
+| 3 | Financials | 31.0% | 20/33 | 29.0% | Up | +0.0012 | Normal |
+| 4 | Consumer Discretionary | 30.0% | 17/30 | 28.0% | Up | +0.0011 | Normal |
+| 5 | Communication Services | 29.0% | 7/12 | 27.0% | Up | +0.0010 | Normal |
+| 6 | Materials | 27.0% | 8/17 | 26.0% | Up | +0.0008 | Normal |
+| 7 | Energy | 26.0% | 6/12 | 25.0% | Up | +0.0007 | Normal |
+| 8 | Health Care | 24.0% | 14/30 | 24.0% | Up | +0.0005 | Normal |
+| 9 | Consumer Staples | 19.0% | 6/17 | 21.0% | Down | -0.0004 | Normal |
+| 10 | Utilities | 17.0% | 5/16 | 19.0% | Down | -0.0006 | Normal |
+| 11 | Real Estate | 16.0% | 4/15 | 18.0% | Down | -0.0007 | Normal |
+
+---
+
+## Recommended Actions
+
+**Zone:** Bull (Bull-Upper)
+**Exposure Guidance:** Normal Exposure (80-100%)
+
+- Maintain positions
+- Watch momentum
+
+---
+
+## Methodology
+
+This analysis uses Monty's Uptrend Ratio Dashboard data to assess market breadth health.
+The dashboard tracks ~2,800 US stocks across 11 sectors, measuring the percentage in uptrends.
+
+**5-Component Scoring System (0-100, higher = healthier):**
+
+1. **Market Breadth (30%):** Overall uptrend ratio level and trend direction
+2. **Sector Participation (25%):** Number of uptrending sectors and spread uniformity
+3. **Sector Rotation (15%):** Cyclical vs Defensive vs Commodity balance
+4. **Momentum (20%):** Slope direction, acceleration, and sector slope breadth
+5. **Historical Context (10%):** Percentile rank in historical distribution
+
+**Key Thresholds (Monty's Dashboard):** Overbought = 37%, Oversold = 9.7%
+
+For detailed methodology, see `references/uptrend_methodology.md`.
+
+---
+
+**Disclaimer:** This analysis is for educational and informational purposes only. Not investment advice. Past patterns may not predict future outcomes. Conduct your own research and consult a financial advisor before making investment decisions.

--- a/examples/workflows/market-regime-daily/sample-run/04_exposure_decision.json
+++ b/examples/workflows/market-regime-daily/sample-run/04_exposure_decision.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-01-15T13:05:00+00:00",
+  "exposure_ceiling_pct": 48,
+  "bias": "NEUTRAL",
+  "participation": "BROAD",
+  "recommendation": "REDUCE_ONLY",
+  "confidence": "LOW",
+  "composite_score": 49.0,
+  "component_scores": {
+    "breadth_score": 66,
+    "uptrend_score": 72
+  },
+  "inputs_provided": [
+    "breadth",
+    "uptrend"
+  ],
+  "inputs_missing": [
+    "regime",
+    "top_risk",
+    "institutional",
+    "sector",
+    "theme",
+    "ftd"
+  ],
+  "rationale": "Broad participation indicates healthy market internals. Missing critical inputs (top_risk, regime) reduce confidence. New entries not recommended; consider trimming on strength."
+}

--- a/examples/workflows/market-regime-daily/sample-run/04_exposure_decision.md
+++ b/examples/workflows/market-regime-daily/sample-run/04_exposure_decision.md
@@ -1,0 +1,20 @@
+# Market Posture Summary
+**Date:** 2026-01-15 | **Confidence:** LOW
+
+## Exposure Ceiling: 48%
+
+| Dimension | Score | Status |
+|-----------|-------|--------|
+| Breadth | 66 | Healthy |
+| Uptrend | 72 | Strong |
+
+## Recommendation: REDUCE_ONLY
+
+**Bias:** NEUTRAL
+**Participation:** BROAD
+
+### Rationale
+Broad participation indicates healthy market internals. Missing critical inputs (top_risk, regime) reduce confidence. New entries not recommended; consider trimming on strength.
+
+### Missing Inputs
+regime, top_risk, institutional, sector, theme, ftd

--- a/examples/workflows/market-regime-daily/sample-run/manifest.yaml
+++ b/examples/workflows/market-regime-daily/sample-run/manifest.yaml
@@ -1,0 +1,45 @@
+workflow_id: market-regime-daily
+sample_type: required-only
+illustrative: true                 # fictional market snapshot; not investment advice
+artifact_shape: raw-plus-handoff   # composite{} mirrors raw skill output;
+                                   # top-level *_score is the workflow hand-off field
+prompt: prompt.md
+
+optional_steps_skipped:
+  - step: 3
+    skill: market-top-detector
+    reason: required-only canonical sample
+
+artifacts:
+  - step: 1
+    artifact_id: market_breadth_report
+    skill: market-breadth-analyzer
+    files:
+      canonical: 01_market_breadth_report.json
+      companion: 01_market_breadth_report.md
+  - step: 2
+    artifact_id: uptrend_report
+    skill: uptrend-analyzer
+    files:
+      canonical: 02_uptrend_report.json
+      companion: 02_uptrend_report.md
+  - step: 4
+    artifact_id: exposure_decision
+    skill: exposure-coach
+    files:
+      canonical: 04_exposure_decision.json
+      companion: 04_exposure_decision.md
+
+# Fixture note: 04_exposure_decision.json is reproducible. Running the real
+# exposure-coach extractors over the hand-off files yields the same scores:
+#   extract_breadth_score(01) == component_scores.breadth_score == 66
+#   extract_uptrend_score(02) == component_scores.uptrend_score  == 72
+verification:
+  data_date: "2026-01-15"
+  expected:
+    breadth_score: 66
+    uptrend_score: 72
+    composite_score: 49.0
+    exposure_ceiling_pct: 48
+    recommendation: REDUCE_ONLY
+    confidence: LOW

--- a/examples/workflows/market-regime-daily/sample-run/prompt.md
+++ b/examples/workflows/market-regime-daily/sample-run/prompt.md
@@ -1,0 +1,38 @@
+# Prompt — `market-regime-daily` (required-only)
+
+Paste the following to Claude (Claude Code or the web app, with the
+`market-breadth-analyzer`, `uptrend-analyzer`, and `exposure-coach` skills
+available). Replace `<repo>` with your checkout path.
+
+---
+
+> Run the **market-regime-daily** workflow for me (required steps only — skip
+> the optional market-top-detector step today).
+>
+> 1. Use **market-breadth-analyzer** to score current market breadth from the
+>    public TraderMonty CSV. Save the JSON + Markdown to
+>    `<repo>/reports/`.
+> 2. Use **uptrend-analyzer** to score uptrend participation from Monty's
+>    public Uptrend Ratio Dashboard CSV. Save to `<repo>/reports/`.
+> 3. Hand the breadth and uptrend scores to **exposure-coach** and produce a
+>    one-page market posture (exposure ceiling, bias, participation,
+>    new-entry-allowed vs cash-priority).
+>
+> Then tell me: is new swing-trade risk **allowed**, **restricted**, or
+> **cash-priority** today, and why. Treat the output as a posture, not a
+> buy/sell signal.
+
+---
+
+## What to expect
+
+This is the **required-only** path: `macro-regime-detector` and
+`market-top-detector` are **not** run. `exposure-coach` treats `regime` and
+`top_risk` as *critical* inputs, so with both absent it applies a fixed
+confidence haircut. In this sample that yields **REDUCE_ONLY / LOW
+confidence** even though breadth (66) and uptrend (72) are individually
+healthy — see [`../README.md`](../README.md) for why this is the correct,
+code-faithful behavior and how adding the optional satellites changes it.
+
+> ⚠️ Illustrative sample — fictional market snapshot, **not investment
+> advice**.

--- a/examples/workflows/trade-memory-loop/README.md
+++ b/examples/workflows/trade-memory-loop/README.md
@@ -1,0 +1,90 @@
+# Example: `trade-memory-loop` (required-only)
+
+A canonical sample run of the
+[`trade-memory-loop`](../../../workflows/trade-memory-loop.yaml) workflow: the
+per-closed-trade loop that records the outcome, generates a postmortem, and
+journals the lessons so the next decision is better-informed.
+
+> ⚠️ **Illustrative only — not investment advice.** This sample uses the
+> **fictional ticker `EXMPL`** (Example Corp) and a hand-authored trade. The
+> numbers are internally consistent and schema-faithful, **not** captured from
+> a real account.
+
+## Steps in this sample
+
+| Step | Skill | Artifact | In this sample |
+|---|---|---|---|
+| 1 | `trader-memory-core` | `closed_thesis_record` | ✅ included |
+| 2 | `signal-postmortem` | `postmortem_findings` | ✅ included |
+| 3 | `backtest-expert` | `backtest_validation` | ⏭️ **skipped** (optional) |
+| 4 | `trader-memory-core` | `lessons_log_entry` | ✅ included |
+
+Step 3 is the workflow's one optional step. This is the **required-only**
+canonical sample, so it is intentionally skipped (recorded in
+[`sample-run/manifest.yaml`](sample-run/manifest.yaml) under
+`optional_steps_skipped`). A full-path sample including the backtest
+re-validation may be added later in a separate change.
+
+## Files
+
+```
+sample-run/
+  prompt.md                       # the prompt you give Claude
+  manifest.yaml                   # machine-readable step → artifact → file map
+  01_closed_thesis_record.yaml    # step 1 canonical (trader-memory-core thesis, CLOSED)
+  02_postmortem_findings.json     # step 2 canonical (signal-postmortem record)
+  02_postmortem_summary.md        # step 2 companion (human summary)
+  04_lessons_log_entry.md         # step 4 canonical (journal entry)
+```
+
+`closed_thesis_record` has no companion (the YAML *is* the canonical artifact);
+`lessons_log_entry` is inherently Markdown (canonical, no companion).
+`postmortem_findings` has a JSON canonical + a Markdown companion. Every file
+above (except `manifest.yaml` itself) is referenced from the manifest.
+
+## The trade (fictional)
+
+`EXMPL`, a `growth_momentum` / VCP-breakout thesis surfaced by `vcp-screener`
+(grade A). Entered 2026-01-08 @ 142.10 (70 sh, 1% risk, stop 134.50), exited
+2026-02-27 @ 168.40 (`target_hit`) after trailing past the initial 2R target.
+Result: +18.5% / +$1,841 over 50 holding days; MAE -4.2%, MFE +21.0%.
+Postmortem classifies it **`TRUE_POSITIVE`** — thesis-driven, not luck.
+
+## Schema fidelity (this is enforced, not asserted)
+
+- `01_closed_thesis_record.yaml` passes the **real** trader-memory-core
+  validator: `jsonschema` Draft-07 against
+  `skills/trader-memory-core/schemas/thesis.schema.json` **plus** the `CLOSED`
+  business invariants in `thesis_store._validate_thesis()` (exit price/date
+  set, valid `exit_reason`, `exit_date ≥ entry_date`, `status_history`
+  monotonic and ending in `CLOSED`, RFC-3339 timestamps with timezone). Date
+  strings are quoted so `yaml.safe_load` returns them as strings (the schema
+  requires `type: string` + `format: date-time`/`date`).
+- `02_postmortem_findings.json` is produced by the **real**
+  `signal-postmortem` recorder consuming that thesis, so its
+  `outcome_category` / `holding_days` are computed, not hand-typed.
+
+## Reproduce / verify
+
+From the repo root (read-only; `uv` provides `jsonschema`):
+
+```bash
+uv run python - <<'PY'
+import json, sys, yaml
+sys.path.insert(0, "skills/trader-memory-core/scripts")
+import thesis_store
+d = "examples/workflows/trade-memory-loop/sample-run"
+t = yaml.safe_load(open(f"{d}/01_closed_thesis_record.yaml"))
+thesis_store._validate_thesis(t)            # raises on any violation
+pm = json.load(open(f"{d}/02_postmortem_findings.json"))
+assert pm["outcome_category"] == "TRUE_POSITIVE"
+assert pm["holding_days"] == 50
+print("OK: thesis validates; postmortem fields reproduce")
+PY
+```
+
+## Run it for real
+
+See [`sample-run/prompt.md`](sample-run/prompt.md). No API key is required
+(FMP is optional, only for MAE/MFE auto-calc); your real thesis IDs, dates,
+and outcome will differ from this fixed sample.

--- a/examples/workflows/trade-memory-loop/sample-run/01_closed_thesis_record.yaml
+++ b/examples/workflows/trade-memory-loop/sample-run/01_closed_thesis_record.yaml
@@ -1,0 +1,98 @@
+# Illustrative sample — fictional ticker EXMPL. NOT investment advice.
+# Schema: skills/trader-memory-core/schemas/thesis.schema.json
+# Date/date-time values are quoted so yaml.safe_load returns them as strings
+# (the schema requires "type": string + "format": date-time / date).
+thesis_id: th_EXMPL_growth_20260108_a1b2
+ticker: EXMPL
+created_at: '2026-01-05T13:00:00+00:00'
+updated_at: '2026-02-27T16:00:00+00:00'
+thesis_type: growth_momentum
+setup_type: vcp_breakout
+catalyst: Q4 earnings beat plus a multi-week VCP base breakout
+status: CLOSED
+status_history:
+  - status: IDEA
+    at: '2026-01-05T13:00:00+00:00'
+    reason: Surfaced by vcp-screener (grade A) in the 2026-01-05 scan
+  - status: ENTRY_READY
+    at: '2026-01-07T18:00:00+00:00'
+    reason: technical-analyst confirmed the weekly base; pivot defined
+  - status: ACTIVE
+    at: '2026-01-08T14:35:00+00:00'
+    reason: Pivot cleared on volume; entry filled
+  - status: CLOSED
+    at: '2026-02-27T15:50:00+00:00'
+    reason: Trailed exit after target_hit; thesis played out
+thesis_statement: >-
+  EXMPL completed a tight 7-week VCP base after a Q4 earnings beat; a breakout
+  through the 142.50 pivot on expanding volume should resolve into a
+  momentum advance toward the 165-170 measured-move zone.
+mechanism_tag: structure
+evidence:
+  - VCP base with three contractions, final contraction < 8%
+  - Q4 revenue +24% YoY, raised FY guidance
+  - Relative strength line at new high ahead of price
+  - 'Accumulation: 4 up-weeks on volume vs 1 down-week'
+kill_criteria:
+  - Close back below the 134.50 stop (base failure)
+  - Two distribution weeks in the first 10 sessions post-breakout
+  - Guidance walk-back or negative pre-announcement
+confidence: medium
+confidence_score: 0.6
+entry:
+  target_price: 142.5
+  conditions:
+    - Break and 30-min hold above 142.50 pivot
+    - Breakout volume >= 1.5x 50-day average
+  actual_price: 142.1
+  actual_date: '2026-01-08T14:35:00+00:00'
+exit:
+  stop_loss: 134.5
+  stop_loss_pct: -5.35
+  take_profit: 157.3
+  take_profit_rr: 2.0
+  time_stop_days: 60
+  actual_price: 168.4
+  actual_date: '2026-02-27T15:50:00+00:00'
+  exit_reason: target_hit
+position:
+  shares: 70
+  shares_remaining: 0
+  position_value: 9947.0
+  risk_dollars: 532.0
+  risk_pct_of_account: 0.53
+  account_type: margin
+  sizing_method: fixed_risk_1pct
+  raw_source:
+    skill: position-sizer
+    file: reports/position_sizer_EXMPL_2026-01-08.json
+    fields:
+      account_size: 100000
+      risk_pct: 1.0
+market_context:
+  regime: RISK_ON
+  breadth_score: 66
+  top_detector_score: null
+  sector: Technology
+origin:
+  skill: vcp-screener
+  output_file: reports/vcp_screen_2026-01-05.json
+  screening_grade: A
+  screening_score: 88
+  raw_provenance: {}
+linked_reports:
+  - skill: technical-analyst
+    file: reports/ta_EXMPL_2026-01-07.md
+    date: '2026-01-07'
+outcome:
+  pnl_dollars: 1841.0
+  pnl_pct: 18.5
+  holding_days: 50
+  mae_pct: -4.2
+  mfe_pct: 21.0
+  mae_mfe_source: manual (illustrative)
+  lessons_learned: >-
+    Thesis-driven winner. The initial 2R target (157.30) was reached on
+    2026-02-10; trailing the stop under the rising 10-EMA captured an extra
+    ~7% before the trail triggered at 168.40. MAE stayed shallow (-4.2%),
+    confirming the breakout was well-timed.

--- a/examples/workflows/trade-memory-loop/sample-run/02_postmortem_findings.json
+++ b/examples/workflows/trade-memory-loop/sample-run/02_postmortem_findings.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0",
+  "postmortem_id": "pm_sig_EXMPL_20260108_a1b2",
+  "signal_id": "sig_EXMPL_20260108_a1b2",
+  "ticker": "EXMPL",
+  "signal_date": "2026-01-08",
+  "source_skill": "vcp-screener",
+  "predicted_direction": "LONG",
+  "entry_price": 142.1,
+  "realized_returns": {
+    "5d": 0.021,
+    "20d": 0.083
+  },
+  "exit_price": 168.4,
+  "exit_date": "2026-02-27",
+  "holding_days": 50,
+  "outcome_category": "TRUE_POSITIVE",
+  "regime_at_signal": "RISK_ON",
+  "regime_at_exit": "RISK_ON",
+  "outcome_notes": "Thesis-driven win: VCP breakout held; initial 2R target reached, trailed exit captured additional momentum. No regime change.",
+  "recorded_at": "2026-02-27T16:05:00Z"
+}

--- a/examples/workflows/trade-memory-loop/sample-run/02_postmortem_summary.md
+++ b/examples/workflows/trade-memory-loop/sample-run/02_postmortem_summary.md
@@ -1,0 +1,34 @@
+# Postmortem Summary — `sig_EXMPL_20260108_a1b2`
+
+> ⚠️ Illustrative sample — fictional ticker **EXMPL**. Not investment advice.
+> Companion of [`02_postmortem_findings.json`](02_postmortem_findings.json).
+
+**Ticker:** EXMPL  **Source:** vcp-screener  **Direction:** LONG
+**Outcome:** `TRUE_POSITIVE`
+
+| Field | Value |
+|---|---|
+| Signal date | 2026-01-08 |
+| Exit date | 2026-02-27 |
+| Holding days | 50 |
+| Entry price | 142.10 |
+| Exit price | 168.40 |
+| Realized return (5d) | +2.1% |
+| Realized return (20d) | +8.3% |
+| Regime at signal → exit | RISK_ON → RISK_ON |
+
+## Classification rationale
+
+The 5-day return (+2.1%) is the primary classifier input. Predicted
+direction was **LONG** and the 5-day return was **positive**, so the signal is
+a **direction match → `TRUE_POSITIVE`**. Regime was unchanged
+(`RISK_ON → RISK_ON`), so no `REGIME_MISMATCH` override applied; the move was
+well above the ±0.5% neutral band.
+
+## Root-cause read (decision gate)
+
+This was **thesis-driven, not luck**: the VCP base breakout resolved exactly
+as the thesis predicted, MAE stayed shallow (-4.2%), and the advance tracked
+the expected measured move. Execution (entry on the pivot, trailed exit)
+added to the result rather than detracting. No process change required —
+catalogue as a repeatable setup.

--- a/examples/workflows/trade-memory-loop/sample-run/04_lessons_log_entry.md
+++ b/examples/workflows/trade-memory-loop/sample-run/04_lessons_log_entry.md
@@ -1,0 +1,65 @@
+<!-- Illustrative sample — fictional ticker EXMPL. Not investment advice. -->
+<!-- Step 4 (trader-memory-core): lessons appended to the trader journal.   -->
+<!-- Rendering mirrors trader-memory-core assets/postmortem_template.md.    -->
+# Postmortem: th_EXMPL_growth_20260108_a1b2
+
+**Ticker:** EXMPL
+**Type:** growth_momentum
+**Status:** CLOSED
+
+## Thesis
+
+EXMPL completed a tight 7-week VCP base after a Q4 earnings beat; a breakout
+through the 142.50 pivot on expanding volume should resolve into a momentum
+advance toward the 165-170 measured-move zone.
+
+## Timeline
+
+| Event | Date | Price |
+|-------|------|-------|
+| Created | 2026-01-05T13:00:00+00:00 | — |
+| Entry | 2026-01-08T14:35:00+00:00 | 142.10 |
+| Exit | 2026-02-27T15:50:00+00:00 | 168.40 |
+
+## Outcome
+
+| Metric | Value |
+|--------|-------|
+| P&L ($) | 1841.00 |
+| P&L (%) | 18.5 |
+| Holding Days | 50 |
+| Exit Reason | target_hit |
+| MAE (%) | -4.2 |
+| MFE (%) | 21.0 |
+
+## Position
+
+| Metric | Value |
+|--------|-------|
+| Shares | 70 |
+| Position Value | 9947.00 |
+| Risk ($) | 532.00 |
+
+## Evidence at Entry
+
+- VCP base with three contractions, final contraction < 8%
+- Q4 revenue +24% YoY, raised FY guidance
+- Relative strength line at new high ahead of price
+- Accumulation: 4 up-weeks on volume vs 1 down-week
+
+## Kill Criteria
+
+- Close back below the 134.50 stop (base failure)
+- Two distribution weeks in the first 10 sessions post-breakout
+- Guidance walk-back or negative pre-announcement
+
+## Lessons Learned
+
+Thesis-driven winner (postmortem classified `TRUE_POSITIVE`). The initial 2R
+target (157.30) was reached on 2026-02-10; trailing the stop under the rising
+10-EMA captured an extra ~7% before the trail triggered at 168.40. MAE stayed
+shallow (-4.2%), confirming the breakout was well-timed. **Repeatable:** keep
+the "trail under 10-EMA after 2R" rule for clean VCP breakouts in RISK_ON
+regimes. The optional `backtest-expert` re-validation step was **skipped** in
+this required-only sample — a backtest of the trail rule would be the natural
+next refinement.

--- a/examples/workflows/trade-memory-loop/sample-run/manifest.yaml
+++ b/examples/workflows/trade-memory-loop/sample-run/manifest.yaml
@@ -1,0 +1,42 @@
+workflow_id: trade-memory-loop
+sample_type: required-only
+illustrative: true                 # fictional ticker EXMPL; not investment advice
+artifact_shape: raw-plus-handoff   # consistent across examples/workflows/;
+                                   # this workflow's artifacts are native shapes
+prompt: prompt.md
+
+optional_steps_skipped:
+  - step: 3
+    skill: backtest-expert
+    reason: required-only canonical sample
+
+artifacts:
+  - step: 1
+    artifact_id: closed_thesis_record
+    skill: trader-memory-core
+    schema: skills/trader-memory-core/schemas/thesis.schema.json
+    files:
+      canonical: 01_closed_thesis_record.yaml
+  - step: 2
+    artifact_id: postmortem_findings
+    skill: signal-postmortem
+    files:
+      canonical: 02_postmortem_findings.json
+      companion: 02_postmortem_summary.md
+  - step: 4
+    artifact_id: lessons_log_entry
+    skill: trader-memory-core
+    files:
+      canonical: 04_lessons_log_entry.md
+
+# Fixture note: 01_closed_thesis_record.yaml validates against the schema via
+# the real trader-memory-core validator (jsonschema Draft7 + CLOSED business
+# invariants); 02_postmortem_findings.json is produced by the real
+# signal-postmortem recorder consuming that thesis.
+verification:
+  thesis_status: CLOSED
+  thesis_validates: true            # thesis_store._validate_thesis() passes
+  expected:
+    outcome_category: TRUE_POSITIVE
+    holding_days: 50
+    exit_reason: target_hit

--- a/examples/workflows/trade-memory-loop/sample-run/prompt.md
+++ b/examples/workflows/trade-memory-loop/sample-run/prompt.md
@@ -1,0 +1,38 @@
+# Prompt — `trade-memory-loop` (required-only)
+
+Paste the following to Claude (with the `trader-memory-core` and
+`signal-postmortem` skills available). Replace `<repo>` with your checkout
+path and `$PROJECT_DIR` with your thesis state directory.
+
+---
+
+> I just closed a position. Run the **trade-memory-loop** workflow (required
+> steps only — skip the optional backtest-expert step).
+>
+> 1. Use **trader-memory-core** to record the closed trade outcome: update the
+>    thesis to `CLOSED` with the exit price/date, realized P&L, MAE/MFE, and
+>    final status history. State dir: `$PROJECT_DIR/state/theses/`.
+> 2. Use **signal-postmortem** to consume the closed thesis and classify the
+>    outcome (TRUE_POSITIVE / FALSE_POSITIVE / REGIME_MISMATCH / NEUTRAL),
+>    with the root-cause read: was it thesis quality, execution, market
+>    environment, or randomness?
+> 3. Use **trader-memory-core** again to append the lessons to my journal.
+>
+> Be honest about whether the win was thesis-driven or luck. Don't rationalize
+> randomness as skill.
+
+Trade details for this sample run: ticker **EXMPL**, LONG, entered
+2026-01-08 @ 142.10 (70 sh, 1% risk, stop 134.50), exited 2026-02-27 @
+168.40 (`target_hit`), origin `vcp-screener` grade A.
+
+---
+
+## What to expect
+
+This is the **required-only** path: the optional **backtest-expert**
+re-validation (step 3) is **not** run. The postmortem still fully classifies
+the outcome and the lessons are still journaled — a backtest would only add an
+extra statistical cross-check, noted as a follow-up in the journal entry.
+
+> ⚠️ Illustrative sample — fictional ticker `EXMPL`, **not investment
+> advice**.


### PR DESCRIPTION
## Summary

The canonical workflows in `workflows/*.yaml` had **no concrete sample run** —
only manifest YAML + prose. This adds the first two, as a prompt +
required-only sample artifacts + a machine-readable manifest, under a new
`examples/workflows/` tree.

**Additive, docs/sample-only. 17 files, all under `examples/workflows/`. No
code, skills-index, workflows, skillsets, docs, catalog, snapshot, config, CI,
or test change. No drift gate.**

## Why this is safe (no coupling)

No `scripts/generate_*.py`, `scripts/validate_*.py`, `build_snapshot.py`, CI
metadata job, or pytest path reads `examples/` (grep-confirmed; all five
`--check` generators show **no diff**). CI lint is hard-scoped to
`skills/ scripts/`. Editing/extending these files cannot cause
catalog/snapshot/docs drift. (The standard hygiene hooks — whitespace, YAML
syntax, `detect-secrets`, `no-absolute-paths`, `codespell` — *do* run and
pass; note `detect-secrets` is not `.yaml`-excluded, and the new YAML carries
no secret-like strings.)

## Code-faithful, not hand-typed

Sample artifacts are **hand-authored workflow hand-off artifacts** generated
via the **real** skill modules:

- `market-regime-daily/sample-run/04_exposure_decision.json` is produced by
  the real `exposure-coach` pipeline reading the `01`/`02` hand-off files.
  Required-only ⇒ `regime`/`top_risk` absent ⇒ the real critical-input
  haircut ⇒ **`REDUCE_ONLY` / `LOW` / ceiling 48**. This is the honest,
  code-faithful required-only result, and the README explains *why* (and that
  adding the optional satellites lifts it).
- `trade-memory-loop/sample-run/01_closed_thesis_record.yaml` passes the real
  `trader-memory-core` `_validate_thesis()` (`jsonschema` Draft-07 + `CLOSED`
  business invariants + RFC-3339);
  `02_postmortem_findings.json` is produced by the real `signal-postmortem`
  recorder (`TRUE_POSITIVE`, `holding_days=50`).

## `raw-plus-handoff` convention (documents a real gap)

The `01`/`02` JSON carry the real nested `composite { … }` block **and** a
top-level hand-off field (`breadth_score`/`uptrend_score`). This documents a
real `exposure-coach` parser asymmetry: `extract_uptrend_score()` handles the
nested shape but `extract_breadth_score()` does not. **That parser gap is NOT
fixed in this PR** — it is tracked separately in **#116** (a code change /
separate PR). `Refs #116` (intentionally not `Closes`).

## Scope decisions

- **Required-only**: each workflow's one optional step (market-regime
  step 3 `market-top-detector`; trade-memory step 3 `backtest-expert`) is
  intentionally skipped, recorded in `manifest.yaml` `optional_steps_skipped`
  + the README. Full-path samples deferred to a future change.
- **Fictional / not investment advice**: `EXMPL` ticker; market-level-only
  regime snapshot; bold disclaimer in every README; `illustrative: true` in
  every manifest.

## Verification

| Check | Result |
|---|---|
| Diff scope | **17 files, all under `examples/workflows/`**; non-examples diff empty; `git diff --check` clean |
| `generate_catalog_from_index.py --check` / `build_snapshot.py --check` / `generate_{skill,skillset,workflow}_docs.py --check` | **all pass, no diff** |
| Real extractors | `extract_breadth_score(01)=66`, `extract_uptrend_score(02)=72` == `04` `component_scores`; raw-only breadth → `None` (documents the gap) |
| Thesis schema | real `_validate_thesis()` PASS (Draft7 + `CLOSED` invariants + dates; `status_history` ends `CLOSED`, `shares_remaining=0`) |
| Manifest reachability | both workflows: `{prompt} ∪ canonical ∪ companion` == `ls sample-run/` − `manifest.yaml` (no orphan/dangling); skipped step matches workflow `optional` & has no artifact |
| Cross-artifact coherence | `04` == `01`/`02` composites, `top_risk` in `inputs_missing`; postmortem ↔ thesis consistent; journal cites postmortem, no fabricated backtest |
| `pre-commit run --all-files` | all 20 hooks pass (generator whitespace/EOF auto-fixed → re-staged → clean) |
| `uv run pytest -q` | **3283 passed, 17 skipped, 0 failed** |
| `scripts/run_all_tests.sh` | **46/46 passed**, 2 known skips (theme-detector, canslim-screener) |

Closes #117
Refs #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
