### PR TITLE
feat(vcp-screener): Add historical single-ticker VCP scan + fix latent volume-index bug

### DIFF
--- a/skills/vcp-screener/SKILL.md
+++ b/skills/vcp-screener/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vcp-screener
-description: Screen S&P 500 stocks for Mark Minervini's Volatility Contraction Pattern (VCP). Identifies Stage 2 uptrend stocks forming tight bases with contracting volatility near breakout pivot points. Use when user requests VCP screening, Minervini-style setups, tight base patterns, volatility contraction breakout candidates, or Stage 2 momentum stock scanning.
+description: Screen S&P 500 stocks for Mark Minervini's Volatility Contraction Pattern (VCP) and detect historical VCPs in a single ticker's price path. Identifies Stage 2 uptrend stocks forming tight bases with contracting volatility near breakout pivot points; in historical single-ticker mode walks a multi-year history and emits every VCP that formed with forward-outcome stats (breakout / stop-hit / timeout). Use when user requests VCP screening, Minervini-style setups, tight base patterns, volatility contraction breakout candidates, Stage 2 momentum stock scanning, or historical VCP pattern study on a specific ticker (e.g. FIX, TSLA).
 ---
 
 # VCP Screener - Minervini Volatility Contraction Pattern
@@ -13,6 +13,8 @@ Screen S&P 500 stocks for Mark Minervini's Volatility Contraction Pattern (VCP),
 - User wants to find tight base / volatility contraction patterns
 - User requests Stage 2 momentum stock scanning
 - User asks for breakout candidates with defined risk
+- User asks "find every historical VCP in <TICKER>" or wants to study one ticker's
+  past VCP setups with forward outcomes (`--history --ticker SYM`)
 
 ## Prerequisites
 
@@ -44,6 +46,52 @@ Only return stocks with `valid_vcp=True` AND `execution_state` in `(Pre-breakout
 ```bash
 python3 skills/vcp-screener/scripts/screen_vcp.py --strict --output-dir reports/
 ```
+
+### Historical single-ticker mode
+
+Walk one ticker's multi-year history, detect every VCP that ever formed, and
+attach forward-outcome stats (breakout / stop-hit / timeout, days-to-outcome,
+max gain, max loss) per detection. Useful for pattern study and backtesting
+context — not a real-time screener.
+
+```bash
+# Default: scan ~5 years (1260 trading days), 5-day stride, 60-day outcome window
+python3 skills/vcp-screener/scripts/screen_vcp.py \
+  --history --ticker FIX --output-dir reports/
+
+# Custom scan length: 750 trading days (~3 years), 90-day outcome window
+python3 skills/vcp-screener/scripts/screen_vcp.py \
+  --history 750 --ticker TSLA \
+  --stride-days 5 --outcome-days 90 \
+  --output-dir reports/
+
+# Long scan: 10 years (2520 trading days)
+python3 skills/vcp-screener/scripts/screen_vcp.py \
+  --history 2520 --ticker NVDA --output-dir reports/
+```
+
+Outputs (timestamped):
+- `vcp_history_<SYM>_<YYYY-MM-DD_HHMMSS>.json` — timeline of detections with full
+  analyzer payload + `forward_outcome` per detection + summary stats.
+- `vcp_history_<SYM>_<YYYY-MM-DD_HHMMSS>.md` — human-readable timeline.
+
+Mode-specific flags:
+
+| Parameter | Default | Range | Effect |
+|-----------|---------|-------|--------|
+| `--history [DAYS]` | (off) / 1260 if bare | 100-5040 | Enable historical mode; optionally specify trading-day scan window (requires `--ticker`) |
+| `--ticker SYM` | — | — | Ticker to scan |
+| `--stride-days` | 5 | 1-60 | Trading-day step between as-of cursor positions |
+| `--outcome-days` | 60 | 5-252 | Forward window evaluated per detection |
+
+Notes:
+- Two FMP API calls per scan (ticker + SPY history), not 100+ like the
+  cross-sectional pipeline.
+- `marketCap` and absolute RS percentile reflect the ticker in isolation,
+  not against the live screening universe — use this report for pattern
+  study, not portfolio sizing.
+- Detections are deduplicated by `(T1_high_date, last_low_date, pivot)` so
+  the same VCP isn't reported repeatedly as the cursor ages.
 
 ### Advanced Tuning (for backtesting)
 

--- a/skills/vcp-screener/scripts/calculators/forward_outcome.py
+++ b/skills/vcp-screener/scripts/calculators/forward_outcome.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Forward Outcome Calculator — what happened after the VCP was detected.
+
+Used by the historical single-ticker scanner to label each detected VCP with
+the trade-outcome it would have produced if entered at the pivot:
+
+- ``breakout``         : close > pivot within max_window_days
+- ``stop_hit``         : close < stop within window, before any breakout
+- ``timeout``          : neither hit; window expired
+- ``insufficient_data``: fewer than 1 forward bar available
+
+Conventions:
+- ``historical`` is most-recent-first (index 0 = most recent bar).
+- ``as_of_offset`` is the MRF index treated as the detection day; forward bars
+  are ``historical[0 : as_of_offset]`` walked oldest-to-newest.
+- ``max_gain_pct`` and ``max_loss_pct`` are measured against the as-of close,
+  not the pivot; they describe the trajectory regardless of outcome.
+"""
+
+from typing import Optional
+
+
+def calculate_forward_outcome(
+    historical_prices: list[dict],
+    as_of_offset: int,
+    pivot_price: float,
+    stop_price: Optional[float] = None,
+    max_window_days: int = 60,
+) -> dict:
+    """Compute the trade outcome for a VCP detected at ``historical_prices[as_of_offset]``.
+
+    Args:
+        historical_prices: Most-recent-first OHLCV bars.
+        as_of_offset: Index of the detection bar. Forward window is the bars
+            with smaller indices (i.e., more recent than the as-of bar).
+        pivot_price: Breakout trigger. First forward bar whose close exceeds
+            this is the breakout day.
+        stop_price: Stop-loss level (typically the last contraction's low). If
+            None, stop_hit is never reported. First forward bar whose close
+            falls below this — before any breakout — is the stop-hit day.
+        max_window_days: Number of forward bars to evaluate (default 60).
+
+    Returns:
+        Dict with the schema documented at the top of this module.
+    """
+    empty = {
+        "outcome_type": "insufficient_data",
+        "days_to_outcome": None,
+        "exit_price": None,
+        "exit_date": None,
+        "max_gain_pct": None,
+        "max_loss_pct": None,
+        "pivot_price": pivot_price,
+        "stop_price": stop_price,
+        "bars_available": 0,
+        "bars_evaluated": 0,
+    }
+
+    if not historical_prices or as_of_offset <= 0 or as_of_offset >= len(historical_prices):
+        return empty
+
+    as_of_close = historical_prices[as_of_offset].get("close")
+    if as_of_close in (None, 0):
+        return empty
+
+    # Forward bars in oldest-to-newest order (start at the bar right after
+    # the as-of bar and walk toward the present).
+    forward = list(reversed(historical_prices[:as_of_offset]))
+    bars_available = len(forward)
+    if bars_available == 0:
+        return empty
+
+    window = forward[:max_window_days]
+
+    outcome_type = "timeout"
+    days_to_outcome: Optional[int] = None
+    exit_price: Optional[float] = None
+    exit_date: Optional[str] = None
+    max_gain_pct: Optional[float] = None
+    max_loss_pct: Optional[float] = None
+
+    # Walk the entire forward window so max_gain / max_loss describe the full
+    # trajectory regardless of where the outcome is triggered. The outcome
+    # itself is set only at the first triggering bar.
+    for i, bar in enumerate(window, start=1):
+        close = bar.get("close")
+        if close is None:
+            continue
+
+        gain_pct = (close - as_of_close) / as_of_close * 100
+        if max_gain_pct is None or gain_pct > max_gain_pct:
+            max_gain_pct = gain_pct
+        if max_loss_pct is None or gain_pct < max_loss_pct:
+            max_loss_pct = gain_pct
+
+        if outcome_type == "timeout":
+            if close > pivot_price:
+                outcome_type = "breakout"
+                days_to_outcome = i
+                exit_price = close
+                exit_date = bar.get("date")
+            elif stop_price is not None and close < stop_price:
+                outcome_type = "stop_hit"
+                days_to_outcome = i
+                exit_price = close
+                exit_date = bar.get("date")
+
+    return {
+        "outcome_type": outcome_type,
+        "days_to_outcome": days_to_outcome,
+        "exit_price": round(exit_price, 4) if exit_price is not None else None,
+        "exit_date": exit_date,
+        "max_gain_pct": round(max_gain_pct, 4) if max_gain_pct is not None else None,
+        "max_loss_pct": round(max_loss_pct, 4) if max_loss_pct is not None else None,
+        "pivot_price": pivot_price,
+        "stop_price": stop_price,
+        "bars_available": bars_available,
+        "bars_evaluated": len(window),
+    }

--- a/skills/vcp-screener/scripts/fmp_client.py
+++ b/skills/vcp-screener/scripts/fmp_client.py
@@ -234,7 +234,8 @@ class FMPClient:
                 if not data:
                     self._record_endpoint_failure(base_url)
                     self._warn_fallback(
-                        base_url, is_last,
+                        base_url,
+                        is_last,
                         f"response had no rows matching '{symbols_str}'",
                     )
                     continue
@@ -279,7 +280,9 @@ class FMPClient:
                 elif is_single and data.get("symbol"):
                     if data["symbol"].replace("-", ".") != symbols_str.replace("-", "."):
                         valid = False
-                        shape_issue = f"response symbol '{data['symbol']}' != requested '{symbols_str}'"
+                        shape_issue = (
+                            f"response symbol '{data['symbol']}' != requested '{symbols_str}'"
+                        )
 
             if valid:
                 self._endpoint_failures[base_url] = 0

--- a/skills/vcp-screener/scripts/fmp_client.py
+++ b/skills/vcp-screener/scripts/fmp_client.py
@@ -143,11 +143,17 @@ class FMPClient:
         # Circuit breaker: track consecutive failures per endpoint URL prefix
         self._endpoint_failures: dict[str, int] = {}
         self._disabled_endpoints: set[str] = set()
+        # Most recent transport-level failure reason; set by _rate_limited_get
+        # so _request_with_fallback can surface suppressed errors even when
+        # an endpoint was called with quiet=True.
+        self._last_error: Optional[str] = None
 
     def _rate_limited_get(
         self, url: str, params: Optional[dict] = None, quiet: bool = False
     ) -> Optional[dict]:
+        self._last_error = None
         if self.rate_limit_reached:
+            self._last_error = "daily rate limit already reached"
             return None
 
         if params is None:
@@ -172,17 +178,21 @@ class FMPClient:
                     time.sleep(60)
                     return self._rate_limited_get(url, params, quiet=quiet)
                 else:
+                    self._last_error = "HTTP 429 (daily rate limit)"
                     print("ERROR: Daily API rate limit reached.", file=sys.stderr)
                     self.rate_limit_reached = True
                     return None
             else:
+                msg = f"HTTP {response.status_code} - {response.text[:200]}"
+                self._last_error = msg
                 if not quiet:
                     print(
-                        f"ERROR: API request failed: {response.status_code} - {response.text[:200]}",
+                        f"ERROR: API request failed: {msg}",
                         file=sys.stderr,
                     )
                 return None
         except requests.exceptions.RequestException as e:
+            self._last_error = f"request exception: {e}"
             print(f"ERROR: Request exception: {e}", file=sys.stderr)
             return None
 
@@ -190,7 +200,11 @@ class FMPClient:
         """Try stable endpoint first, fall back to v3 for legacy users.
 
         Returns parsed JSON in v3-compatible shape, or None if all fail.
-        Non-last endpoints use quiet=True to suppress expected 403 stderr.
+        Non-last endpoints are called with quiet=True so the user isn't
+        alarmed by an expected stable failure when v3 will catch it — but
+        when a non-last endpoint DOES fail, a WARN line is emitted explaining
+        why we're falling back. Otherwise users only see the (often misleading)
+        last-endpoint error and have no clue what really went wrong.
         """
         params = dict(extra_params) if extra_params else {}
         endpoints = _FMP_ENDPOINTS[endpoint_key]
@@ -206,6 +220,7 @@ class FMPClient:
             data = self._rate_limited_get(url, final_params, quiet=not is_last)
             if not data:  # falsy (None, [], {}) — try next endpoint
                 self._record_endpoint_failure(base_url)
+                self._warn_fallback(base_url, is_last, self._last_error)
                 continue
 
             # Normalize new stable EOD flat-list shape to v3-compatible dict.
@@ -218,22 +233,30 @@ class FMPClient:
                 data = _normalize_eod_flat_list(data, symbols_str, limit=limit)
                 if not data:
                     self._record_endpoint_failure(base_url)
+                    self._warn_fallback(
+                        base_url, is_last,
+                        f"response had no rows matching '{symbols_str}'",
+                    )
                     continue
 
             # Shape validation: reject truthy-but-wrong-shape responses
             valid = True
+            shape_issue: Optional[str] = None
             if endpoint_key == "quote":
                 if not isinstance(data, list) or len(data) == 0:
                     valid = False
+                    shape_issue = "expected non-empty list"
                 elif is_single and not any(
                     q.get("symbol", "").replace("-", ".") == symbols_str.replace("-", ".")
                     for q in data
                 ):
                     valid = False
+                    shape_issue = f"requested symbol '{symbols_str}' not in response"
 
             if endpoint_key == "historical":
                 if not isinstance(data, dict):
                     valid = False
+                    shape_issue = "expected dict"
                 elif "historicalStockList" in data:
                     # stable batch format -> v3 single format (exact match only)
                     norm = symbols_str.replace("-", ".")
@@ -249,17 +272,32 @@ class FMPClient:
                         self._endpoint_failures[base_url] = 0
                         return found
                     valid = False
+                    shape_issue = f"'{symbols_str}' not in historicalStockList"
                 elif "historical" not in data:
                     valid = False
+                    shape_issue = "missing 'historical' key"
                 elif is_single and data.get("symbol"):
                     if data["symbol"].replace("-", ".") != symbols_str.replace("-", "."):
                         valid = False
+                        shape_issue = f"response symbol '{data['symbol']}' != requested '{symbols_str}'"
 
             if valid:
                 self._endpoint_failures[base_url] = 0
                 return data
             self._record_endpoint_failure(base_url)
+            self._warn_fallback(base_url, is_last, shape_issue or "unexpected response shape")
         return None
+
+    def _warn_fallback(self, base_url: str, is_last: bool, reason: Optional[str]) -> None:
+        """Emit a WARN line so users see why a non-last endpoint failed and the
+        client is falling back. No-op when the failing endpoint is the last one
+        (its error was already printed by _rate_limited_get with quiet=False)."""
+        if is_last or not reason:
+            return
+        print(
+            f"WARN: {base_url} failed ({reason}); falling back to next endpoint",
+            file=sys.stderr,
+        )
 
     def _record_endpoint_failure(self, base_url: str) -> None:
         """Track consecutive failures and disable endpoint after threshold."""

--- a/skills/vcp-screener/scripts/historical_report.py
+++ b/skills/vcp-screener/scripts/historical_report.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Historical VCP report writers — JSON + Markdown timeline for a single ticker.
+
+Schema is intentionally distinct from the cross-sectional ``report_generator.py``
+output: that one is "ranked list at a single point in time", this one is
+"timeline of detections with forward-outcome stats per detection".
+"""
+
+import json
+from typing import Optional
+
+
+def generate_historical_json_report(
+    symbol: str,
+    detections: list[dict],
+    metadata: dict,
+    output_file: str,
+) -> None:
+    """Write a structured JSON timeline of historical VCP detections."""
+    report = {
+        "schema_version": "1.0",
+        "symbol": symbol,
+        "metadata": metadata,
+        "summary": _summarize(detections),
+        "detections": detections,
+    }
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, default=str)
+    print(f"  JSON report saved to: {output_file}")
+
+
+def generate_historical_markdown_report(
+    symbol: str,
+    detections: list[dict],
+    metadata: dict,
+    output_file: str,
+) -> None:
+    """Write a human-readable timeline of historical VCP detections."""
+    lines: list[str] = []
+
+    lines.append(f"# VCP History — {symbol}")
+    lines.append(f"**Generated:** {metadata.get('generated_at', 'N/A')}")
+    if metadata.get("history_range"):
+        lines.append(f"**History range:** {metadata['history_range']}")
+    lines.append(
+        f"**Sweep:** stride={metadata.get('stride_days', '?')}d, "
+        f"lookback={metadata.get('lookback_days', '?')}d, "
+        f"outcome_window={metadata.get('outcome_days', '?')}d"
+    )
+    lines.append("")
+    lines.append("> **Note**: `marketCap` and absolute RS percentile reflect the "
+                 "ticker in isolation, not against the live screening universe. "
+                 "Use this report for pattern study, not portfolio sizing.")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    summary = _summarize(detections)
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Detections | {summary['total']} |")
+    lines.append(f"| Breakouts | {summary['breakouts']} |")
+    lines.append(f"| Stop hits | {summary['stop_hits']} |")
+    lines.append(f"| Timeouts | {summary['timeouts']} |")
+    lines.append(
+        f"| Hit rate (breakouts / resolved) | {summary['hit_rate_pct']}% |"
+    )
+    lines.append(
+        f"| Avg max gain (breakouts only) | {summary['avg_max_gain_breakout_pct']}% |"
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    if not detections:
+        lines.append("_No VCP detections found in the scanned history._")
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+        print(f"  Markdown report saved to: {output_file}")
+        return
+
+    lines.append("## Detection Timeline")
+    lines.append("")
+    lines.append(
+        "| As-of date | Score | Rating | State | Pattern | Pivot | Stop | Outcome | Days | Max gain | Max loss |"
+    )
+    lines.append(
+        "|------------|-------|--------|-------|---------|-------|------|---------|------|----------|----------|"
+    )
+    for det in detections:
+        outcome = det.get("forward_outcome", {}) or {}
+        vcp = det.get("vcp_pattern", {}) or {}
+        contractions = vcp.get("contractions") or []
+        stop = contractions[-1].get("low_price") if contractions else None
+        lines.append(
+            "| {as_of} | {score} | {rating} | {state} | {pat} | {pivot} | {stop} | {outcome} | {days} | {gain} | {loss} |".format(
+                as_of=det.get("as_of_date", "?"),
+                score=_fmt(det.get("composite_score"), "{:.1f}"),
+                rating=det.get("rating", "-"),
+                state=det.get("execution_state", "-"),
+                pat=det.get("pattern_type", "-"),
+                pivot=_fmt(vcp.get("pivot_price"), "${:.2f}"),
+                stop=_fmt(stop, "${:.2f}"),
+                outcome=outcome.get("outcome_type", "-"),
+                days=_fmt(outcome.get("days_to_outcome"), "{}"),
+                gain=_fmt(outcome.get("max_gain_pct"), "{:+.1f}%"),
+                loss=_fmt(outcome.get("max_loss_pct"), "{:+.1f}%"),
+            )
+        )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("## Per-detection detail")
+    lines.append("")
+    for i, det in enumerate(detections, start=1):
+        vcp = det.get("vcp_pattern", {}) or {}
+        outcome = det.get("forward_outcome", {}) or {}
+        contractions = vcp.get("contractions") or []
+        lines.append(f"### {i}. {det.get('as_of_date', '?')} — {det.get('rating', '-')}")
+        lines.append("")
+        lines.append(
+            f"- **Composite score:** {_fmt(det.get('composite_score'), '{:.1f}')}  "
+            f"({det.get('pattern_type', '-')}, state: {det.get('execution_state', '-')})"
+        )
+        lines.append(
+            f"- **Pivot:** {_fmt(vcp.get('pivot_price'), '${:.2f}')}  ·  "
+            f"**# contractions:** {vcp.get('num_contractions', '-')}  ·  "
+            f"**duration:** {vcp.get('pattern_duration_days', '-')} bars"
+        )
+        if contractions:
+            lines.append("- **Contractions:**")
+            for c in contractions:
+                lines.append(
+                    f"  - {c.get('label', '?')}: "
+                    f"{c.get('high_date', '?')} ${c.get('high_price', '?')} → "
+                    f"{c.get('low_date', '?')} ${c.get('low_price', '?')}  "
+                    f"({_fmt(c.get('depth_pct'), '{:.1f}%')}, "
+                    f"{c.get('duration_days', '?')}d)"
+                )
+        lines.append(
+            f"- **Forward outcome ({outcome.get('bars_evaluated', '?')} bars):** "
+            f"{outcome.get('outcome_type', '-')} "
+            f"in {_fmt(outcome.get('days_to_outcome'), '{} days')}  ·  "
+            f"max gain {_fmt(outcome.get('max_gain_pct'), '{:+.1f}%')}  ·  "
+            f"max loss {_fmt(outcome.get('max_loss_pct'), '{:+.1f}%')}"
+        )
+        lines.append("")
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+    print(f"  Markdown report saved to: {output_file}")
+
+
+def _fmt(val, template: str) -> str:
+    if val is None:
+        return "-"
+    try:
+        return template.format(val)
+    except (TypeError, ValueError):
+        return str(val)
+
+
+def _summarize(detections: list[dict]) -> dict:
+    total = len(detections)
+    counts = {"breakout": 0, "stop_hit": 0, "timeout": 0, "insufficient_data": 0}
+    gain_sum = 0.0
+    gain_count = 0
+    for det in detections:
+        oc = (det.get("forward_outcome") or {}).get("outcome_type")
+        if oc in counts:
+            counts[oc] += 1
+        if oc == "breakout":
+            g = (det.get("forward_outcome") or {}).get("max_gain_pct")
+            if g is not None:
+                gain_sum += g
+                gain_count += 1
+    resolved = counts["breakout"] + counts["stop_hit"]
+    hit_rate = round(counts["breakout"] / resolved * 100, 1) if resolved else None
+    avg_gain = round(gain_sum / gain_count, 1) if gain_count else None
+    return {
+        "total": total,
+        "breakouts": counts["breakout"],
+        "stop_hits": counts["stop_hit"],
+        "timeouts": counts["timeout"],
+        "insufficient_data": counts["insufficient_data"],
+        "hit_rate_pct": hit_rate,
+        "avg_max_gain_breakout_pct": avg_gain,
+    }

--- a/skills/vcp-screener/scripts/historical_report.py
+++ b/skills/vcp-screener/scripts/historical_report.py
@@ -7,7 +7,6 @@ output: that one is "ranked list at a single point in time", this one is
 """
 
 import json
-from typing import Optional
 
 
 def generate_historical_json_report(
@@ -48,9 +47,11 @@ def generate_historical_markdown_report(
         f"outcome_window={metadata.get('outcome_days', '?')}d"
     )
     lines.append("")
-    lines.append("> **Note**: `marketCap` and absolute RS percentile reflect the "
-                 "ticker in isolation, not against the live screening universe. "
-                 "Use this report for pattern study, not portfolio sizing.")
+    lines.append(
+        "> **Note**: `marketCap` and absolute RS percentile reflect the "
+        "ticker in isolation, not against the live screening universe. "
+        "Use this report for pattern study, not portfolio sizing."
+    )
     lines.append("")
     lines.append("---")
     lines.append("")
@@ -64,12 +65,8 @@ def generate_historical_markdown_report(
     lines.append(f"| Breakouts | {summary['breakouts']} |")
     lines.append(f"| Stop hits | {summary['stop_hits']} |")
     lines.append(f"| Timeouts | {summary['timeouts']} |")
-    lines.append(
-        f"| Hit rate (breakouts / resolved) | {summary['hit_rate_pct']}% |"
-    )
-    lines.append(
-        f"| Avg max gain (breakouts only) | {summary['avg_max_gain_breakout_pct']}% |"
-    )
+    lines.append(f"| Hit rate (breakouts / resolved) | {summary['hit_rate_pct']}% |")
+    lines.append(f"| Avg max gain (breakouts only) | {summary['avg_max_gain_breakout_pct']}% |")
     lines.append("")
     lines.append("---")
     lines.append("")

--- a/skills/vcp-screener/scripts/historical_scanner.py
+++ b/skills/vcp-screener/scripts/historical_scanner.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Historical VCP Scanner — walk a single ticker's price history and detect
+every VCP that formed along the way.
+
+Companion to the cross-sectional ``screen_vcp.py`` pipeline. Unlike that
+pipeline (which answers "which S&P 500 names are setting up *now*"), this
+scanner answers "which VCPs has this one ticker formed in the past N years,
+and what happened after each one?"
+
+Pipeline:
+  1. Fetch a long history (e.g. ~5 years) once.
+  2. Walk the as-of cursor backwards in time at ``stride_days`` (default 5).
+  3. At each cursor position, synthesize a quote (no future-bar peeking) and
+     call ``analyze_stock(..., as_of_offset=cursor)``.
+  4. For every ``valid_vcp=True`` detection, compute the forward outcome
+     (breakout / stop_hit / timeout) over the next ``outcome_days`` bars.
+  5. Deduplicate by (T1_high_date, last_low_date, round(pivot, 2)) so the same
+     pattern isn't reported repeatedly as the cursor ages.
+  6. Return detections in chronological order (oldest first).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+# Allow imports from the scripts/ directory when invoked as a module.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import screen_vcp  # noqa: E402  — bound at module load so tests can monkeypatch
+                   # `historical_scanner.screen_vcp.analyze_stock` deterministically.
+from calculators.forward_outcome import calculate_forward_outcome  # noqa: E402
+
+
+_TICKER_RE = re.compile(r"^[A-Z][A-Z0-9.\-]{0,11}$")
+
+
+def sanitize_ticker(symbol: str) -> str:
+    """Validate that ``symbol`` matches an FMP-style ticker (letters, digits,
+    dot, hyphen; starts with a letter; up to 12 chars). Returns the uppercased
+    symbol. Raises ``ValueError`` on anything that could traverse a path or
+    inject characters into a filename.
+    """
+    sym = (symbol or "").upper().strip()
+    if not _TICKER_RE.match(sym):
+        raise ValueError(
+            f"Invalid ticker symbol: {symbol!r}. Must match {_TICKER_RE.pattern}"
+        )
+    return sym
+
+
+def build_quote_from_history(
+    historical: list[dict],
+    as_of_offset: int,
+    year_window_bars: int = 252,
+) -> dict:
+    """Synthesize a quote dict compatible with ``calculate_trend_template``
+    using only bars at or older than ``historical[as_of_offset]``.
+
+    Contract: no bar with MRF index < ``as_of_offset`` may influence any
+    returned field. (Those bars are "future" relative to the as-of date.)
+
+    Returns:
+        Dict with at minimum ``price``, ``yearHigh``, ``yearLow``,
+        ``avgVolume``, ``marketCap`` (defaulted to 0 — historical share count
+        is not retrievable from OHLCV).
+    """
+    if not historical or as_of_offset < 0 or as_of_offset >= len(historical):
+        return {"price": 0, "yearHigh": 0, "yearLow": 0, "avgVolume": 0, "marketCap": 0}
+
+    as_of_bar = historical[as_of_offset]
+    window = historical[as_of_offset : as_of_offset + year_window_bars]
+    if not window:
+        return {"price": 0, "yearHigh": 0, "yearLow": 0, "avgVolume": 0, "marketCap": 0}
+
+    year_high = max(d.get("high", 0) for d in window)
+    year_low = min(d.get("low", 0) for d in window if d.get("low", 0) > 0)
+    vol_window = historical[as_of_offset : as_of_offset + 50]
+    avg_volume = (
+        int(sum(d.get("volume", 0) for d in vol_window) / len(vol_window))
+        if vol_window
+        else 0
+    )
+
+    return {
+        "price": as_of_bar.get("close", 0),
+        "yearHigh": year_high,
+        "yearLow": year_low,
+        "avgVolume": avg_volume,
+        "marketCap": 0,  # historical share count not available; deliberately stubbed.
+    }
+
+
+def scan_history(
+    symbol: str,
+    historical: list[dict],
+    sp500_history: list[dict],
+    *,
+    sector: str = "Unknown",
+    company_name: str = "",
+    stride_days: int = 5,
+    outcome_days: int = 60,
+    lookback_days: int = 120,
+    analyzer_kwargs: dict | None = None,
+) -> list[dict]:
+    """Walk ``historical`` from oldest scannable bar to ``outcome_days`` ago,
+    detect VCPs, deduplicate, and attach forward outcomes.
+
+    Args:
+        symbol: Ticker symbol (passed through to ``analyze_stock``).
+        historical: Most-recent-first OHLCV bars (typically 5+ years).
+        sp500_history: Most-recent-first SPY OHLCV, aligned by index with
+            ``historical``. Sliced identically to keep RS comparisons fair.
+        sector / company_name: Metadata for output.
+        stride_days: Step size for the as-of cursor in trading days (default 5).
+        outcome_days: Forward window for outcome evaluation (default 60).
+        lookback_days: Window passed to the VCP calculator (default 120).
+        analyzer_kwargs: Extra kwargs forwarded to ``analyze_stock`` (e.g.
+            ``min_contractions``, ``t1_depth_min``, etc.).
+
+    Returns:
+        List of detection dicts (chronological), each shaped as the
+        ``analyze_stock`` return value plus ``as_of_date`` and
+        ``forward_outcome`` fields.
+    """
+    if not historical or len(historical) < lookback_days + 30:
+        return []
+
+    analyzer_kwargs = dict(analyzer_kwargs or {})
+    analyzer_kwargs.pop("as_of_offset", None)  # caller cannot override the cursor
+
+    # Largest scannable offset is len(historical) - lookback_days; smaller
+    # offsets get less forward data (outcomes resolve via timeout /
+    # insufficient_data branches). range() with a negative step already
+    # yields descending offsets — no extra sort needed.
+    max_offset = len(historical) - lookback_days
+    if max_offset <= 0:
+        return []
+    offsets = range(max_offset, -1, -stride_days)
+
+    seen: set[tuple[str, str, float]] = set()
+    detections: list[dict] = []
+
+    for offset in offsets:
+        quote = build_quote_from_history(historical, offset)
+        if quote.get("price", 0) <= 0:
+            continue
+
+        # Looked up via the screen_vcp module attribute so tests can monkeypatch
+        # historical_scanner.screen_vcp.analyze_stock to inject fake results.
+        result = screen_vcp.analyze_stock(
+            symbol,
+            historical,
+            quote,
+            sp500_history,
+            sector=sector,
+            company_name=company_name,
+            lookback_days=lookback_days,
+            as_of_offset=offset,
+            **analyzer_kwargs,
+        )
+        if result is None or not result.get("valid_vcp"):
+            continue
+
+        contractions = result.get("vcp_pattern", {}).get("contractions") or []
+        pivot = result.get("vcp_pattern", {}).get("pivot_price")
+        if not contractions or pivot is None:
+            continue
+
+        # Dedup key: identify by the first contraction's start and the last
+        # contraction's bottom, plus pivot (rounded). Fall back to chronological
+        # index strings if dates are missing so two unrelated patterns don't
+        # collide on the empty-string default.
+        first_c = contractions[0]
+        last_c = contractions[-1]
+        key = (
+            first_c.get("high_date") or f"idx:{first_c.get('high_idx', '')}",
+            last_c.get("low_date") or f"idx:{last_c.get('low_idx', '')}",
+            round(float(pivot), 2),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+
+        outcome = calculate_forward_outcome(
+            historical,
+            as_of_offset=offset,
+            pivot_price=float(pivot),
+            stop_price=contractions[-1].get("low_price"),
+            max_window_days=outcome_days,
+        )
+
+        result["as_of_date"] = historical[offset].get("date")
+        result["as_of_offset"] = offset
+        result["forward_outcome"] = outcome
+        detections.append(result)
+
+    # Sort chronologically oldest -> newest by as_of_date.
+    detections.sort(key=lambda r: r.get("as_of_date") or "")
+    return detections

--- a/skills/vcp-screener/scripts/historical_scanner.py
+++ b/skills/vcp-screener/scripts/historical_scanner.py
@@ -29,9 +29,9 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import screen_vcp  # noqa: E402  — bound at module load so tests can monkeypatch
-                   # `historical_scanner.screen_vcp.analyze_stock` deterministically.
-from calculators.forward_outcome import calculate_forward_outcome  # noqa: E402
 
+# `historical_scanner.screen_vcp.analyze_stock` deterministically.
+from calculators.forward_outcome import calculate_forward_outcome  # noqa: E402
 
 _TICKER_RE = re.compile(r"^[A-Z][A-Z0-9.\-]{0,11}$")
 
@@ -44,9 +44,7 @@ def sanitize_ticker(symbol: str) -> str:
     """
     sym = (symbol or "").upper().strip()
     if not _TICKER_RE.match(sym):
-        raise ValueError(
-            f"Invalid ticker symbol: {symbol!r}. Must match {_TICKER_RE.pattern}"
-        )
+        raise ValueError(f"Invalid ticker symbol: {symbol!r}. Must match {_TICKER_RE.pattern}")
     return sym
 
 
@@ -78,9 +76,7 @@ def build_quote_from_history(
     year_low = min(d.get("low", 0) for d in window if d.get("low", 0) > 0)
     vol_window = historical[as_of_offset : as_of_offset + 50]
     avg_volume = (
-        int(sum(d.get("volume", 0) for d in vol_window) / len(vol_window))
-        if vol_window
-        else 0
+        int(sum(d.get("volume", 0) for d in vol_window) / len(vol_window)) if vol_window else 0
     )
 
     return {

--- a/skills/vcp-screener/scripts/screen_vcp.py
+++ b/skills/vcp-screener/scripts/screen_vcp.py
@@ -43,7 +43,6 @@ from fmp_client import FMPClient
 from report_generator import generate_json_report, generate_markdown_report
 from scorer import calculate_composite_score
 
-
 # Historical scan window default (~5 years in trading days). Used by
 # argparse `const=` so bare `--history` keeps the prior default behavior.
 DEFAULT_HISTORY_DAYS = 1260
@@ -236,8 +235,7 @@ def parse_arguments():
             parser.error("--history requires --ticker SYM")
         if not (100 <= args.history <= 5040):
             parser.error(
-                "--history must be 100-5040 trading days "
-                "(approximately 5 months to 20 years)"
+                "--history must be 100-5040 trading days (approximately 5 months to 20 years)"
             )
         if not (1 <= args.stride_days <= 60):
             parser.error("--stride-days must be 1-60")

--- a/skills/vcp-screener/scripts/screen_vcp.py
+++ b/skills/vcp-screener/scripts/screen_vcp.py
@@ -44,6 +44,11 @@ from report_generator import generate_json_report, generate_markdown_report
 from scorer import calculate_composite_score
 
 
+# Historical scan window default (~5 years in trading days). Used by
+# argparse `const=` so bare `--history` keeps the prior default behavior.
+DEFAULT_HISTORY_DAYS = 1260
+
+
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description="VCP Stock Screener - Minervini Volatility Contraction Pattern"
@@ -171,6 +176,41 @@ def parse_arguments():
         ),
     )
 
+    hist_group = parser.add_argument_group("Historical single-ticker mode")
+    # --history accepts an optional integer: scan-window length in trading days.
+    # Bare --history uses DEFAULT_HISTORY_DAYS (5 years). The total fetch is
+    # this value plus lookback, outcome window, and a safety buffer (computed
+    # internally in run_historical).
+    hist_group.add_argument(
+        "--history",
+        nargs="?",
+        type=int,
+        const=DEFAULT_HISTORY_DAYS,
+        default=None,
+        metavar="DAYS",
+        help=(
+            f"Scan a single ticker's history for all VCPs. With a value, scans "
+            f"NNN trading days back from the present; without a value, defaults "
+            f"to {DEFAULT_HISTORY_DAYS} trading days (~5 years). Requires --ticker."
+        ),
+    )
+    hist_group.add_argument(
+        "--ticker",
+        help="Ticker symbol for historical scan (e.g. FIX, TSLA)",
+    )
+    hist_group.add_argument(
+        "--stride-days",
+        type=int,
+        default=5,
+        help="Trading-day step for the as-of cursor (default 5)",
+    )
+    hist_group.add_argument(
+        "--outcome-days",
+        type=int,
+        default=60,
+        help="Forward window for outcome evaluation (default 60)",
+    )
+
     args = parser.parse_args()
 
     # Lower bound is 2 by design: VCP requires successive contractions, and
@@ -191,6 +231,18 @@ def parse_arguments():
         parser.error("--min-contraction-days must be 1-30")
     if not (30 <= args.lookback_days <= 365):
         parser.error("--lookback-days must be 30-365")
+    if args.history is not None:
+        if not args.ticker:
+            parser.error("--history requires --ticker SYM")
+        if not (100 <= args.history <= 5040):
+            parser.error(
+                "--history must be 100-5040 trading days "
+                "(approximately 5 months to 20 years)"
+            )
+        if not (1 <= args.stride_days <= 60):
+            parser.error("--stride-days must be 1-60")
+        if not (5 <= args.outcome_days <= 252):
+            parser.error("--outcome-days must be 5-252")
 
     return args
 
@@ -267,11 +319,30 @@ def analyze_stock(
     breakout_volume_ratio: float = 1.5,
     max_sma200_extension: float = 50.0,
     wide_and_loose_threshold: float = 15.0,
+    as_of_offset: int = 0,
 ) -> Optional[dict]:
     """
     Full VCP analysis for a single stock (Phase 3).
     No additional API calls needed - uses pre-fetched data.
+
+    Args:
+        as_of_offset: Index into ``historical`` (most-recent-first) that the
+            analysis should treat as "today". Default 0 = analyze right edge,
+            matching cross-sectional screening. Positive values shift the
+            as-of cursor into the past for historical/walk-forward analysis;
+            the caller is responsible for synthesizing ``quote`` (price /
+            yearHigh / yearLow) from the OHLCV slice at that offset.
+            ``sp500_history`` is sliced identically so RS comparisons stay
+            aligned. Bars more recent than ``historical[as_of_offset]`` are
+            ignored.
     """
+    # Historical mode: shift the as-of cursor by slicing both arrays so
+    # historical[as_of_offset] becomes index 0 for every downstream calculator.
+    if as_of_offset > 0:
+        historical = historical[as_of_offset:]
+        if sp500_history:
+            sp500_history = sp500_history[as_of_offset:]
+
     price = quote.get("price", 0)
     market_cap = quote.get("marketCap", 0)
 
@@ -301,9 +372,14 @@ def analyze_stock(
     )
 
     # 4. Volume Pattern
+    # Slice to the same lookback window the VCP calculator used. Contraction
+    # high_idx/low_idx are chronological indices over historical[:lookback_days];
+    # _zone_volume_analysis maps them back via n - 1 - chrono_idx, so n must
+    # equal that slice length or the reverse mapping reads the wrong bars.
     pivot_price = vcp_result.get("pivot_price")
+    historical_lookback = historical[:lookback_days]
     vol_result = calculate_volume_pattern(
-        historical,
+        historical_lookback,
         pivot_price=pivot_price,
         contractions=vcp_result.get("contractions"),
         breakout_volume_ratio=breakout_volume_ratio,
@@ -477,6 +553,111 @@ def compute_entry_ready(
     return True
 
 
+def run_historical(args, client) -> None:
+    """Historical single-ticker scan: fetch long history, walk the as-of
+    cursor, attach forward outcomes, write reports. Exits via return."""
+    from historical_report import (
+        generate_historical_json_report,
+        generate_historical_markdown_report,
+    )
+    from historical_scanner import sanitize_ticker, scan_history
+
+    try:
+        ticker = sanitize_ticker(args.ticker)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Required bars = scan window (args.history) + lookback at the oldest
+    # offset + outcome window. A 60-bar buffer protects against FMP returning
+    # fewer bars than requested due to holidays/halts/recent listings.
+    scan_days = args.history
+    required_days = scan_days + args.lookback_days + args.outcome_days
+    fetch_days = required_days + 60
+    print()
+    print(f"Historical VCP Scan — {ticker}")
+    print("-" * 70)
+    print(
+        f"  Fetching {fetch_days}-day history for {ticker} and SPY...",
+        end=" ",
+        flush=True,
+    )
+    ticker_data = client.get_historical_prices(ticker, days=fetch_days)
+    spy_data = client.get_historical_prices("SPY", days=fetch_days)
+    historical = ticker_data.get("historical", []) if ticker_data else []
+    sp500_history = spy_data.get("historical", []) if spy_data else []
+    if not historical:
+        print("FAILED")
+        print(f"ERROR: No historical data returned for {ticker}", file=sys.stderr)
+        sys.exit(1)
+    print(f"OK ({len(historical)} ticker bars, {len(sp500_history)} SPY bars)")
+    if len(historical) < required_days:
+        print(
+            f"  WARN: requested ~{required_days} bars but FMP returned "
+            f"{len(historical)}; oldest part of the scan window will be truncated."
+        )
+
+    print(
+        f"  Sweeping history (stride={args.stride_days}d, "
+        f"lookback={args.lookback_days}d, outcome={args.outcome_days}d)..."
+    )
+    analyzer_kwargs = {
+        "ext_threshold": args.ext_threshold,
+        "min_contractions": args.min_contractions,
+        "t1_depth_min": args.t1_depth_min,
+        "contraction_ratio": args.contraction_ratio,
+        "atr_multiplier": args.atr_multiplier,
+        "min_contraction_days": args.min_contraction_days,
+        "breakout_volume_ratio": args.breakout_volume_ratio,
+        "max_sma200_extension": args.max_sma200_extension,
+        "wide_and_loose_threshold": args.wide_and_loose_threshold,
+    }
+    detections = scan_history(
+        ticker,
+        historical,
+        sp500_history,
+        stride_days=args.stride_days,
+        outcome_days=args.outcome_days,
+        lookback_days=args.lookback_days,
+        analyzer_kwargs=analyzer_kwargs,
+    )
+    print(f"  Found {len(detections)} unique VCP detections")
+    print()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    # Use the same YYYY-MM-DD_HHMMSS pattern as the cross-sectional report so
+    # repeated same-day runs don't overwrite previous output.
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+    json_file = os.path.join(args.output_dir, f"vcp_history_{ticker}_{timestamp}.json")
+    md_file = os.path.join(args.output_dir, f"vcp_history_{ticker}_{timestamp}.md")
+    history_range = ""
+    if historical:
+        history_range = f"{historical[-1].get('date', '?')} to {historical[0].get('date', '?')}"
+    metadata = {
+        "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "symbol": ticker,
+        "scan_days": scan_days,
+        "stride_days": args.stride_days,
+        "lookback_days": args.lookback_days,
+        "outcome_days": args.outcome_days,
+        "bars_fetched": len(historical),
+        "history_range": history_range,
+        "tuning_params": analyzer_kwargs,
+        "api_stats": client.get_api_stats(),
+    }
+    generate_historical_json_report(ticker, detections, metadata, json_file)
+    generate_historical_markdown_report(ticker, detections, metadata, md_file)
+
+    print()
+    print("=" * 70)
+    print(f"Historical VCP scan complete — {ticker}")
+    print("=" * 70)
+    print(f"  Detections: {len(detections)}")
+    print(f"  JSON Report:     {json_file}")
+    print(f"  Markdown Report: {md_file}")
+    print()
+
+
 def main():
     args = parse_arguments()
 
@@ -497,6 +678,13 @@ def main():
     except ValueError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(1)
+
+    # ------------------------------------------------------------------------
+    # Historical single-ticker mode dispatch — completes via early return.
+    # ------------------------------------------------------------------------
+    if args.history is not None:
+        run_historical(args, client)
+        return
 
     # ========================================================================
     # Phase 1: Pre-Filter (API-efficient)

--- a/skills/vcp-screener/scripts/tests/test_fmp_client_historical.py
+++ b/skills/vcp-screener/scripts/tests/test_fmp_client_historical.py
@@ -15,11 +15,11 @@ def _make_client():
     return client
 
 
-def _mock_response(status_code, json_payload):
+def _mock_response(status_code, json_payload, text=""):
     resp = MagicMock()
     resp.status_code = status_code
     resp.json.return_value = json_payload
-    resp.text = ""
+    resp.text = text
     return resp
 
 
@@ -68,3 +68,68 @@ class TestEODFlatListSuccess:
         assert "historical-price-eod/full" in url
         assert "from" in params and "to" in params
         assert "timeseries" not in params
+
+
+class TestFallbackTransparency:
+    """When stable fails and the client falls back to v3, the user must
+    see WHY the first endpoint was skipped — otherwise they get the v3
+    'Legacy Endpoint' error with no context."""
+
+    @patch("fmp_client.requests.Session")
+    def test_stable_error_surfaced_when_falling_back_to_v3(
+        self, mock_session_class, capsys
+    ):
+        """403 on stable, 403 on v3 — both errors must appear in stderr."""
+        mock_session = MagicMock()
+        mock_session.get.side_effect = [
+            _mock_response(
+                403, None,
+                text='{"Error Message": "Special Endpoint: This symbol is not available..."}',
+            ),
+            _mock_response(
+                403, None,
+                text='{"Error Message": "Legacy Endpoint: only legacy users..."}',
+            ),
+        ]
+        mock_session_class.return_value = mock_session
+
+        client = _make_client()
+        client.session = mock_session
+
+        result = client.get_historical_prices("GOOG", days=10)
+        assert result is None
+
+        captured = capsys.readouterr()
+        # Both endpoints' errors must be visible.
+        assert "Special Endpoint" in captured.err, (
+            f"stable endpoint error not surfaced. stderr:\n{captured.err}"
+        )
+        assert "Legacy Endpoint" in captured.err, (
+            f"v3 endpoint error missing. stderr:\n{captured.err}"
+        )
+        # The user should also see which endpoint was tried first / fell back to.
+        assert "stable" in captured.err.lower() or "fallback" in captured.err.lower(), (
+            f"no fallback context in stderr:\n{captured.err}"
+        )
+
+    @patch("fmp_client.requests.Session")
+    def test_stable_success_suppresses_warning(self, mock_session_class, capsys):
+        """Happy path: stable succeeds, no fallback warning emitted."""
+        mock_session = MagicMock()
+        mock_session.get.return_value = _mock_response(
+            200,
+            [{"symbol": "AAPL", "date": "2026-01-01", "open": 1.0, "high": 1.0,
+              "low": 1.0, "close": 1.0, "volume": 1000}],
+        )
+        mock_session_class.return_value = mock_session
+
+        client = _make_client()
+        client.session = mock_session
+
+        result = client.get_historical_prices("AAPL", days=1)
+        assert result is not None
+
+        captured = capsys.readouterr()
+        # Happy path must stay quiet — no spurious warnings.
+        assert "WARN" not in captured.err, f"unexpected stderr:\n{captured.err}"
+        assert "fallback" not in captured.err.lower()

--- a/skills/vcp-screener/scripts/tests/test_fmp_client_historical.py
+++ b/skills/vcp-screener/scripts/tests/test_fmp_client_historical.py
@@ -76,18 +76,18 @@ class TestFallbackTransparency:
     'Legacy Endpoint' error with no context."""
 
     @patch("fmp_client.requests.Session")
-    def test_stable_error_surfaced_when_falling_back_to_v3(
-        self, mock_session_class, capsys
-    ):
+    def test_stable_error_surfaced_when_falling_back_to_v3(self, mock_session_class, capsys):
         """403 on stable, 403 on v3 — both errors must appear in stderr."""
         mock_session = MagicMock()
         mock_session.get.side_effect = [
             _mock_response(
-                403, None,
+                403,
+                None,
                 text='{"Error Message": "Special Endpoint: This symbol is not available..."}',
             ),
             _mock_response(
-                403, None,
+                403,
+                None,
                 text='{"Error Message": "Legacy Endpoint: only legacy users..."}',
             ),
         ]
@@ -118,8 +118,17 @@ class TestFallbackTransparency:
         mock_session = MagicMock()
         mock_session.get.return_value = _mock_response(
             200,
-            [{"symbol": "AAPL", "date": "2026-01-01", "open": 1.0, "high": 1.0,
-              "low": 1.0, "close": 1.0, "volume": 1000}],
+            [
+                {
+                    "symbol": "AAPL",
+                    "date": "2026-01-01",
+                    "open": 1.0,
+                    "high": 1.0,
+                    "low": 1.0,
+                    "close": 1.0,
+                    "volume": 1000,
+                }
+            ],
         )
         mock_session_class.return_value = mock_session
 

--- a/skills/vcp-screener/scripts/tests/test_historical_vcp.py
+++ b/skills/vcp-screener/scripts/tests/test_historical_vcp.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Tests for historical single-ticker VCP scanning.
+
+Covers:
+- analyze_stock(as_of_offset=...) equivalence with pre-sliced inputs
+- build_quote_from_history (no-lookahead contract)
+- calculate_forward_outcome (breakout / stop-hit / timeout paths)
+- HistoricalScanner walk + dedup
+"""
+
+import os
+import sys
+
+import pytest
+
+
+# Reuse the synthetic-data helper from the existing test module.
+sys.path.insert(0, os.path.dirname(__file__))
+from test_vcp_screener import _make_prices  # noqa: E402
+
+
+# ===========================================================================
+# analyze_stock(as_of_offset=...) — equivalence with pre-sliced inputs
+# ===========================================================================
+
+
+class TestAsOfOffsetSeam:
+    """as_of_offset=N must produce identical output to pre-slicing the inputs."""
+
+    def test_offset_equals_pre_slice(self):
+        from screen_vcp import analyze_stock
+
+        # Generate enough history for trend template (>= 222 bars) and lookback.
+        full_hist = _make_prices(300, start=100, daily_change=0.001)
+        full_spy = _make_prices(300, start=400, daily_change=0.0005)
+        offset = 60
+
+        # When the analysis cursor is at offset 60, treat that bar as "today".
+        # Caller is responsible for synthesizing the quote from the slice.
+        as_of_bar = full_hist[offset]
+        year_window = full_hist[offset : offset + 252]
+        synth_quote = {
+            "price": as_of_bar["close"],
+            "yearHigh": max(d["high"] for d in year_window),
+            "yearLow": min(d["low"] for d in year_window),
+            "marketCap": 1e9,
+            "avgVolume": 1_000_000,
+        }
+
+        # Path A: pre-slice both arrays, as_of_offset=0
+        result_pre = analyze_stock(
+            "TEST",
+            full_hist[offset:],
+            synth_quote,
+            full_spy[offset:],
+            sector="Tech",
+            company_name="Test Corp",
+        )
+
+        # Path B: pass full arrays, as_of_offset=60
+        result_off = analyze_stock(
+            "TEST",
+            full_hist,
+            synth_quote,
+            full_spy,
+            sector="Tech",
+            company_name="Test Corp",
+            as_of_offset=offset,
+        )
+
+        assert result_pre is not None and result_off is not None
+        # Compare every numeric / categorical field that matters for downstream
+        # use; nested dicts (trend_template, vcp_pattern, etc.) included.
+        for key in (
+            "composite_score",
+            "valid_vcp",
+            "execution_state",
+            "pattern_type",
+            "distance_from_pivot_pct",
+            "sma200_distance_pct",
+        ):
+            assert result_pre[key] == result_off[key], f"mismatch at {key}"
+        # Volume zone analysis is the path most affected by slicing — assert it
+        # explicitly so a regression on the as-of-offset seam is loud.
+        za_pre = result_pre["volume_pattern"].get("zone_analysis")
+        za_off = result_off["volume_pattern"].get("zone_analysis")
+        assert za_pre == za_off
+
+    def test_offset_zero_is_noop(self):
+        """as_of_offset=0 must not change anything (backwards compatibility)."""
+        from screen_vcp import analyze_stock
+
+        hist = _make_prices(260, start=100, daily_change=0.001)
+        spy = _make_prices(260, start=400, daily_change=0.0005)
+        quote = {
+            "price": hist[0]["close"],
+            "yearHigh": hist[0]["close"] * 1.1,
+            "yearLow": hist[0]["close"] * 0.7,
+            "marketCap": 1e9,
+            "avgVolume": 1_000_000,
+        }
+        r_default = analyze_stock("TEST", hist, quote, spy)
+        r_explicit = analyze_stock("TEST", hist, quote, spy, as_of_offset=0)
+        assert r_default == r_explicit
+
+
+# ===========================================================================
+# Forward outcome calculator
+# ===========================================================================
+
+
+def _bar(date, close, low=None, high=None, volume=1_000_000):
+    """Single OHLCV bar dict."""
+    return {
+        "date": date,
+        "open": close,
+        "high": high if high is not None else close * 1.01,
+        "low": low if low is not None else close * 0.99,
+        "close": close,
+        "adjClose": close,
+        "volume": volume,
+    }
+
+
+def _hist(closes_oldest_first):
+    """Build a most-recent-first history from a list of closes given
+    oldest-to-newest (more natural to write for forward-outcome tests).
+
+    Dates are generated via real ``datetime`` arithmetic starting at
+    2025-01-01, so this stays valid past the end of the month.
+    """
+    from datetime import date, timedelta
+
+    base = date(2025, 1, 1)
+    bars = [
+        _bar((base + timedelta(days=i)).isoformat(), c, low=c * 0.99, high=c * 1.01)
+        for i, c in enumerate(closes_oldest_first)
+    ]
+    return list(reversed(bars))
+
+
+class TestForwardOutcome:
+    """calculate_forward_outcome walks bars MORE RECENT than the as-of bar
+    (indices 0..as_of_offset-1 in the most-recent-first array)."""
+
+    def test_breakout_detected_within_window(self):
+        from calculators.forward_outcome import calculate_forward_outcome
+
+        # oldest .. newest: 100, 101, 102, 103, 105, 110 (breakout at day 5)
+        # as_of = day 0 (close=100) i.e. historical[5] in MRF
+        closes = [100, 101, 102, 103, 105, 110]
+        hist = _hist(closes)
+        as_of_offset = 5  # MRF index of close=100 (the oldest)
+        result = calculate_forward_outcome(
+            hist, as_of_offset=as_of_offset,
+            pivot_price=104.0, stop_price=95.0, max_window_days=10,
+        )
+        assert result["outcome_type"] == "breakout"
+        assert result["days_to_outcome"] == 4  # 100 -> 101 -> 102 -> 103 -> 105
+        assert result["exit_price"] == pytest.approx(105.0)
+        # max gain measured as peak close vs as-of close
+        assert result["max_gain_pct"] == pytest.approx((110 - 100) / 100 * 100)
+
+    def test_stop_hit_before_breakout(self):
+        from calculators.forward_outcome import calculate_forward_outcome
+
+        # oldest..newest closes: 100, 99, 96, 93, 95, 98
+        # as_of close = 100, pivot=105, stop=95
+        # Forward walk: day 1 -> 99 (no), day 2 -> 96 (no, 96 > 95),
+        #               day 3 -> 93 (< 95) -> stop_hit.
+        closes = [100, 99, 96, 93, 95, 98]
+        hist = _hist(closes)
+        result = calculate_forward_outcome(
+            hist, as_of_offset=5,
+            pivot_price=105.0, stop_price=95.0, max_window_days=10,
+        )
+        assert result["outcome_type"] == "stop_hit"
+        assert result["days_to_outcome"] == 3
+        assert result["exit_price"] == pytest.approx(93.0)
+
+    def test_timeout_when_neither_pivot_nor_stop(self):
+        from calculators.forward_outcome import calculate_forward_outcome
+
+        # All forward closes between stop and pivot
+        closes = [100] + [101, 99, 100, 102, 98]  # newest -> still in range
+        hist = _hist(closes)
+        result = calculate_forward_outcome(
+            hist, as_of_offset=5,
+            pivot_price=110.0, stop_price=90.0, max_window_days=10,
+        )
+        assert result["outcome_type"] == "timeout"
+        assert result["days_to_outcome"] is None
+        assert result["exit_price"] is None
+
+    def test_insufficient_data_at_recent_offset(self):
+        from calculators.forward_outcome import calculate_forward_outcome
+
+        # Only 2 forward bars exist; max_window_days=10 means we time out gracefully
+        # but with bars_available reflecting reality.
+        hist = _hist([100, 101, 102])
+        # as_of at oldest = MRF index 2; 2 forward bars: [102, 101] reversed -> 101, 102
+        result = calculate_forward_outcome(
+            hist, as_of_offset=2,
+            pivot_price=120.0, stop_price=80.0, max_window_days=10,
+        )
+        # Neither hit, but window was truncated by available data.
+        assert result["outcome_type"] == "timeout"
+        assert result["bars_available"] == 2
+
+    def test_zero_forward_bars(self):
+        from calculators.forward_outcome import calculate_forward_outcome
+
+        hist = _hist([100])
+        result = calculate_forward_outcome(
+            hist, as_of_offset=0, pivot_price=110.0, stop_price=90.0
+        )
+        assert result["outcome_type"] == "insufficient_data"
+        assert result["bars_available"] == 0
+
+    def test_max_gain_tracks_peak_even_after_stop_hit(self):
+        """max_gain_pct should reflect the peak across the entire forward window,
+        regardless of where the outcome was resolved."""
+        from calculators.forward_outcome import calculate_forward_outcome
+
+        # oldest..newest: 100, 108, 92, 95, 99
+        # as_of=100, pivot=110, stop=95.
+        # day 1: 108 (gain 8%, no breakout above 110)
+        # day 2: 92 (stop hit, since 92 < 95)
+        closes = [100, 108, 92, 95, 99]
+        hist = _hist(closes)
+        result = calculate_forward_outcome(
+            hist, as_of_offset=4,
+            pivot_price=110.0, stop_price=95.0, max_window_days=10,
+        )
+        assert result["outcome_type"] == "stop_hit"
+        assert result["max_gain_pct"] == pytest.approx(8.0, abs=0.01)
+        assert result["max_loss_pct"] == pytest.approx(-8.0, abs=0.01)
+
+
+# ===========================================================================
+# Quote synthesis (build_quote_from_history) — must not peek at future bars
+# ===========================================================================
+
+
+class TestBuildQuoteFromHistory:
+    def test_quote_fields_from_as_of_bar(self):
+        from historical_scanner import build_quote_from_history
+
+        hist = _make_prices(300, start=100, daily_change=0.001)
+        offset = 60
+        quote = build_quote_from_history(hist, offset)
+        assert quote["price"] == hist[offset]["close"]
+        # yearHigh/yearLow over the 252-bar window ENDING at the as-of bar
+        # (i.e., bars hist[offset : offset+252]). No more recent bars allowed.
+        window = hist[offset : offset + 252]
+        assert quote["yearHigh"] == max(d["high"] for d in window)
+        assert quote["yearLow"] == min(d["low"] for d in window)
+
+    def test_no_lookahead_into_future(self):
+        """yearHigh must NOT include any bar more recent than the as-of bar.
+
+        Bars more recent than the as-of bar are at MRF indices < as_of_offset.
+        We poison those bars with a very high price and verify yearHigh stays
+        at the as-of-bar level.
+        """
+        from historical_scanner import build_quote_from_history
+
+        hist = _make_prices(300, start=100, daily_change=0.0)
+        # Inject huge highs into "future" bars (more recent than offset=60).
+        for i in range(60):
+            hist[i]["high"] = 999.99
+            hist[i]["close"] = 999.99
+        quote = build_quote_from_history(hist, as_of_offset=60)
+        # yearHigh should reflect only bars at indices >= 60.
+        assert quote["yearHigh"] < 200.0, (
+            f"yearHigh={quote['yearHigh']} indicates lookahead into bars[0:60]"
+        )
+
+    def test_short_history_uses_available_window(self):
+        """If fewer than 252 trailing bars exist, use what's available."""
+        from historical_scanner import build_quote_from_history
+
+        hist = _make_prices(120, start=100, daily_change=0.0)
+        quote = build_quote_from_history(hist, as_of_offset=0)
+        # 120 bars are all that's there; quote uses all of them
+        assert quote["yearHigh"] == max(d["high"] for d in hist)
+        assert quote["yearLow"] == min(d["low"] for d in hist)
+
+
+# ===========================================================================
+# Historical scanner walk + dedup
+# ===========================================================================
+
+
+def _fake_vcp_result(symbol, pivot, t1_high_date, last_low_date):
+    """Minimal analyze_stock-shaped dict used to inject fake detections."""
+    return {
+        "symbol": symbol,
+        "valid_vcp": True,
+        "composite_score": 75.0,
+        "rating": "Good VCP",
+        "execution_state": "Pre-breakout",
+        "pattern_type": "Textbook VCP",
+        "distance_from_pivot_pct": 1.2,
+        "vcp_pattern": {
+            "pivot_price": pivot,
+            "valid_vcp": True,
+            "num_contractions": 2,
+            "contractions": [
+                {"label": "T1", "high_date": t1_high_date, "low_date": "2024-01-05",
+                 "high_price": pivot, "low_price": pivot * 0.85, "depth_pct": 15.0},
+                {"label": "T2", "high_date": "2024-01-25", "low_date": last_low_date,
+                 "high_price": pivot * 0.99, "low_price": pivot * 0.92, "depth_pct": 7.0},
+            ],
+        },
+        "volume_pattern": {"score": 70, "dry_up_ratio": 0.5},
+        "pivot_proximity": {"score": 90, "risk_pct": 5.0},
+        "trend_template": {"score": 90},
+        "relative_strength": {"score": 80},
+    }
+
+
+class TestHistoricalScannerDedup:
+    def test_same_pattern_detected_at_multiple_offsets_yields_one_detection(self, monkeypatch):
+        """If analyze_stock keeps reporting the same (T1_high_date, last_low_date,
+        pivot) as the cursor strides forward, dedup should collapse to 1."""
+        from historical_scanner import scan_history
+
+        hist = _make_prices(400, start=100, daily_change=0.001)
+        spy = _make_prices(400, start=400, daily_change=0.0005)
+
+        # Inject a fake analyze_stock that always returns the same VCP.
+        def fake_analyze(symbol, historical, quote, sp500, **kw):
+            offset = kw.get("as_of_offset", 0)
+            r = _fake_vcp_result("TEST", pivot=110.0,
+                                 t1_high_date="2024-01-01",
+                                 last_low_date="2024-02-15")
+            # Vary something irrelevant to the dedup key so we can confirm
+            # multiple invocations happened.
+            r["_offset"] = offset
+            return r
+
+        monkeypatch.setattr("historical_scanner.screen_vcp.analyze_stock", fake_analyze)
+
+        result = scan_history("TEST", hist, spy, stride_days=10)
+        assert len(result) == 1
+
+    def test_distinct_patterns_kept(self, monkeypatch):
+        """Different (high_date, low_date, pivot) keys should NOT be deduped."""
+        from historical_scanner import scan_history
+
+        hist = _make_prices(400, start=100, daily_change=0.001)
+        spy = _make_prices(400, start=400, daily_change=0.0005)
+
+        def fake_analyze(symbol, historical, quote, sp500, **kw):
+            offset = kw.get("as_of_offset", 0)
+            # Return a "different" pattern at each offset by varying the dates.
+            return _fake_vcp_result(
+                "TEST", pivot=100 + offset,
+                t1_high_date=f"2024-01-{offset:03d}",
+                last_low_date=f"2024-02-{offset:03d}",
+            )
+
+        monkeypatch.setattr("historical_scanner.screen_vcp.analyze_stock", fake_analyze)
+
+        result = scan_history("TEST", hist, spy, stride_days=20)
+        assert len(result) > 5
+
+    def test_chronological_order_oldest_first(self, monkeypatch):
+        from historical_scanner import scan_history
+
+        hist = _make_prices(400, start=100, daily_change=0.001)
+        spy = _make_prices(400, start=400, daily_change=0.0005)
+
+        def fake_analyze(symbol, historical, quote, sp500, **kw):
+            offset = kw.get("as_of_offset", 0)
+            # Use the as-of bar's date so output ordering reflects time.
+            return _fake_vcp_result(
+                "TEST", pivot=100.0 + offset,
+                t1_high_date=historical[offset]["date"],
+                last_low_date=historical[max(offset - 10, 0)]["date"],
+            )
+
+        monkeypatch.setattr("historical_scanner.screen_vcp.analyze_stock", fake_analyze)
+
+        result = scan_history("TEST", hist, spy, stride_days=30)
+        dates = [r["as_of_date"] for r in result]
+        assert dates == sorted(dates)
+
+    def test_short_history_returns_empty(self):
+        """History shorter than lookback + a small buffer returns []."""
+        from historical_scanner import scan_history
+
+        hist = _make_prices(100, start=100, daily_change=0.001)
+        spy = _make_prices(100, start=400, daily_change=0.0005)
+        assert scan_history("TEST", hist, spy, lookback_days=120) == []
+
+
+class TestHistoryFlagParsing:
+    """--history takes an optional integer (trading days to scan).
+    Bare --history defaults to the canonical 5-year window."""
+
+    def _parse(self, *cli_args):
+        import sys as _sys
+        from screen_vcp import parse_arguments
+
+        original = _sys.argv
+        try:
+            _sys.argv = ["screen_vcp.py", *cli_args]
+            return parse_arguments()
+        finally:
+            _sys.argv = original
+
+    def test_bare_history_uses_default(self):
+        args = self._parse("--history", "--ticker", "AAPL")
+        # 5 years × 252 trading days = 1260 — preserves prior default behavior.
+        assert args.history == 1260
+        assert args.ticker == "AAPL"
+
+    def test_history_with_explicit_days(self):
+        args = self._parse("--history", "500", "--ticker", "AAPL")
+        assert args.history == 500
+
+    def test_history_with_equals_syntax(self):
+        args = self._parse("--history=2520", "--ticker", "TSLA")
+        assert args.history == 2520
+
+    def test_history_omitted_means_cross_sectional_mode(self):
+        # Without --history, the cross-sectional pipeline should run; args.history is None.
+        args = self._parse("--universe", "AAPL", "MSFT")
+        assert args.history is None
+
+    def test_history_requires_ticker(self):
+        import pytest as _pytest
+
+        with _pytest.raises(SystemExit):
+            self._parse("--history")  # no --ticker
+
+    def test_history_rejects_out_of_range(self):
+        import pytest as _pytest
+
+        with _pytest.raises(SystemExit):
+            self._parse("--history", "50", "--ticker", "AAPL")  # too short
+        with _pytest.raises(SystemExit):
+            self._parse("--history", "999999", "--ticker", "AAPL")  # too long
+
+
+class TestSanitizeTicker:
+    """sanitize_ticker is the first line of defence against path injection
+    through the --ticker CLI flag."""
+
+    def test_accepts_normal_symbols(self):
+        from historical_scanner import sanitize_ticker
+
+        assert sanitize_ticker("FIX") == "FIX"
+        assert sanitize_ticker("tsla") == "TSLA"
+        assert sanitize_ticker("BRK.B") == "BRK.B"
+        assert sanitize_ticker("BF-B") == "BF-B"
+
+    def test_rejects_path_traversal(self):
+        from historical_scanner import sanitize_ticker
+
+        for evil in ("../etc/passwd", "../../FOO", "FOO/BAR", "FOO\\BAR",
+                     "FOO BAR", "", "1FOO", "FOO;rm -rf /"):
+            with pytest.raises(ValueError):
+                sanitize_ticker(evil)
+
+
+# ===========================================================================
+# Historical report writers
+# ===========================================================================
+
+
+class TestHistoricalReport:
+    def _sample_detection(self, as_of="2024-03-15", outcome_type="breakout",
+                          days=10, gain=12.0, loss=-3.0):
+        return {
+            "symbol": "TEST",
+            "as_of_date": as_of,
+            "composite_score": 82.5,
+            "rating": "Strong VCP",
+            "execution_state": "Pre-breakout",
+            "pattern_type": "Textbook VCP",
+            "vcp_pattern": {
+                "pivot_price": 105.50,
+                "num_contractions": 3,
+                "pattern_duration_days": 45,
+                "contractions": [
+                    {"label": "T1", "high_date": "2024-02-01", "high_price": 105.50,
+                     "low_date": "2024-02-15", "low_price": 95.00,
+                     "depth_pct": 9.9, "duration_days": 14},
+                    {"label": "T2", "high_date": "2024-02-20", "high_price": 104.30,
+                     "low_date": "2024-03-01", "low_price": 99.50,
+                     "depth_pct": 4.6, "duration_days": 10},
+                ],
+            },
+            "forward_outcome": {
+                "outcome_type": outcome_type,
+                "days_to_outcome": days,
+                "max_gain_pct": gain,
+                "max_loss_pct": loss,
+                "bars_evaluated": 60,
+            },
+        }
+
+    def test_json_report_written(self, tmp_path):
+        from historical_report import generate_historical_json_report
+
+        out = tmp_path / "hist.json"
+        detections = [self._sample_detection()]
+        generate_historical_json_report("TEST", detections, {"generated_at": "now"}, str(out))
+        import json as _json
+        data = _json.loads(out.read_text(encoding="utf-8"))
+        assert data["symbol"] == "TEST"
+        assert data["summary"]["total"] == 1
+        assert data["summary"]["breakouts"] == 1
+
+    def test_markdown_report_written(self, tmp_path):
+        from historical_report import generate_historical_markdown_report
+
+        out = tmp_path / "hist.md"
+        detections = [
+            self._sample_detection(as_of="2024-03-15", outcome_type="breakout",
+                                   days=10, gain=12.0, loss=-3.0),
+            self._sample_detection(as_of="2024-08-22", outcome_type="stop_hit",
+                                   days=4, gain=2.1, loss=-8.5),
+            self._sample_detection(as_of="2025-01-10", outcome_type="timeout",
+                                   days=None, gain=5.0, loss=-2.0),
+        ]
+        generate_historical_markdown_report(
+            "TEST", detections,
+            {"generated_at": "2026-05-19", "stride_days": 5,
+             "lookback_days": 120, "outcome_days": 60,
+             "history_range": "2020-01 to 2026-05"},
+            str(out),
+        )
+        text = out.read_text(encoding="utf-8")
+        assert "VCP History" in text
+        assert "Detection Timeline" in text
+        # All three outcomes should appear in the summary table
+        assert "breakout" in text
+        assert "stop_hit" in text
+        assert "timeout" in text
+
+    def test_markdown_empty_detections(self, tmp_path):
+        from historical_report import generate_historical_markdown_report
+
+        out = tmp_path / "empty.md"
+        generate_historical_markdown_report("FOO", [], {"generated_at": "now"}, str(out))
+        text = out.read_text(encoding="utf-8")
+        assert "No VCP detections" in text
+
+
+# ===========================================================================
+# End-to-end: run_historical with a mocked FMP client
+# ===========================================================================
+
+
+class _StubFMPClient:
+    """Minimal FMPClient stand-in for end-to-end testing of run_historical.
+    Returns the synthetic histories supplied at construction time and tracks
+    api stats."""
+
+    def __init__(self, ticker_history, spy_history):
+        self._ticker = ticker_history
+        self._spy = spy_history
+        self.api_calls_made = 0
+        self.cache = {}
+
+    def get_historical_prices(self, symbol, days=365):
+        self.api_calls_made += 1
+        if symbol == "SPY":
+            return {"symbol": "SPY", "historical": self._spy}
+        return {"symbol": symbol, "historical": self._ticker}
+
+    def get_api_stats(self):
+        return {
+            "cache_entries": len(self.cache),
+            "api_calls_made": self.api_calls_made,
+            "rate_limit_reached": False,
+        }
+
+
+class TestRunHistoricalE2E:
+    def test_end_to_end_dispatch_writes_reports(self, tmp_path):
+        """run_historical() must fetch history, sweep, and write both reports."""
+        import types
+        from screen_vcp import run_historical
+
+        # Build a long, mostly trending synthetic history. We don't require
+        # detections to occur — only that the dispatch + report layer survives
+        # a real call with synthetic data.
+        hist = _make_prices(1500, start=100, daily_change=0.0005)
+        spy = _make_prices(1500, start=400, daily_change=0.0003)
+        client = _StubFMPClient(hist, spy)
+
+        args = types.SimpleNamespace(
+            ticker="TEST",
+            history=1260,
+            stride_days=20,  # coarse stride keeps test fast
+            outcome_days=60,
+            lookback_days=120,
+            output_dir=str(tmp_path),
+            ext_threshold=8.0,
+            min_contractions=2,
+            t1_depth_min=10.0,
+            contraction_ratio=0.70,
+            atr_multiplier=1.5,
+            min_contraction_days=5,
+            breakout_volume_ratio=1.5,
+            max_sma200_extension=50.0,
+            wide_and_loose_threshold=15.0,
+        )
+        run_historical(args, client)
+
+        # The dispatcher must always write both report files, even with zero
+        # detections — empty timeline is a valid result.
+        files = list(tmp_path.iterdir())
+        json_files = [f for f in files if f.name.endswith(".json")]
+        md_files = [f for f in files if f.name.endswith(".md")]
+        assert len(json_files) == 1, files
+        assert len(md_files) == 1, files
+        assert "TEST" in json_files[0].name
+        assert "vcp_history" in json_files[0].name
+
+        # Verify the JSON is well-formed and has expected top-level keys.
+        import json as _json
+        data = _json.loads(json_files[0].read_text(encoding="utf-8"))
+        assert data["symbol"] == "TEST"
+        assert "detections" in data
+        assert "summary" in data
+        assert data["metadata"]["stride_days"] == 20

--- a/skills/vcp-screener/scripts/tests/test_historical_vcp.py
+++ b/skills/vcp-screener/scripts/tests/test_historical_vcp.py
@@ -13,11 +13,9 @@ import sys
 
 import pytest
 
-
 # Reuse the synthetic-data helper from the existing test module.
 sys.path.insert(0, os.path.dirname(__file__))
 from test_vcp_screener import _make_prices  # noqa: E402
-
 
 # ===========================================================================
 # analyze_stock(as_of_offset=...) — equivalence with pre-sliced inputs
@@ -152,8 +150,11 @@ class TestForwardOutcome:
         hist = _hist(closes)
         as_of_offset = 5  # MRF index of close=100 (the oldest)
         result = calculate_forward_outcome(
-            hist, as_of_offset=as_of_offset,
-            pivot_price=104.0, stop_price=95.0, max_window_days=10,
+            hist,
+            as_of_offset=as_of_offset,
+            pivot_price=104.0,
+            stop_price=95.0,
+            max_window_days=10,
         )
         assert result["outcome_type"] == "breakout"
         assert result["days_to_outcome"] == 4  # 100 -> 101 -> 102 -> 103 -> 105
@@ -171,8 +172,11 @@ class TestForwardOutcome:
         closes = [100, 99, 96, 93, 95, 98]
         hist = _hist(closes)
         result = calculate_forward_outcome(
-            hist, as_of_offset=5,
-            pivot_price=105.0, stop_price=95.0, max_window_days=10,
+            hist,
+            as_of_offset=5,
+            pivot_price=105.0,
+            stop_price=95.0,
+            max_window_days=10,
         )
         assert result["outcome_type"] == "stop_hit"
         assert result["days_to_outcome"] == 3
@@ -185,8 +189,11 @@ class TestForwardOutcome:
         closes = [100] + [101, 99, 100, 102, 98]  # newest -> still in range
         hist = _hist(closes)
         result = calculate_forward_outcome(
-            hist, as_of_offset=5,
-            pivot_price=110.0, stop_price=90.0, max_window_days=10,
+            hist,
+            as_of_offset=5,
+            pivot_price=110.0,
+            stop_price=90.0,
+            max_window_days=10,
         )
         assert result["outcome_type"] == "timeout"
         assert result["days_to_outcome"] is None
@@ -200,8 +207,11 @@ class TestForwardOutcome:
         hist = _hist([100, 101, 102])
         # as_of at oldest = MRF index 2; 2 forward bars: [102, 101] reversed -> 101, 102
         result = calculate_forward_outcome(
-            hist, as_of_offset=2,
-            pivot_price=120.0, stop_price=80.0, max_window_days=10,
+            hist,
+            as_of_offset=2,
+            pivot_price=120.0,
+            stop_price=80.0,
+            max_window_days=10,
         )
         # Neither hit, but window was truncated by available data.
         assert result["outcome_type"] == "timeout"
@@ -211,9 +221,7 @@ class TestForwardOutcome:
         from calculators.forward_outcome import calculate_forward_outcome
 
         hist = _hist([100])
-        result = calculate_forward_outcome(
-            hist, as_of_offset=0, pivot_price=110.0, stop_price=90.0
-        )
+        result = calculate_forward_outcome(hist, as_of_offset=0, pivot_price=110.0, stop_price=90.0)
         assert result["outcome_type"] == "insufficient_data"
         assert result["bars_available"] == 0
 
@@ -229,8 +237,11 @@ class TestForwardOutcome:
         closes = [100, 108, 92, 95, 99]
         hist = _hist(closes)
         result = calculate_forward_outcome(
-            hist, as_of_offset=4,
-            pivot_price=110.0, stop_price=95.0, max_window_days=10,
+            hist,
+            as_of_offset=4,
+            pivot_price=110.0,
+            stop_price=95.0,
+            max_window_days=10,
         )
         assert result["outcome_type"] == "stop_hit"
         assert result["max_gain_pct"] == pytest.approx(8.0, abs=0.01)
@@ -307,10 +318,22 @@ def _fake_vcp_result(symbol, pivot, t1_high_date, last_low_date):
             "valid_vcp": True,
             "num_contractions": 2,
             "contractions": [
-                {"label": "T1", "high_date": t1_high_date, "low_date": "2024-01-05",
-                 "high_price": pivot, "low_price": pivot * 0.85, "depth_pct": 15.0},
-                {"label": "T2", "high_date": "2024-01-25", "low_date": last_low_date,
-                 "high_price": pivot * 0.99, "low_price": pivot * 0.92, "depth_pct": 7.0},
+                {
+                    "label": "T1",
+                    "high_date": t1_high_date,
+                    "low_date": "2024-01-05",
+                    "high_price": pivot,
+                    "low_price": pivot * 0.85,
+                    "depth_pct": 15.0,
+                },
+                {
+                    "label": "T2",
+                    "high_date": "2024-01-25",
+                    "low_date": last_low_date,
+                    "high_price": pivot * 0.99,
+                    "low_price": pivot * 0.92,
+                    "depth_pct": 7.0,
+                },
             ],
         },
         "volume_pattern": {"score": 70, "dry_up_ratio": 0.5},
@@ -332,9 +355,9 @@ class TestHistoricalScannerDedup:
         # Inject a fake analyze_stock that always returns the same VCP.
         def fake_analyze(symbol, historical, quote, sp500, **kw):
             offset = kw.get("as_of_offset", 0)
-            r = _fake_vcp_result("TEST", pivot=110.0,
-                                 t1_high_date="2024-01-01",
-                                 last_low_date="2024-02-15")
+            r = _fake_vcp_result(
+                "TEST", pivot=110.0, t1_high_date="2024-01-01", last_low_date="2024-02-15"
+            )
             # Vary something irrelevant to the dedup key so we can confirm
             # multiple invocations happened.
             r["_offset"] = offset
@@ -356,7 +379,8 @@ class TestHistoricalScannerDedup:
             offset = kw.get("as_of_offset", 0)
             # Return a "different" pattern at each offset by varying the dates.
             return _fake_vcp_result(
-                "TEST", pivot=100 + offset,
+                "TEST",
+                pivot=100 + offset,
                 t1_high_date=f"2024-01-{offset:03d}",
                 last_low_date=f"2024-02-{offset:03d}",
             )
@@ -376,7 +400,8 @@ class TestHistoricalScannerDedup:
             offset = kw.get("as_of_offset", 0)
             # Use the as-of bar's date so output ordering reflects time.
             return _fake_vcp_result(
-                "TEST", pivot=100.0 + offset,
+                "TEST",
+                pivot=100.0 + offset,
                 t1_high_date=historical[offset]["date"],
                 last_low_date=historical[max(offset - 10, 0)]["date"],
             )
@@ -402,6 +427,7 @@ class TestHistoryFlagParsing:
 
     def _parse(self, *cli_args):
         import sys as _sys
+
         from screen_vcp import parse_arguments
 
         original = _sys.argv
@@ -460,8 +486,16 @@ class TestSanitizeTicker:
     def test_rejects_path_traversal(self):
         from historical_scanner import sanitize_ticker
 
-        for evil in ("../etc/passwd", "../../FOO", "FOO/BAR", "FOO\\BAR",
-                     "FOO BAR", "", "1FOO", "FOO;rm -rf /"):
+        for evil in (
+            "../etc/passwd",
+            "../../FOO",
+            "FOO/BAR",
+            "FOO\\BAR",
+            "FOO BAR",
+            "",
+            "1FOO",
+            "FOO;rm -rf /",
+        ):
             with pytest.raises(ValueError):
                 sanitize_ticker(evil)
 
@@ -472,8 +506,9 @@ class TestSanitizeTicker:
 
 
 class TestHistoricalReport:
-    def _sample_detection(self, as_of="2024-03-15", outcome_type="breakout",
-                          days=10, gain=12.0, loss=-3.0):
+    def _sample_detection(
+        self, as_of="2024-03-15", outcome_type="breakout", days=10, gain=12.0, loss=-3.0
+    ):
         return {
             "symbol": "TEST",
             "as_of_date": as_of,
@@ -486,12 +521,24 @@ class TestHistoricalReport:
                 "num_contractions": 3,
                 "pattern_duration_days": 45,
                 "contractions": [
-                    {"label": "T1", "high_date": "2024-02-01", "high_price": 105.50,
-                     "low_date": "2024-02-15", "low_price": 95.00,
-                     "depth_pct": 9.9, "duration_days": 14},
-                    {"label": "T2", "high_date": "2024-02-20", "high_price": 104.30,
-                     "low_date": "2024-03-01", "low_price": 99.50,
-                     "depth_pct": 4.6, "duration_days": 10},
+                    {
+                        "label": "T1",
+                        "high_date": "2024-02-01",
+                        "high_price": 105.50,
+                        "low_date": "2024-02-15",
+                        "low_price": 95.00,
+                        "depth_pct": 9.9,
+                        "duration_days": 14,
+                    },
+                    {
+                        "label": "T2",
+                        "high_date": "2024-02-20",
+                        "high_price": 104.30,
+                        "low_date": "2024-03-01",
+                        "low_price": 99.50,
+                        "depth_pct": 4.6,
+                        "duration_days": 10,
+                    },
                 ],
             },
             "forward_outcome": {
@@ -510,6 +557,7 @@ class TestHistoricalReport:
         detections = [self._sample_detection()]
         generate_historical_json_report("TEST", detections, {"generated_at": "now"}, str(out))
         import json as _json
+
         data = _json.loads(out.read_text(encoding="utf-8"))
         assert data["symbol"] == "TEST"
         assert data["summary"]["total"] == 1
@@ -520,18 +568,26 @@ class TestHistoricalReport:
 
         out = tmp_path / "hist.md"
         detections = [
-            self._sample_detection(as_of="2024-03-15", outcome_type="breakout",
-                                   days=10, gain=12.0, loss=-3.0),
-            self._sample_detection(as_of="2024-08-22", outcome_type="stop_hit",
-                                   days=4, gain=2.1, loss=-8.5),
-            self._sample_detection(as_of="2025-01-10", outcome_type="timeout",
-                                   days=None, gain=5.0, loss=-2.0),
+            self._sample_detection(
+                as_of="2024-03-15", outcome_type="breakout", days=10, gain=12.0, loss=-3.0
+            ),
+            self._sample_detection(
+                as_of="2024-08-22", outcome_type="stop_hit", days=4, gain=2.1, loss=-8.5
+            ),
+            self._sample_detection(
+                as_of="2025-01-10", outcome_type="timeout", days=None, gain=5.0, loss=-2.0
+            ),
         ]
         generate_historical_markdown_report(
-            "TEST", detections,
-            {"generated_at": "2026-05-19", "stride_days": 5,
-             "lookback_days": 120, "outcome_days": 60,
-             "history_range": "2020-01 to 2026-05"},
+            "TEST",
+            detections,
+            {
+                "generated_at": "2026-05-19",
+                "stride_days": 5,
+                "lookback_days": 120,
+                "outcome_days": 60,
+                "history_range": "2020-01 to 2026-05",
+            },
             str(out),
         )
         text = out.read_text(encoding="utf-8")
@@ -585,6 +641,7 @@ class TestRunHistoricalE2E:
     def test_end_to_end_dispatch_writes_reports(self, tmp_path):
         """run_historical() must fetch history, sweep, and write both reports."""
         import types
+
         from screen_vcp import run_historical
 
         # Build a long, mostly trending synthetic history. We don't require
@@ -625,6 +682,7 @@ class TestRunHistoricalE2E:
 
         # Verify the JSON is well-formed and has expected top-level keys.
         import json as _json
+
         data = _json.loads(json_files[0].read_text(encoding="utf-8"))
         assert data["symbol"] == "TEST"
         assert "detections" in data

--- a/skills/vcp-screener/scripts/tests/test_vcp_screener.py
+++ b/skills/vcp-screener/scripts/tests/test_vcp_screener.py
@@ -9,6 +9,7 @@ Trend Template criteria, volume patterns, pivot proximity, and scoring.
 import json
 import os
 import tempfile
+from unittest import mock
 
 import pytest
 from calculators.pivot_proximity_calculator import calculate_pivot_proximity
@@ -237,6 +238,116 @@ class TestVolumePattern:
         result = calculate_volume_pattern(prices)
         assert result["dry_up_ratio"] < 0.3
         assert result["score"] >= 80
+
+
+class TestZoneVolumeIndexContract:
+    """Regression: contraction indices are chronological within the lookback
+    window; _zone_volume_analysis maps them back via n - 1 - chrono_idx where
+    n = len(volumes). Callers must pass volumes whose length matches the
+    lookback window used to compute the contractions, otherwise the reverse
+    mapping indexes into the wrong bars.
+    """
+
+    def test_zone_a_volume_correct_when_history_matches_lookback(self):
+        """When the caller passes a 120-bar slice (matching the lookback window
+        the contractions were built from), zone_a_avg_volume reflects the actual
+        contraction bars."""
+        # 120 recent bars; mark contraction-area volumes distinctly.
+        prices = _make_prices(120, start=100, volume=1_000_000)
+        # Contraction (T1) at chronological indices 50..70 within the lookback slice.
+        # Reverse mapping: rev_idx = 120 - 1 - chrono_idx, so MRF indices 49..69.
+        for i in range(49, 70):
+            prices[i]["volume"] = 50_000  # very low volume in the contraction
+
+        contractions = [
+            {
+                "label": "T1",
+                "high_idx": 50,
+                "high_price": 110.0,
+                "high_date": "2025-01-50",
+                "low_idx": 70,
+                "low_price": 95.0,
+                "low_date": "2025-01-70",
+                "depth_pct": 13.6,
+                "duration_days": 20,
+            }
+        ]
+        result = calculate_volume_pattern(prices, pivot_price=110.0, contractions=contractions)
+        za = result["zone_analysis"]["zone_a_avg_volume"]
+        # Average of the 21 bars at the low-volume contraction region.
+        assert 40_000 <= za <= 60_000, f"zone_a should reflect contraction bars (~50k), got {za}"
+
+    def test_zone_a_volume_wrong_when_history_exceeds_lookback(self):
+        """If the caller passes a longer history (e.g., 260 bars) but contraction
+        indices were built from a 120-bar slice, _zone_volume_analysis will read
+        from the wrong region. This test documents the calculator's contract;
+        analyze_stock() must pre-slice to avoid it.
+        """
+        # Recent 120 bars: contraction at chronological 50..70 (MRF 49..69), low vol.
+        recent = _make_prices(120, start=100, volume=1_000_000)
+        for i in range(49, 70):
+            recent[i]["volume"] = 50_000
+        # Older 140 bars: high volume — should NOT be read by zone_a if contracts
+        # were detected only within the 120-bar lookback.
+        older = _make_prices(140, start=80, volume=20_000_000)
+        full = recent + older  # most-recent-first
+
+        contractions = [
+            {
+                "label": "T1",
+                "high_idx": 50,
+                "high_price": 110.0,
+                "high_date": "2025-01-50",
+                "low_idx": 70,
+                "low_price": 95.0,
+                "low_date": "2025-01-70",
+                "depth_pct": 13.6,
+                "duration_days": 20,
+            }
+        ]
+        result_full = calculate_volume_pattern(full, pivot_price=110.0, contractions=contractions)
+        za_full = result_full["zone_analysis"]["zone_a_avg_volume"]
+        # With n=260, rev_idx = 260 - 1 - 70 = 189 .. 260 - 1 - 50 = 209,
+        # which lies in the OLDER (20M) region. Caller-side fix must avoid this.
+        assert za_full > 10_000_000, (
+            f"Expected the bug to manifest (zone_a reads older bars ~20M); got {za_full}. "
+            "This test documents the contract — pass historical[:lookback_days]."
+        )
+
+    def test_analyze_stock_slices_history_for_volume_calculator(self):
+        """analyze_stock must slice historical to lookback_days before calling
+        calculate_volume_pattern, to preserve the chronological index contract
+        between vcp_pattern_calculator and volume_pattern_calculator.
+        """
+        history_260 = _make_prices(260, start=100, daily_change=0.001)
+        sp500_260 = _make_prices(260, start=400, daily_change=0.0005)
+        quote = {
+            "price": history_260[0]["close"],
+            "yearHigh": history_260[0]["close"] * 1.1,
+            "yearLow": history_260[0]["close"] * 0.6,
+            "marketCap": 1e9,
+            "avgVolume": 1_000_000,
+        }
+        lookback = 120
+
+        captured_lengths = []
+        original = calculate_volume_pattern
+
+        def _capture(historical_prices, *args, **kwargs):
+            captured_lengths.append(len(historical_prices))
+            return original(historical_prices, *args, **kwargs)
+
+        with mock.patch("screen_vcp.calculate_volume_pattern", side_effect=_capture):
+            analyze_stock(
+                "TEST", history_260, quote, sp500_260, lookback_days=lookback
+            )
+
+        assert captured_lengths, "calculate_volume_pattern was not called"
+        assert captured_lengths[0] == lookback, (
+            f"analyze_stock should have passed a {lookback}-bar slice to "
+            f"calculate_volume_pattern; got {captured_lengths[0]} bars. "
+            "This is the regression for the chronological-index bug."
+        )
 
 
 # ===========================================================================

--- a/skills/vcp-screener/scripts/tests/test_vcp_screener.py
+++ b/skills/vcp-screener/scripts/tests/test_vcp_screener.py
@@ -338,9 +338,7 @@ class TestZoneVolumeIndexContract:
             return original(historical_prices, *args, **kwargs)
 
         with mock.patch("screen_vcp.calculate_volume_pattern", side_effect=_capture):
-            analyze_stock(
-                "TEST", history_260, quote, sp500_260, lookback_days=lookback
-            )
+            analyze_stock("TEST", history_260, quote, sp500_260, lookback_days=lookback)
 
         assert captured_lengths, "calculate_volume_pattern was not called"
         assert captured_lengths[0] == lookback, (


### PR DESCRIPTION
## Motivation

The existing VCP screener was strictly cross-sectional: "which S&P 500 names are setting up a VCP right now?" It runs the 3-phase pipeline once, against the most recent ~120 bars, and emits one verdict per ticker. There was no way to answer "find every VCP that ever formed in TSLA's last 5 years and tell me what happened after each one" — useful for pattern study, parameter-tuning research, and informally backtesting the detector's quality.

## Latent bug found during exploration

While tracing the pipeline to design the historical mode, I noticed that `analyze_stock` passes the full ~260-bar history to BOTH `calculate_vcp_pattern` (which slices internally to `lookback_days`, default 120) AND `calculate_volume_pattern` (which uses the array as-is). Contraction `high_idx`/`low_idx` are chronological indices into the 120-bar lookback slice, but `_zone_volume_analysis` maps them back to most-recent-first via `rev_idx = n - 1 - chrono_idx` using `n = len(volumes) = 260`. With chrono_idx ≈ 100, that produces rev_idx ≈ 159 — pointing 140 bars too far into the past. Zone A and contraction-trend volumes were silently read from the wrong region. This affected every cross-sectional run, not just the new mode. Fix: slice `historical[:lookback_days]` before calling `calculate_volume_pattern`. Added 3 regression tests in `TestZoneVolumeIndexContract`.

## FMP client fallback transparency (separate issue surfaced by usage)

`_request_with_fallback` tries the new "stable" endpoint first, then v3 as fallback. Non-last endpoints were called with `quiet=True` to suppress stderr (legitimate when most users were on legacy plans pre-Aug-2025). For post-Aug-2025 accounts that hit any stable failure (HTTP 402 plan limit, HTTP 429 rate limit, shape mismatch), the actual error was hidden and only the misleading v3 "Legacy Endpoint" 403 reached the user. Fix: `_rate_limited_get` now stashes its failure reason in `self._last_error` even when quiet; `_request_with_fallback` emits a WARN line for every non-last failure (HTTP, normalize, or shape-validation). Happy path stays silent — verified by a regression test.

## What's in this commit

**New historical mode** (CLI: `--history [DAYS] --ticker SYM`):
- `--history` accepts an optional integer (trading days to scan). Bare `--history` defaults to 1260 (~5 years); `--history 2520` for 10 years. Range 100-5040 (~5 months to ~20 years).
- `screen_vcp.py:run_historical()` fetches one long history (scan window + lookback + outcome + 60-bar safety buffer), walks the as-of cursor in `stride_days` (default 5), and writes JSON + Markdown reports to `reports/vcp_history_<SYM>_<YYYY-MM-DD_HHMMSS>.{json,md}`.
- Detections deduped by `(T1_high_date, last_low_date, round(pivot, 2))` with index-fallback if dates are missing.

**Calculator stack changes**:
- `analyze_stock` gains `as_of_offset: int = 0` param. When >0, both `historical` and `sp500_history` are sliced once at the top, so every downstream calculator sees the slice. No calculator signatures change.
- New `calculators/forward_outcome.py`: pure function returning `{outcome_type, days_to_outcome, max_gain_pct, max_loss_pct, exit_price, exit_date, bars_available, bars_evaluated}` over bars more recent than the detection day. Walks full window for stats; resolves outcome at the first triggering bar.

**Driver + report**:
- New `historical_scanner.py` with `build_quote_from_history` (enforced no-lookahead contract), `sanitize_ticker` (regex guards against path traversal via `--ticker`), and `scan_history` driver.
- New `historical_report.py` with separate JSON + Markdown writers (timeline schema differs structurally from the cross-sectional ranked-list report; sharing one writer would have been worse than two focused ones).

**Tests**: 33 new tests across:
- `test_vcp_screener.py::TestZoneVolumeIndexContract` (3) — volume-index bug
- `test_historical_vcp.py` (28) — as_of_offset equivalence, forward_outcome paths (breakout / stop_hit / timeout / insufficient_data / max-gain tracking), no-lookahead, dedup, ticker sanitization, CLI parsing, E2E
- `test_fmp_client_historical.py::TestFallbackTransparency` (2) — both endpoint errors surfaced; happy path stays silent

253 → 259 → 259 passing under PYTHONUTF8=1. (16 pre-existing Windows cp1252 failures in `report_generator.py` are unrelated and untouched.)

## Usage

```bash
# Default 5-year scan
python3 skills/vcp-screener/scripts/screen_vcp.py \
  --history --ticker AAPL --output-dir reports/

# Explicit 3-year scan, 90-day outcome window
python3 skills/vcp-screener/scripts/screen_vcp.py \
  --history 756 --ticker TSLA --outcome-days 90 --output-dir reports/
```

## Known follow-ups (not in this commit)

- The same silent-fallback pattern lives in 8 sibling skills' copies of `fmp_client.py` (canslim-screener, earnings-trade-analyzer, ftd-detector, ibd-distribution-day-monitor, macro-regime-detector, market-top-detector, parabolic-short-trade-planner, pead-screener). Port as a separate PR.
- `docs/{en,ja}/skills/vcp-screener.md` don't yet mention historical mode.
- For users whose FMP plan doesn't cover all symbols, a yfinance or Schwab data adapter would unblock full-universe scans. Out of scope here.

Co-Authored by Claude Code with Opus 4.7