### PR TITLE
fix(market-top-detector): loop per-symbol in get_batch_quotes to avoid FMP legacy/empty responses

### DIFF
--- a/skills/market-top-detector/scripts/fmp_client.py
+++ b/skills/market-top-detector/scripts/fmp_client.py
@@ -290,17 +290,22 @@ class FMPClient:
         return data
 
     def get_batch_quotes(self, symbols: list[str]) -> dict[str, dict]:
-        """Fetch quotes for a list of symbols, batching up to 5 per request"""
+        """Fetch quotes for a list of symbols.
+
+        Note: The FMP `/stable/quote` endpoint only accepts a single symbol per
+        call. Passing comma-separated symbols silently returns []. The
+        deprecated `/api/v3/quote/A,B,C` batch syntax now returns 403 for
+        non-legacy keys (retired Aug 31, 2025). So we iterate one symbol at a
+        time. Rate limiting in `_rate_limited_get` keeps this within plan
+        limits.
+        """
         results = {}
-        # FMP supports comma-separated symbols in quote endpoint
-        batch_size = 5
-        for i in range(0, len(symbols), batch_size):
-            batch = symbols[i : i + batch_size]
-            batch_str = ",".join(batch)
-            quotes = self.get_quote(batch_str)
+        for symbol in symbols:
+            quotes = self.get_quote(symbol)
             if quotes:
                 for q in quotes:
-                    results[q["symbol"]] = q
+                    if q.get("symbol"):
+                        results[q["symbol"]] = q
         return results
 
     def get_batch_historical(self, symbols: list[str], days: int = 50) -> dict[str, list[dict]]:


### PR DESCRIPTION
## Summary

`market-top-detector` is hitting the FMP `Legacy Endpoint` 403 on Starter-plan keys, which silently degrades the Leading Stock Health component to its default and biases the composite score.

Root cause in `get_batch_quotes`: it builds comma-separated batches and passes them through `get_quote` → `_request_with_fallback`. Both fallback endpoints fail:

1. `/stable/quote?symbol=A,B,C` silently returns `[]` — comma syntax is only supported on the paid `stable/batch-quote` endpoint.
2. `/api/v3/quote/A,B,C` returns:
   ```
   Legacy Endpoint : Due to Legacy endpoints being no longer supported - This endpoint is only available for legacy users who have valid subscriptions prior August 31, 2025.
   ```

Fix: iterate one symbol per call against `/stable/quote`, which works on all current plans. The existing `_rate_limited_get` keeps us inside the 300/min Starter limit (a 10-ETF basket costs ~3s).

## Reproduction (before this PR)

With a Starter-plan FMP key (any key issued after Aug 31, 2025):

```bash
python3 skills/market-top-detector/scripts/market_top_detector.py \
  --api-key $FMP_API_KEY \
  --breadth-50dma 46.52 --breadth-50dma-date 2026-05-14 \
  --put-call 0.59 --put-call-date 2026-05-15
```

You'll see:
```
Fetching candidate pool quotes for dynamic basket... ERROR: API request failed: 403 - ... Legacy Endpoint ...
OK (0 candidates)
Selected dynamic basket: ['ARKK', 'WCLD', 'IGV', 'XBI', 'SOXX', 'SMH', 'KWEB', 'TAN']
Fetching Leading ETFs (dynamic basket)... OK (0 quotes, 8 histories)
...
[2/6] Leading Stock Health... Score: 50 (INSUFFICIENT DATA)
```

## After this PR

Same invocation:
```
Fetching candidate pool quotes for dynamic basket... OK (20 candidates)
Selected dynamic basket: ['TAN', 'ICLN', 'KOMP', 'BOTZ', 'SMH', 'SOXQ', 'SOXX', 'PSI', 'XBI', 'FDN']
Fetching Leading ETFs (dynamic basket)... OK (10 quotes, 10 histories)
...
[2/6] Leading Stock Health... Score: 11 (HEALTHY: Leadership intact)
```

Composite score moved from **41.3 (Orange / Elevated Risk)** to **35.2 (Yellow / Early Warning)** — a real reading rather than a default-driven score.

## Scope

This PR fixes the `market-top-detector` batch quote path only. I noticed the same root cause (`/api/v3/...` 403 on current keys) affects at least three other scripts that use the also-retired `/api/v3/stock-screener` endpoint:

- `skills/institutional-flow-tracker/scripts/track_institutional_flow.py`
- `skills/downtrend-duration-analyzer/scripts/analyze_downtrends.py`
- `skills/pair-trade-screener/scripts/find_pairs.py`

Those need migration to a `/stable/` equivalent. Happy to follow up in a separate PR — wanted to keep this one focused on the demonstrable, verified fix.

## Test plan

- [x] Reproduced original failure on a Starter-plan key
- [x] Verified fix produces real ETF quotes and a real Leading Stock Health score
- [x] Composite score drops from 41.3 → 35.2 (Orange → Yellow) on the same input data (correct direction — the previous score was inflated by the INSUFFICIENT-DATA default of 50)
- [ ] Existing pytest suite in `skills/market-top-detector/scripts/tests/` (would prefer CI to run — pytest not in my local env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)