### PR TITLE
fix(options-strategy-advisor): migrate FMP /api/v3 → /stable

### DIFF
--- a/skills/options-strategy-advisor/scripts/black_scholes.py
+++ b/skills/options-strategy-advisor/scripts/black_scholes.py
@@ -379,43 +379,66 @@ def fetch_historical_prices_for_hv(symbol, api_key, days=90):
 
 
 def get_current_stock_price(symbol, api_key):
-    """Fetch current stock price from FMP API"""
-    url = f"https://financialmodelingprep.com/api/v3/quote/{symbol}"
+    """Fetch current stock price from FMP API (stable, with v3 fallback)."""
+    # stable: /quote?symbol=SYM ; v3 fallback (legacy keys): /quote/SYM
+    endpoints = [
+        ("https://financialmodelingprep.com/stable/quote", True),
+        ("https://financialmodelingprep.com/api/v3/quote", False),
+    ]
+    for base_url, is_stable in endpoints:
+        try:
+            if is_stable:
+                response = requests.get(
+                    base_url, headers={"apikey": api_key}, params={"symbol": symbol}, timeout=30
+                )
+            else:
+                response = requests.get(
+                    f"{base_url}/{symbol}", headers={"apikey": api_key}, timeout=30
+                )
+            if response.status_code != 200:
+                continue
+            data = response.json()
+            if data and len(data) > 0 and data[0].get("price") is not None:
+                return data[0]["price"]
+        except Exception:  # nosec B112 - intentional fallback to next FMP endpoint
+            continue
 
-    try:
-        response = requests.get(url, headers={"apikey": api_key}, timeout=30)
-        response.raise_for_status()
-        data = response.json()
-
-        if data and len(data) > 0:
-            return data[0]["price"]
-        return None
-
-    except Exception as e:
-        print(f"Error fetching current price for {symbol}: {e}")
-        return None
+    print(f"Error fetching current price for {symbol}: all endpoints failed")
+    return None
 
 
 def get_dividend_yield(symbol, api_key):
-    """Fetch dividend yield from FMP API"""
-    url = f"https://financialmodelingprep.com/api/v3/profile/{symbol}"
+    """Fetch dividend yield from FMP API (stable, with v3 fallback)."""
+    # stable: /profile?symbol=SYM ; v3 fallback (legacy keys): /profile/SYM
+    endpoints = [
+        ("https://financialmodelingprep.com/stable/profile", True),
+        ("https://financialmodelingprep.com/api/v3/profile", False),
+    ]
+    for base_url, is_stable in endpoints:
+        try:
+            if is_stable:
+                response = requests.get(
+                    base_url, headers={"apikey": api_key}, params={"symbol": symbol}, timeout=30
+                )
+            else:
+                response = requests.get(
+                    f"{base_url}/{symbol}", headers={"apikey": api_key}, timeout=30
+                )
+            if response.status_code != 200:
+                continue
+            data = response.json()
+            if data and len(data) > 0:
+                # /stable/profile renamed lastDiv -> lastDividend; accept either.
+                last_div = data[0].get("lastDividend")
+                if last_div is None:
+                    last_div = data[0].get("lastDiv", 0)
+                last_div = last_div or 0
+                price = data[0].get("price", 1) or 1
+                return (last_div / price) if price > 0 else 0
+        except Exception:  # nosec B112 - intentional fallback to next FMP endpoint
+            continue
 
-    try:
-        response = requests.get(url, headers={"apikey": api_key}, timeout=30)
-        response.raise_for_status()
-        data = response.json()
-
-        if data and len(data) > 0:
-            # Last annual dividend / current price
-            last_div = data[0].get("lastDiv", 0)
-            price = data[0].get("price", 1)
-            div_yield = (last_div / price) if price > 0 else 0
-            return div_yield
-
-        return 0
-
-    except Exception:
-        return 0
+    return 0
 
 
 # =============================================================================

--- a/skills/options-strategy-advisor/scripts/tests/test_fmp_endpoints.py
+++ b/skills/options-strategy-advisor/scripts/tests/test_fmp_endpoints.py
@@ -1,0 +1,75 @@
+"""FMP /stable migration: live quote + dividend-yield helpers.
+
+get_current_stock_price and get_dividend_yield used v3 path-style endpoints
+(/quote/SYM, /profile/SYM) that 403 for keys issued after 2025-08-31. They now
+call the /stable query-style endpoints first, with a v3 fallback. /stable also
+renamed the dividend field lastDiv -> lastDividend, which get_dividend_yield
+must read or it silently returns 0.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from black_scholes import get_current_stock_price, get_dividend_yield
+
+
+def _resp(status_code, json_payload):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_payload
+    return resp
+
+
+class TestCurrentStockPrice:
+    @patch("black_scholes.requests")
+    def test_uses_stable_quote_first(self, mock_requests):
+        mock_requests.get.return_value = _resp(200, [{"symbol": "AAPL", "price": 150.0}])
+        price = get_current_stock_price("AAPL", "key")
+        assert price == 150.0
+        call = mock_requests.get.call_args
+        assert call[0][0].endswith("/stable/quote")
+        assert call[1]["params"] == {"symbol": "AAPL"}
+
+    @patch("black_scholes.requests")
+    def test_falls_back_to_v3(self, mock_requests):
+        def fake_get(url, headers=None, params=None, timeout=None):
+            if url.endswith("/stable/quote"):
+                return _resp(403, {})  # legacy/stable failure -> fallback
+            return _resp(200, [{"symbol": "AAPL", "price": 150.0}])
+
+        mock_requests.get.side_effect = fake_get
+        price = get_current_stock_price("AAPL", "key")
+        assert price == 150.0
+        urls = [c[0][0] for c in mock_requests.get.call_args_list]
+        assert any(u.endswith("/api/v3/quote/AAPL") for u in urls)
+
+
+class TestDividendYield:
+    @patch("black_scholes.requests")
+    def test_reads_stable_lastDividend_field(self, mock_requests):
+        # /stable/profile uses lastDividend (no lastDiv). Yield = 2.0 / 100.
+        mock_requests.get.return_value = _resp(
+            200, [{"symbol": "AAPL", "lastDividend": 2.0, "price": 100.0}]
+        )
+        assert get_dividend_yield("AAPL", "key") == 0.02
+        call = mock_requests.get.call_args
+        assert call[0][0].endswith("/stable/profile")
+        assert call[1]["params"] == {"symbol": "AAPL"}
+
+    @patch("black_scholes.requests")
+    def test_v3_lastDiv_still_supported(self, mock_requests):
+        def fake_get(url, headers=None, params=None, timeout=None):
+            if url.endswith("/stable/profile"):
+                return _resp(403, {})
+            return _resp(200, [{"symbol": "AAPL", "lastDiv": 4.0, "price": 100.0}])
+
+        mock_requests.get.side_effect = fake_get
+        assert get_dividend_yield("AAPL", "key") == 0.04
+
+    @patch("black_scholes.requests")
+    def test_zero_when_no_data(self, mock_requests):
+        mock_requests.get.return_value = _resp(200, [])
+        assert get_dividend_yield("AAPL", "key") == 0


### PR DESCRIPTION
## Root cause
FMP retired the legacy `/api/v3/` API. Keys issued after **2025-08-31** lose v3 access and get `403 — "Legacy Endpoint ..."`. Two `options-strategy-advisor` helpers in `black_scholes.py` used v3 path-style endpoints:

1. **`get_current_stock_price()`** → v3 `/quote/{symbol}`.
2. **`get_dividend_yield()`** → v3 `/profile/{symbol}`.

(`fetch_historical_prices_for_hv` was already migrated to `/stable` in 44eadf8.)

## Fix
- Both now call the `/stable` query-style endpoints first (`/stable/quote?symbol=`, `/stable/profile?symbol=`), with a v3 fallback for legacy keys — mirroring the stable-first/v3-fallback pattern already used by `fetch_historical_prices_for_hv`.
- **Field-rename fix:** `/stable/profile` renamed `lastDiv` → `lastDividend`. `get_dividend_yield()` now reads either, so the dividend yield isn't silently `0` (a zero yield would feed a wrong cost-of-carry into the Black-Scholes pricing).

## Before / after (key issued after 2025-08-31)
```
before: /quote/SYM and /profile/SYM → 403
after:  AAPL price=298.97, div_yield=0.00351 (1.05/298.97)
        MSFT div_yield=0.00635
```

## Tests
- New `tests/test_fmp_endpoints.py` (5 tests): stable quote/profile used first + correct params; v3 fallback for both; reads `lastDividend` (stable) and still supports `lastDiv` (v3); returns 0 on empty data.
- Full suite: 41 passing (36 existing math tests + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
