### PR TITLE
fix(parabolic-short-trade-planner): migrate FMP /api/v3 → /stable

### DIFF
--- a/skills/parabolic-short-trade-planner/scripts/check_live_apis.py
+++ b/skills/parabolic-short-trade-planner/scripts/check_live_apis.py
@@ -45,6 +45,7 @@ for _p in (str(ADAPTERS_DIR), str(SCRIPTS_DIR)):
         sys.path.insert(0, _p)
 
 
+FMP_STABLE = "https://financialmodelingprep.com/stable"
 FMP_STABLE_HIST = "https://financialmodelingprep.com/stable/historical-price-eod/full"
 FMP_V3 = "https://financialmodelingprep.com/api/v3"
 ALPACA_PAPER = "https://paper-api.alpaca.markets"
@@ -119,61 +120,77 @@ def check_fmp_historical(api_key: str) -> bool:
 
 
 def check_fmp_profile(api_key: str) -> bool:
-    """Gate 2 — verify profile/AAPL returns a non-empty list with mktCap."""
+    """Gate 2 — verify profile returns a non-empty list with a market-cap field.
+
+    Tries /stable/profile?symbol=AAPL first, then the v3 /profile/AAPL fallback
+    (matching the client). /stable renamed mktCap -> marketCap, so either is OK.
+    """
     name = "fmp.profile"
-    url = f"{FMP_V3}/profile/AAPL"
-    try:
-        r = requests.get(url, params={"apikey": api_key}, timeout=15)
-    except requests.RequestException as e:
-        _print_fail(name, f"network error: {e}")
-        return False
+    attempts = [
+        (f"{FMP_STABLE}/profile", {"symbol": "AAPL", "apikey": api_key}),
+        (f"{FMP_V3}/profile/AAPL", {"apikey": api_key}),
+    ]
+    last_detail = "no response"
+    for url, params in attempts:
+        try:
+            r = requests.get(url, params=params, timeout=15)
+        except requests.RequestException as e:
+            last_detail = f"network error: {e}"
+            continue
+        if r.status_code != 200:
+            last_detail = f"HTTP {r.status_code} — {_truncate(r.text)}"
+            continue
+        try:
+            data = r.json()
+        except ValueError:
+            last_detail = f"non-JSON body: {_truncate(r.text)}"
+            continue
+        if isinstance(data, list) and data:
+            cap = data[0].get("mktCap", data[0].get("marketCap"))
+            if cap is not None:
+                _print_pass(name, f"marketCap={cap}")
+                return True
+        last_detail = f"expected list with market cap on first item, got {data!r:.200}"
 
-    if r.status_code != 200:
-        _print_fail(name, f"HTTP {r.status_code} — {_truncate(r.text)}")
-        return False
-
-    try:
-        data = r.json()
-    except ValueError:
-        _print_fail(name, f"non-JSON body: {_truncate(r.text)}")
-        return False
-
-    if not isinstance(data, list) or not data or "mktCap" not in data[0]:
-        _print_fail(name, f"expected list with mktCap on first item, got {data!r:.200}")
-        return False
-
-    _print_pass(name, f"mktCap={data[0].get('mktCap')}")
-    return True
+    _print_fail(name, last_detail)
+    return False
 
 
 def check_fmp_sp500(api_key: str) -> bool:
-    """Optional warning — sp500_constituent entitlement varies by FMP tier."""
+    """Optional warning — sp500 constituent entitlement varies by FMP tier.
+
+    Tries /stable/sp500-constituent first, then the v3 /sp500_constituent
+    fallback.
+    """
     name = "fmp.sp500_constituent"
-    url = f"{FMP_V3}/sp500_constituent"
-    try:
-        r = requests.get(url, params={"apikey": api_key}, timeout=15)
-    except requests.RequestException as e:
-        _print_warn(name, f"network error (optional gate): {e}")
-        return True
+    attempts = [
+        (f"{FMP_STABLE}/sp500-constituent", {"apikey": api_key}),
+        (f"{FMP_V3}/sp500_constituent", {"apikey": api_key}),
+    ]
+    last_detail = "no response"
+    for url, params in attempts:
+        try:
+            r = requests.get(url, params=params, timeout=15)
+        except requests.RequestException as e:
+            last_detail = f"network error (optional gate): {e}"
+            continue
+        if r.status_code != 200:
+            last_detail = (
+                f"HTTP {r.status_code} — likely entitlement (skip on Free); "
+                f"body: {_truncate(r.text)}"
+            )
+            continue
+        try:
+            data = r.json()
+        except ValueError:
+            last_detail = f"non-JSON body: {_truncate(r.text)}"
+            continue
+        if isinstance(data, list) and data:
+            _print_pass(name, f"{len(data)} constituents")
+            return True
+        last_detail = "empty list (skip on Free)"
 
-    if r.status_code != 200:
-        _print_warn(
-            name,
-            f"HTTP {r.status_code} — likely entitlement (skip on Free); body: {_truncate(r.text)}",
-        )
-        return True
-
-    try:
-        data = r.json()
-    except ValueError:
-        _print_warn(name, f"non-JSON body: {_truncate(r.text)}")
-        return True
-
-    if not isinstance(data, list) or not data:
-        _print_warn(name, "empty list (skip on Free)")
-        return True
-
-    _print_pass(name, f"{len(data)} constituents")
+    _print_warn(name, last_detail)
     return True
 
 

--- a/skills/parabolic-short-trade-planner/scripts/tests/test_check_live_apis.py
+++ b/skills/parabolic-short-trade-planner/scripts/tests/test_check_live_apis.py
@@ -57,9 +57,9 @@ def _route_get(url: str, **_kwargs):
     """Dispatch mocked GET responses by URL substring."""
     if "historical-price-eod/full" in url:
         return _fmp_historical_response()
-    if "/profile/" in url:
+    if "/stable/profile" in url or "/profile/" in url:
         return _fmp_profile_response()
-    if "/sp500_constituent" in url:
+    if "sp500-constituent" in url or "/sp500_constituent" in url:
         return _fmp_sp500_response()
     raise AssertionError(f"Unexpected GET to {url!r} in --fmp-only mode")
 


### PR DESCRIPTION
## Root cause
FMP retired the legacy `/api/v3/` API. Keys issued after **2025-08-31** lose v3 access (→ `403`). Three FMP endpoints used at screen time still relied on v3:

1. **`get_company_profile()`** → v3 `/profile/{symbol}`.
2. **`get_sp500_constituents()`** → v3 `/sp500_constituent` (404 on `/stable`; this is the **default** `--universe`).
3. **`get_earnings_calendar()`** → v3 `/earning_calendar`.

(Quote + historical were already migrated in 44eadf8. `get_batch_quotes` is **not** called at runtime, so the comma-batch bug doesn't apply here.)

## Fix
- **Profile** → `/stable/profile?symbol=` (+ v3 fallback). `/stable` renamed `mktCap` → `marketCap`, so a `mktCap` alias is added — the screener filters on `profile["mktCap"]`, so without it the market-cap gate silently breaks.
- **S&P 500 list** → `/stable/sp500-constituent` (hyphen) (+ v3 fallback).
- **Earnings calendar** → `/stable/earnings-calendar` (+ v3 fallback). The screener already reads `symbol`/`date` permissively, so the shape change is safe.
- **Preflight diagnostic (`check_live_apis.py`):** its `fmp.profile` and `fmp.sp500_constituent` gates pointed at v3 and so falsely *failed* on a working `/stable` key. They now try `/stable` first (with v3 fallback) and accept the renamed `marketCap` field.

## Before / after (key issued after 2025-08-31)
```
before: profile / sp500 / earnings → 403 / 404
after:  profile mktCap=4.39T · 503 sp500 constituents · 3855 earnings events
        check_live_apis.py --fmp-only → 2/2 required gates PASS
```

## Tests
- New `tests/test_fmp_client_stable.py` (5): stable profile + `mktCap` alias + v3 fallback; stable sp500-constituent first; stable earnings-calendar first.
- Updated `tests/test_check_live_apis.py` mock router to recognize the stable URLs.
- Full suite: 263 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
