### PR TITLE
fix(downtrend-duration-analyzer): migrate FMP /api/v3 → /stable

### DIFF
--- a/skills/downtrend-duration-analyzer/scripts/analyze_downtrends.py
+++ b/skills/downtrend-duration-analyzer/scripts/analyze_downtrends.py
@@ -73,19 +73,38 @@ def get_market_cap_tier(market_cap: float | None) -> str:
 
 
 def fetch_stock_list(api_key: str, sector: str | None = None) -> list[dict]:
-    """Fetch list of stocks, optionally filtered by sector."""
-    url = f"https://financialmodelingprep.com/api/v3/stock-screener?apikey={api_key}"
-    if sector:
-        url += f"&sector={sector.replace(' ', '%20')}"
-    url += "&isActivelyTrading=true&limit=500"
+    """Fetch list of stocks, optionally filtered by sector.
 
-    try:
-        response = requests.get(url, timeout=30)
-        response.raise_for_status()
-        return response.json()
-    except requests.RequestException as e:
-        print(f"Error fetching stock list: {e}", file=sys.stderr)
-        return []
+    Uses the /stable/company-screener endpoint (the v3 /stock-screener it
+    replaced 403s for keys issued after 2025-08-31), with a v3 fallback for
+    legacy keys. Both take the same params and return the same fields
+    (symbol, sector, marketCap, ...).
+    """
+    params: dict[str, Any] = {
+        "apikey": api_key,
+        "isActivelyTrading": "true",
+        "limit": 500,
+    }
+    if sector:
+        params["sector"] = sector
+    endpoints = [
+        "https://financialmodelingprep.com/stable/company-screener",
+        "https://financialmodelingprep.com/api/v3/stock-screener",
+    ]
+    for url in endpoints:
+        try:
+            response = requests.get(url, params=params, timeout=30)
+        except requests.RequestException as e:
+            print(f"Error fetching stock list ({url}): {e}", file=sys.stderr)
+            continue
+        if response.status_code != 200:
+            continue
+        try:
+            return response.json()
+        except ValueError:
+            continue
+    print("Error fetching stock list: all screener endpoints failed", file=sys.stderr)
+    return []
 
 
 # --- FMP endpoint fallback: stable (new users) -> v3 (legacy users) ---

--- a/skills/downtrend-duration-analyzer/scripts/tests/test_fetch_stock_list.py
+++ b/skills/downtrend-duration-analyzer/scripts/tests/test_fetch_stock_list.py
@@ -1,0 +1,52 @@
+"""FMP /stable migration: stock list uses /stable/company-screener.
+
+fetch_stock_list() used v3 /stock-screener (403 for keys issued after
+2025-08-31). It now calls /stable/company-screener first with a v3 fallback;
+both take the same params and return the same fields.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import analyze_downtrends
+
+
+def _resp(status_code, payload):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    return resp
+
+
+@patch("analyze_downtrends.requests.get")
+def test_uses_stable_company_screener_first(mock_get):
+    mock_get.return_value = _resp(
+        200, [{"symbol": "XOM", "sector": "Energy", "marketCap": 500_000_000_000}]
+    )
+    stocks = analyze_downtrends.fetch_stock_list("key", sector="Energy")
+
+    assert stocks[0]["symbol"] == "XOM"
+    call = mock_get.call_args_list[0]
+    assert call[0][0].endswith("/stable/company-screener")
+    assert call[1]["params"]["sector"] == "Energy"
+    assert call[1]["params"]["isActivelyTrading"] == "true"
+    assert call[1]["params"]["limit"] == 500
+
+
+@patch("analyze_downtrends.requests.get")
+def test_falls_back_to_v3_stock_screener(mock_get):
+    def fake_get(url, params=None, timeout=None):
+        if url.endswith("/stable/company-screener"):
+            return _resp(403, {})  # legacy/stable failure -> fallback
+        return _resp(200, [{"symbol": "AAPL", "sector": "Technology"}])
+
+    mock_get.side_effect = fake_get
+    stocks = analyze_downtrends.fetch_stock_list("key")
+    assert stocks[0]["symbol"] == "AAPL"
+    urls = [c[0][0] for c in mock_get.call_args_list]
+    assert any(u.endswith("/api/v3/stock-screener") for u in urls)
+
+
+@patch("analyze_downtrends.requests.get")
+def test_returns_empty_when_all_fail(mock_get):
+    mock_get.return_value = _resp(403, {})
+    assert analyze_downtrends.fetch_stock_list("key") == []


### PR DESCRIPTION
## Root cause
FMP retired the legacy `/api/v3/` API. Keys issued after **2025-08-31** lose v3 access (→ `403`). `downtrend-duration-analyzer`'s `fetch_stock_list()` used the v3 `/stock-screener` endpoint to build the universe of stocks to analyze.

(`historical-price-full` was already migrated to `/stable` in 44eadf8.)

## Fix
- `fetch_stock_list()` now calls **`/stable/company-screener`** first, with a v3 `/stock-screener` fallback for legacy keys.
- Both take the same params (`sector`, `isActivelyTrading`, `limit`) and return the same fields the caller reads (`symbol`, `sector`, `marketCap`) — verified live — so downstream processing is unchanged.
- Switched from a hand-built URL string (with manual `%20` sector encoding) to a `params` dict so `requests` handles URL-encoding, and added graceful handling of non-200/non-JSON responses while preserving the original "return `[]` on failure" behaviour.

## Before / after (key issued after 2025-08-31)
```
before: /stock-screener → 403
after:  Energy sector → 387 stocks (XOM / CVX / SHEL, real market caps)
```

## Tests
- New `tests/test_fetch_stock_list.py` (3): stable-first call + correct params, v3 fallback, and empty-on-total-failure. Full suite: 34 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
