### PR TITLE
fix(dividend-growth-pullback-screener): migrate FMP /api/v3 → /stable

### DIFF
--- a/skills/dividend-growth-pullback-screener/scripts/screen_dividend_growth_rsi.py
+++ b/skills/dividend-growth-pullback-screener/scripts/screen_dividend_growth_rsi.py
@@ -28,7 +28,7 @@ import json
 import os
 import sys
 import time
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Optional
 
 import requests
@@ -110,7 +110,7 @@ class FINVIZClient:
 
 # --- FMP endpoint fallback: stable (new users) -> v3 (legacy users) ---
 _FMP_HIST_ENDPOINTS = [
-    ("https://financialmodelingprep.com/stable/historical-price-full", True),
+    ("https://financialmodelingprep.com/stable/historical-price-eod/full", True),
     ("https://financialmodelingprep.com/api/v3/historical-price-full", False),
 ]
 
@@ -119,8 +119,20 @@ class FMPClient:
     """Financial Modeling Prep API client with rate limiting."""
 
     BASE_URL = "https://financialmodelingprep.com/api/v3"
+    STABLE_URL = "https://financialmodelingprep.com/stable"
 
     _ENDPOINT_FAILURE_THRESHOLD = 3
+    # v3 path-style endpoints whose trailing symbol moves to a ?symbol= query
+    # on /stable (e.g. v3 income-statement/AAPL -> stable income-statement?symbol=AAPL)
+    _SYMBOL_QUERY_ENDPOINTS = (
+        "income-statement",
+        "balance-sheet-statement",
+        "cash-flow-statement",
+        "key-metrics",
+        "ratios",
+        "profile",
+        "quote",
+    )
 
     def __init__(self, api_key: str):
         self.api_key = api_key
@@ -131,19 +143,16 @@ class FMPClient:
         self._endpoint_failures: dict[str, int] = {}
         self._disabled_endpoints: set[str] = set()
 
-    def _get(self, endpoint: str, params: Optional[dict] = None) -> Optional[dict]:
-        """Execute GET request with rate limiting and error handling."""
+    def _request(self, url: str, params: dict, quiet: bool = False) -> Optional[dict]:
+        """Single rate-limited GET. Returns parsed JSON, or None on failure.
+
+        Non-final endpoints pass quiet=True to suppress the expected 403 a new
+        key gets on the v3 fallback.
+        """
         if self.rate_limit_reached:
             return None
-
-        if params is None:
-            params = {}
-
-        url = f"{self.BASE_URL}/{endpoint}"
-
         try:
-            response = self.session.get(url, params=params, timeout=30)
-
+            response = self.session.get(url, params=params or {}, timeout=30)
             if response.status_code == 200:
                 self.retry_count = 0
                 time.sleep(0.3)  # Rate limiting: 0.3s between requests
@@ -153,21 +162,86 @@ class FMPClient:
                 if self.retry_count <= 1:
                     print("WARNING: Rate limit exceeded. Waiting 60 seconds...", file=sys.stderr)
                     time.sleep(60)
-                    return self._get(endpoint, params)
-                else:
-                    print(
-                        "ERROR: Daily API rate limit reached. Stopping analysis.", file=sys.stderr
-                    )
-                    self.rate_limit_reached = True
-                    return None
+                    return self._request(url, params, quiet=quiet)
+                print("ERROR: Daily API rate limit reached. Stopping analysis.", file=sys.stderr)
+                self.rate_limit_reached = True
+                return None
             else:
-                print(
-                    f"WARNING: API request failed ({response.status_code}): {url}", file=sys.stderr
-                )
+                if not quiet:
+                    print(
+                        f"WARNING: API request failed ({response.status_code}): {url}",
+                        file=sys.stderr,
+                    )
                 return None
         except Exception as e:
-            print(f"ERROR: Request failed for {url}: {e}", file=sys.stderr)
+            if not quiet:
+                print(f"ERROR: Request failed for {url}: {e}", file=sys.stderr)
             return None
+
+    def _stable_spec(self, endpoint: str, params: dict) -> Optional[tuple]:
+        """Map a v3 path-style endpoint to its (stable_url, stable_params).
+
+        Returns None when there is no known /stable equivalent.
+        """
+        p = dict(params or {})
+        if endpoint == "stock-screener":
+            return f"{self.STABLE_URL}/company-screener", p
+        if endpoint.startswith("historical-price-full/stock_dividend/"):
+            p["symbol"] = endpoint.rsplit("/", 1)[-1]
+            return f"{self.STABLE_URL}/dividends", p
+        head, _, sym = endpoint.partition("/")
+        if sym and head in self._SYMBOL_QUERY_ENDPOINTS:
+            p["symbol"] = sym
+            return f"{self.STABLE_URL}/{head}", p
+        return None
+
+    @staticmethod
+    def _normalize(endpoint: str, data):
+        """Reshape /stable responses to match the v3 shapes callers expect."""
+        if data is None:
+            return None
+        # Dividends: /stable returns a flat list; v3 returned {"historical": [...]}.
+        if endpoint.startswith("historical-price-full/stock_dividend/"):
+            return {"historical": data} if isinstance(data, list) else data
+        # key-metrics: /stable renamed roe -> returnOnEquity (same ratio scale).
+        if endpoint.startswith("key-metrics/") and isinstance(data, list):
+            for rec in data:
+                if isinstance(rec, dict) and "roe" not in rec and "returnOnEquity" in rec:
+                    rec["roe"] = rec["returnOnEquity"]
+        # cash-flow: /stable renamed dividendsPaid -> netDividendsPaid (same
+        # negative-outflow value; callers take abs()).
+        if endpoint.startswith("cash-flow-statement/") and isinstance(data, list):
+            for rec in data:
+                if (
+                    isinstance(rec, dict)
+                    and "dividendsPaid" not in rec
+                    and "netDividendsPaid" in rec
+                ):
+                    rec["dividendsPaid"] = rec["netDividendsPaid"]
+        return data
+
+    def _get(self, endpoint: str, params: Optional[dict] = None) -> Optional[dict]:
+        """GET an FMP endpoint, preferring /stable with a v3 path-style fallback.
+
+        Callers still pass the legacy v3 path-style `endpoint` strings (e.g.
+        "income-statement/AAPL"); this routes them to the /stable query-style
+        equivalents and normalizes the response back to the v3 shape. Keys
+        issued after 2025-08-31 only work on /stable; legacy keys fall back to v3.
+        """
+        if self.rate_limit_reached:
+            return None
+        params = params or {}
+        attempts = []
+        spec = self._stable_spec(endpoint, params)
+        if spec:
+            attempts.append(spec)  # /stable first
+        attempts.append((f"{self.BASE_URL}/{endpoint}", dict(params)))  # v3 fallback
+        for i, (url, req_params) in enumerate(attempts):
+            quiet = i < len(attempts) - 1
+            data = self._request(url, req_params, quiet=quiet)
+            if data is not None:
+                return self._normalize(endpoint, data)
+        return None
 
     def screen_stocks(self, min_market_cap: int = 2000000000, exchange: str = None) -> list[dict]:
         """Screen stocks by market cap and exchange."""
@@ -179,13 +253,23 @@ class FMPClient:
         return result if result else []
 
     def get_historical_prices(self, symbol: str, days: int = 30) -> Optional[list[dict]]:
-        """Get historical daily prices (stable endpoint with v3 fallback)."""
+        """Get historical daily prices, most-recent-first (/stable, v3 fallback).
+
+        /stable/historical-price-eod/full returns a flat list of OHLCV bars and
+        is bounded with from/to; the v3 fallback returns {"historical": [...]}.
+        """
         for base_url, is_stable in _FMP_HIST_ENDPOINTS:
             if base_url in self._disabled_endpoints:
                 continue
             if is_stable:
                 url = base_url
-                params = {"symbol": symbol, "timeseries": days}
+                today = datetime.now().date()
+                params = {
+                    "symbol": symbol,
+                    # ~days trading days needs ~2x calendar days; +10 for slack.
+                    "from": (today - timedelta(days=days * 2 + 10)).isoformat(),
+                    "to": today.isoformat(),
+                }
             else:
                 url = f"{base_url}/{symbol}"
                 params = {"timeseries": days}
@@ -196,6 +280,14 @@ class FMPClient:
                     self._record_endpoint_failure(base_url)
                     continue
                 data = response.json()
+                # /stable: flat list of bars (most-recent-first).
+                if isinstance(data, list):
+                    if data:
+                        self._endpoint_failures[base_url] = 0
+                        return data[:days]
+                    self._record_endpoint_failure(base_url)
+                    continue
+                # v3: {"symbol": ..., "historical": [...]}.
                 if isinstance(data, dict) and "historical" in data:
                     self._endpoint_failures[base_url] = 0
                     return data["historical"]

--- a/skills/dividend-growth-pullback-screener/scripts/tests/test_fmp_stable.py
+++ b/skills/dividend-growth-pullback-screener/scripts/tests/test_fmp_stable.py
@@ -1,0 +1,99 @@
+"""FMP /stable migration for dividend-growth-pullback-screener.
+
+Keys issued after 2025-08-31 lose v3 access (403). FMPClient._get now routes
+the legacy v3 path-style endpoints to their /stable query-style equivalents
+(with a v3 fallback) and normalizes responses to the v3 shapes callers expect:
+
+- historical-price-full/stock_dividend/{sym} -> dividends?symbol= (flat list
+  wrapped as {"historical": [...]})
+- key-metrics: roe <- returnOnEquity
+- cash-flow-statement: dividendsPaid <- netDividendsPaid
+
+get_historical_prices is also fixed to /stable/historical-price-eod/full
+(flat-list parsing + from/to bounding) so RSI has data again.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from unittest.mock import MagicMock  # noqa: E402
+
+import screen_dividend_growth_rsi as mod  # noqa: E402
+from screen_dividend_growth_rsi import FMPClient  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(mod.time, "sleep", lambda *_a, **_k: None)
+
+
+def _resp(status_code, payload):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    return resp
+
+
+def _client(router):
+    client = FMPClient("test_key")
+    session = MagicMock()
+    session.get.side_effect = router
+    client.session = session
+    return client, session
+
+
+class TestGetRouting:
+    def test_statement_path_to_stable_query(self):
+        client, session = _client(lambda *a, **k: _resp(200, [{"symbol": "AAPL", "revenue": 1}]))
+        client.get_income_statement("AAPL", limit=5)
+        call = session.get.call_args_list[0]
+        assert call[0][0].endswith("/stable/income-statement")
+        assert call[1]["params"]["symbol"] == "AAPL"
+        assert call[1]["params"]["limit"] == 5
+
+    def test_screener_to_company_screener(self):
+        client, session = _client(lambda *a, **k: _resp(200, [{"symbol": "X"}]))
+        client.screen_stocks(min_market_cap=2_000_000_000)
+        assert session.get.call_args_list[0][0][0].endswith("/stable/company-screener")
+
+    def test_dividends_normalized_to_historical(self):
+        flat = [{"symbol": "KO", "date": "2026-05-11", "dividend": 0.53}]
+        client, _ = _client(lambda *a, **k: _resp(200, flat))
+        result = client.get_dividend_history("KO")
+        assert isinstance(result, dict) and result["historical"] == flat
+
+    def test_key_metrics_roe_alias(self):
+        client, _ = _client(lambda *a, **k: _resp(200, [{"returnOnEquity": 1.2}]))
+        assert client.get_key_metrics("AAPL", limit=1)[0]["roe"] == 1.2
+
+    def test_cashflow_dividends_paid_alias(self):
+        client, _ = _client(lambda *a, **k: _resp(200, [{"netDividendsPaid": -8_000_000}]))
+        assert client.get_cash_flow("AAPL", limit=1)[0]["dividendsPaid"] == -8_000_000
+
+    def test_v3_fallback_when_stable_fails(self):
+        def router(url, params=None, timeout=None):
+            if "/stable/" in url:
+                return _resp(403, {})
+            return _resp(200, [{"symbol": "AAPL", "sector": "Tech"}])
+
+        client, session = _client(router)
+        assert client.get_company_profile("AAPL")["sector"] == "Tech"
+        urls = [c[0][0] for c in session.get.call_args_list]
+        assert any(u.endswith("/api/v3/profile/AAPL") for u in urls)
+
+
+class TestHistoricalPrices:
+    def test_stable_flat_list_with_from_to(self):
+        bars = [{"date": "2026-05-19", "close": 100.0}, {"date": "2026-05-18", "close": 99.0}]
+
+        def router(url, params=None, timeout=None):
+            assert url.endswith("/stable/historical-price-eod/full")
+            assert "from" in (params or {}) and "to" in (params or {})
+            return _resp(200, bars)
+
+        client, _ = _client(router)
+        assert client.get_historical_prices("AAPL", days=30) == bars  # flat list, close intact


### PR DESCRIPTION
## Root cause
FMP retired the legacy `/api/v3/` API; keys issued after **2025-08-31** get `403`. `dividend-growth-pullback-screener` made many v3 calls (stock-screener, income/balance/cash-flow statements, key-metrics, profile, quote, dividend history) plus a mis-migrated historical-price call. On a new key the skill returned nothing.

## Changes (mostly plumbing — analysis logic unchanged)
- `FMPClient._get()` routes the v3 path-style endpoints to their `/stable` query-style equivalents (with a v3 fallback) and normalizes responses to the shapes callers expect.
- **Field renames handled:** `key-metrics` `roe`←`returnOnEquity`; `cash-flow` `dividendsPaid`←`netDividendsPaid`; `dividends` flat list → `{"historical": [...]}`.
- **Historical fix:** stable path was wrong (`historical-price-full` 404s) → `historical-price-eod/full` + flat-list parsing + `from/to` bounding, so RSI has data again.
- **`screen_stocks` (FMP-only)** only filtered by market cap server-side, so it routes cleanly to `/stable/company-screener` with **no behavior change**. (Unlike value-dividend-screener, this skill's v3 screener did no server-side yield/P-E/P-B filtering, so no client-side gate was needed.)
- **No dividend-methodology change:** `analyze_dividend_growth` already excludes the current (partial) year, so it has no partial-year distortion — left as-is.

## Verification (live, new key)
- Migrated endpoints return real data: historical 30 bars + `close` (RSI works), `key-metrics` `roe`=1.519 (aliased), `cash-flow` `dividendsPaid`=−8.78B (aliased).
- 3-yr div CAGR computes correctly (ABBV 5.17%, MO 4.17%); the full deep-analysis pipeline runs end-to-end and applies the author's gates (12% CAGR / RSI ≤ 40).
- Tests: 17 pass (10 existing + 7 new in `tests/test_fmp_stable.py`) + 2 pre-existing skips.

## Known pre-existing limitation (not changed here)
`analyze_dividend_growth` uses the raw `dividend` field, not split-adjusted `adjDividend`. A stock that **split** during the window (e.g. AVGO's 2024 10:1) shows a distorted CAGR (AVGO computes −47.7% vs its real ~15%). This is present on v3 too and is the author's methodology — flagging for a separate fix rather than changing analysis behavior in a migration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
