### PR TITLE
fix(canslim-screener): migrate FMP /api/v3 → /stable

### DIFF
--- a/skills/canslim-screener/scripts/calculators/institutional_calculator.py
+++ b/skills/canslim-screener/scripts/calculators/institutional_calculator.py
@@ -108,13 +108,21 @@ def calculate_institutional_sponsorship(
             "interpretation": "Data unavailable",
         }
 
-    # Count institutional holders
-    num_holders = len(institutional_holders)
+    # Accept either the /stable aggregate shape (dict from get_institutional_holders)
+    # or a legacy v3 holder list.
+    if isinstance(institutional_holders, dict):
+        num_holders = institutional_holders.get("num_holders") or 0
+        preset_ownership_pct = institutional_holders.get("ownership_pct")
+        holder_list = institutional_holders.get("top_holders") or []
+    else:
+        num_holders = len(institutional_holders)
+        preset_ownership_pct = None
+        holder_list = institutional_holders
 
-    # Check for superinvestors
+    # Check for superinvestors (the top holders carry the names)
     superinvestors_found = []
-    for holder_entry in institutional_holders:
-        holder_name = holder_entry.get("holder", "").upper()
+    for holder_entry in holder_list:
+        holder_name = (holder_entry.get("holder") or "").upper()
         for superinvestor in SUPERINVESTORS:
             if superinvestor in holder_name:
                 superinvestors_found.append(holder_entry.get("holder"))
@@ -122,16 +130,17 @@ def calculate_institutional_sponsorship(
 
     superinvestor_present = len(superinvestors_found) > 0
 
-    # Calculate total shares held by institutions
-    total_shares_held = sum(holder.get("shares", 0) for holder in institutional_holders)
+    # Total shares held (used only for the list-derived ownership path).
+    total_shares_held = sum(holder.get("shares", 0) or 0 for holder in holder_list)
 
-    # Calculate ownership percentage (requires shares outstanding from profile)
-    ownership_pct = None
+    # Ownership %: prefer the /stable summary value; else derive from shares +
+    # shares outstanding; else fall back to Finviz.
+    ownership_pct = preset_ownership_pct
     shares_outstanding = None
-    quality_warning = None
+    quality_warning = ""
     data_source = "FMP"  # Track data source
 
-    if profile:
+    if ownership_pct is None and profile:
         # Try to get shares outstanding (different field names possible)
         shares_outstanding = profile.get("sharesOutstanding")
 
@@ -146,7 +155,7 @@ def calculate_institutional_sponsorship(
             ownership_pct = (total_shares_held / shares_outstanding) * 100
         else:
             quality_warning = "Shares outstanding unavailable from FMP."
-    else:
+    elif ownership_pct is None:
         quality_warning = "Company profile not provided."
 
     # Finviz fallback: If ownership % still unavailable, try Finviz

--- a/skills/canslim-screener/scripts/check_institutional_endpoint.py
+++ b/skills/canslim-screener/scripts/check_institutional_endpoint.py
@@ -6,19 +6,33 @@ Critical decision point for Phase 2 implementation
 
 import os
 import sys
+from datetime import date
 
 import requests
 
 
+def _latest_completed_quarter(as_of=None):
+    """(year, quarter) of the most recent completed calendar quarter."""
+    d = as_of or date.today()
+    year = d.year
+    quarter = (d.month - 1) // 3  # current quarter (1-4) minus 1 = last completed
+    if quarter == 0:
+        quarter, year = 4, year - 1
+    return year, quarter
+
+
 def check_institutional_endpoint():
     """
-    Test if institutional-holder endpoint is available with current API key
+    Test if /stable institutional-ownership data is available with the API key.
+
+    The skill sources the CANSLIM 'I' component from /stable
+    institutional-ownership (symbol-positions-summary for the holder count +
+    ownership %), with a v3 fallback handled automatically in FMPClient. This
+    is just an availability probe.
 
     Returns:
-        bool: True if endpoint available (Full Implementation)
-              False if endpoint restricted (Fallback Implementation)
+        bool: True if institutional data is reachable, False otherwise.
     """
-    # Get API key
     api_key = os.environ.get("FMP_API_KEY")
 
     if not api_key:
@@ -26,75 +40,46 @@ def check_institutional_endpoint():
         print("Please set it with: export FMP_API_KEY=your_key")
         return False
 
-    print(f"Testing institutional-holder endpoint with API key (length: {len(api_key)})...")
+    print(f"Testing /stable institutional-ownership with API key (length: {len(api_key)})...")
     print()
 
-    # Test institutional-holder endpoint
     test_symbol = "AAPL"
-    url = f"https://financialmodelingprep.com/api/v3/institutional-holder/{test_symbol}"
+    year, quarter = _latest_completed_quarter()
+    url = (
+        "https://financialmodelingprep.com/stable/institutional-ownership/symbol-positions-summary"
+    )
+    params = {"symbol": test_symbol, "year": year, "quarter": quarter, "apikey": api_key}
 
     try:
-        response = requests.get(url, headers={"apikey": api_key}, timeout=10)
+        response = requests.get(url, params=params, timeout=10)
 
-        print(f"Status Code: {response.status_code}")
+        print(f"Status Code: {response.status_code} (year={year} Q{quarter})")
         print(f"Response length: {len(response.text)} bytes")
         print()
 
         if response.status_code == 200:
-            # Parse JSON
             data = response.json()
-
-            # Check if it's an error message
-            if isinstance(data, dict) and "Error Message" in data:
-                print("❌ RESULT: Endpoint RESTRICTED")
-                print(f"   Error: {data['Error Message']}")
-                print()
-                print("DECISION: Use Fallback Implementation (Step 3B)")
-                print("  - I component will use Profile API institutionalOwnership field only")
-                print("  - Score capped at 70/100")
-                print("  - Quality warning will be added to all results")
-                return False
-
-            # Check if data is valid
-            if isinstance(data, list) and len(data) > 0:
-                print("✅ RESULT: Endpoint AVAILABLE")
-                print(f"   Found {len(data)} institutional holders for {test_symbol}")
-                print()
-                print("Sample data:")
-                for i, holder in enumerate(data[:3]):
-                    print(
-                        f"  {i + 1}. {holder.get('holder', 'N/A')}: "
-                        f"{holder.get('shares', 0):,} shares"
-                    )
-                print()
-                print("DECISION: Use Full Implementation (Step 3A)")
-                print("  - Full institutional analysis with holder count and ownership %")
-                print("  - Superinvestor detection")
-                print("  - Score range: 0-100")
+            if isinstance(data, list) and data and data[0].get("investorsHolding"):
+                summary = data[0]
+                print("✅ RESULT: Institutional data AVAILABLE")
+                print(
+                    f"   {test_symbol}: {summary.get('investorsHolding')} holders, "
+                    f"ownership {summary.get('ownershipPercent')}%"
+                )
                 return True
-            else:
-                print("⚠️  RESULT: Unexpected response format")
-                print(f"   Data type: {type(data)}")
-                print(f"   Data: {data}")
-                print()
-                print("DECISION: Use Fallback Implementation (Step 3B) as precaution")
-                return False
+            print("⚠️  RESULT: No institutional data for the latest quarter")
+            print(f"   Data: {str(data)[:200]}")
+            return False
 
-        elif response.status_code == 401 or response.status_code == 403:
-            print("❌ RESULT: Endpoint RESTRICTED (401/403)")
-            print()
-            print("DECISION: Use Fallback Implementation (Step 3B)")
+        if response.status_code in (401, 403):
+            print("❌ RESULT: RESTRICTED (401/403) — check subscription/key")
             return False
-        else:
-            print(f"⚠️  RESULT: Unexpected status code {response.status_code}")
-            print()
-            print("DECISION: Use Fallback Implementation (Step 3B) as precaution")
-            return False
+
+        print(f"⚠️  RESULT: Unexpected status code {response.status_code}")
+        return False
 
     except requests.exceptions.RequestException as e:
         print(f"❌ ERROR: Request failed - {e}")
-        print()
-        print("DECISION: Use Fallback Implementation (Step 3B)")
         return False
 
 

--- a/skills/canslim-screener/scripts/fmp_client.py
+++ b/skills/canslim-screener/scripts/fmp_client.py
@@ -120,6 +120,7 @@ class FMPClient:
     """Client for Financial Modeling Prep API with rate limiting and caching"""
 
     BASE_URL = "https://financialmodelingprep.com/api/v3"
+    STABLE_URL = "https://financialmodelingprep.com/stable"
     RATE_LIMIT_DELAY = 0.3  # 300ms between requests (200 requests/minute max)
 
     def __init__(self, api_key: Optional[str] = None):
@@ -307,10 +308,13 @@ class FMPClient:
         if cache_key in self.cache:
             return self.cache[cache_key]
 
-        url = f"{self.BASE_URL}/income-statement/{symbol}"
         params = {"period": period, "limit": limit}
-
-        data = self._rate_limited_get(url, params)
+        # stable: /income-statement?symbol=&period=&limit= ; v3 fallback: path-style
+        data = self._rate_limited_get(
+            f"{self.STABLE_URL}/income-statement", {**params, "symbol": symbol}, quiet=True
+        )
+        if not data:
+            data = self._rate_limited_get(f"{self.BASE_URL}/income-statement/{symbol}", params)
 
         if data:
             self.cache[cache_key] = data
@@ -393,51 +397,103 @@ class FMPClient:
         if cache_key in self.cache:
             return self.cache[cache_key]
 
-        url = f"{self.BASE_URL}/profile/{symbol}"
-
-        data = self._rate_limited_get(url)
+        # stable: /profile?symbol= ; v3 fallback: /profile/{symbol}
+        data = self._rate_limited_get(f"{self.STABLE_URL}/profile", {"symbol": symbol}, quiet=True)
+        if not data:
+            data = self._rate_limited_get(f"{self.BASE_URL}/profile/{symbol}")
 
         if data:
+            # /stable/profile renamed mktCap -> marketCap; expose mktCap so the
+            # screener (profile[0]["mktCap"]) keeps working on either endpoint.
+            for p in data:
+                if isinstance(p, dict) and "mktCap" not in p and "marketCap" in p:
+                    p["mktCap"] = p["marketCap"]
             self.cache[cache_key] = data
 
         return data
 
-    def get_institutional_holders(self, symbol: str) -> Optional[list[dict]]:
+    @staticmethod
+    def _recent_13f_quarters(as_of=None, count: int = 4):
+        """Yield the most recent completed (year, quarter) 13F periods, newest first.
+
+        13F filings lag the quarter end by ~45 days, so the just-completed
+        quarter may not be filed yet; the caller walks back until data exists.
         """
-        Fetch institutional holder data (Phase 2: I component)
+        d = as_of or date.today()
+        year = d.year
+        quarter = (d.month - 1) // 3  # current quarter (1-4) minus 1 = last completed
+        if quarter == 0:
+            quarter, year = 4, year - 1
+        for _ in range(count):
+            yield year, quarter
+            quarter -= 1
+            if quarter == 0:
+                quarter, year = 4, year - 1
 
-        Args:
-            symbol: Stock ticker
+    def get_institutional_holders(self, symbol: str) -> Optional[dict]:
+        """Fetch institutional sponsorship summary (CANSLIM 'I' component).
 
-        Returns:
-            List of institutional holders with:
-                - holder: Institution name (str)
-                - shares: Number of shares held (int)
-                - dateReported: Reporting date (str)
-                - change: Change in shares from previous quarter (int)
-            Returns None on error
+        Returns a dict::
 
-        Example:
-            holders = client.get_institutional_holders("AAPL")
-            # holders[0] = {"holder": "Vanguard Group Inc", "shares": 1234567890, ...}
+            {"num_holders": int, "ownership_pct": float | None,
+             "top_holders": [{"holder": str, "shares": int, "change": int}, ...]}
 
-        Note:
-            This endpoint provides 13F filing data. Free tier may have limited access.
-            Typical response contains hundreds to thousands of institutional holders.
+        /stable has no single endpoint returning the full holder list (the
+        per-holder endpoint is paginated 10/page). Instead this uses
+        institutional-ownership/symbol-positions-summary for the holder count
+        (investorsHolding) and ownership % (ownershipPercent) — more accurate
+        than summing a list — plus extract-analytics/holder (page 0) for the
+        top names used in superinvestor detection. Falls back to the v3
+        institutional-holder list for legacy keys. Returns None on failure.
         """
         cache_key = f"institutional_{symbol}"
-
         if cache_key in self.cache:
             return self.cache[cache_key]
 
-        url = f"{self.BASE_URL}/institutional-holder/{symbol}"
+        result = None
+        # --- /stable: latest available 13F quarter ---
+        for year, quarter in self._recent_13f_quarters():
+            qp = {"symbol": symbol, "year": year, "quarter": quarter}
+            summary = self._rate_limited_get(
+                f"{self.STABLE_URL}/institutional-ownership/symbol-positions-summary",
+                qp,
+                quiet=True,
+            )
+            if isinstance(summary, list) and summary:
+                top = self._rate_limited_get(
+                    f"{self.STABLE_URL}/institutional-ownership/extract-analytics/holder",
+                    {**qp, "page": 0},
+                    quiet=True,
+                )
+                top_holders = [
+                    {
+                        "holder": h.get("investorName"),
+                        "shares": h.get("sharesNumber"),
+                        "change": h.get("changeInSharesNumber"),
+                    }
+                    for h in (top or [])
+                    if isinstance(h, dict)
+                ]
+                result = {
+                    "num_holders": summary[0].get("investorsHolding"),
+                    "ownership_pct": summary[0].get("ownershipPercent"),
+                    "top_holders": top_holders,
+                }
+                break
 
-        data = self._rate_limited_get(url)
+        # --- v3 fallback (legacy keys): full holder list ---
+        if result is None:
+            v3 = self._rate_limited_get(f"{self.BASE_URL}/institutional-holder/{symbol}")
+            if isinstance(v3, list) and v3:
+                result = {
+                    "num_holders": len(v3),
+                    "ownership_pct": None,  # calculator derives from shares/profile/Finviz
+                    "top_holders": v3[:10],  # already {holder, shares, change}
+                }
 
-        if data:
-            self.cache[cache_key] = data
-
-        return data
+        if result is not None:
+            self.cache[cache_key] = result
+        return result
 
     def calculate_ema(self, prices: list[float], period: int = 50) -> float:
         """

--- a/skills/canslim-screener/scripts/tests/test_fmp_stable_migration.py
+++ b/skills/canslim-screener/scripts/tests/test_fmp_stable_migration.py
@@ -1,0 +1,132 @@
+"""FMP /stable migration for canslim-screener.
+
+Keys issued after 2025-08-31 lose v3 access (403). Three FMP calls are migrated
+(stable-first, v3 fallback):
+- get_income_statement: /income-statement/{sym} -> /stable/income-statement?symbol=&period=
+- get_profile: /profile/{sym} -> /stable/profile?symbol= (+ mktCap alias)
+- get_institutional_holders: /institutional-holder/{sym} (full list) ->
+  /stable institutional-ownership summary (count + ownership%) + top-holders
+  page (superinvestor names), returned as an aggregate dict.
+"""
+
+import os
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+
+def _make_client():
+    with patch.dict(os.environ, {"FMP_API_KEY": "test_key"}):  # pragma: allowlist secret
+        from fmp_client import FMPClient
+
+        client = FMPClient(api_key="test_key")
+    client.RATE_LIMIT_DELAY = 0  # no sleep in tests
+    return client
+
+
+def _resp(status_code=200, json_data=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.text = ""
+    return resp
+
+
+class TestIncomeStatementProfile:
+    def test_income_statement_uses_stable_query(self):
+        client = _make_client()
+        captured = {}
+
+        def fake_get(url, params=None, timeout=30):
+            captured["url"], captured["params"] = url, params
+            return _resp(200, [{"symbol": "AAPL", "period": "Q2", "eps": 2.0}])
+
+        client.session.get = fake_get
+        client.get_income_statement("AAPL", period="quarter", limit=8)
+        assert captured["url"].endswith("/stable/income-statement")
+        assert captured["params"]["symbol"] == "AAPL"
+        assert captured["params"]["period"] == "quarter"
+
+    def test_profile_stable_with_mktcap_alias(self):
+        client = _make_client()
+        # /stable/profile returns marketCap, not mktCap.
+        client.session.get = lambda *a, **k: _resp(
+            200, [{"symbol": "AAPL", "companyName": "Apple", "marketCap": 4_000_000_000_000}]
+        )
+        profile = client.get_profile("AAPL")
+        assert profile[0]["mktCap"] == 4_000_000_000_000  # aliased for downstream
+
+
+class TestInstitutionalHolders:
+    def test_summary_plus_top_holders(self):
+        def fake_get(url, params=None, timeout=30):
+            if "symbol-positions-summary" in url:
+                return _resp(200, [{"investorsHolding": 6170, "ownershipPercent": 61.6}])
+            if "extract-analytics/holder" in url:
+                return _resp(
+                    200,
+                    [
+                        {
+                            "investorName": "VANGUARD GROUP INC",
+                            "sharesNumber": 100,
+                            "changeInSharesNumber": 5,
+                        },
+                        {
+                            "investorName": "BLACKROCK, INC.",
+                            "sharesNumber": 90,
+                            "changeInSharesNumber": -2,
+                        },
+                    ],
+                )
+            raise AssertionError(f"unexpected {url}")
+
+        client = _make_client()
+        client.session.get = fake_get
+        result = client.get_institutional_holders("AAPL")
+        assert result["num_holders"] == 6170
+        assert result["ownership_pct"] == 61.6
+        assert result["top_holders"][0] == {
+            "holder": "VANGUARD GROUP INC",
+            "shares": 100,
+            "change": 5,
+        }
+
+    def test_v3_fallback_when_stable_empty(self):
+        def fake_get(url, params=None, timeout=30):
+            if "/stable/" in url:
+                return _resp(200, [])  # no stable 13F data for any quarter
+            # v3 institutional-holder full list
+            return _resp(200, [{"holder": "Vanguard", "shares": 100, "change": 1}] * 75)
+
+        client = _make_client()
+        client.session.get = fake_get
+        result = client.get_institutional_holders("AAPL")
+        assert result["num_holders"] == 75  # len of the v3 list
+        assert result["ownership_pct"] is None  # calculator derives it
+
+    def test_recent_13f_quarters_walk_back(self):
+        from fmp_client import FMPClient
+
+        # May 2026 -> most recent completed quarter is Q1 2026, then walk back.
+        quarters = list(FMPClient._recent_13f_quarters(as_of=date(2026, 5, 20), count=3))
+        assert quarters == [(2026, 1), (2025, 4), (2025, 3)]
+
+
+class TestInstitutionalCalculatorDictShape:
+    def test_uses_aggregate_count_and_ownership(self):
+        from calculators.institutional_calculator import calculate_institutional_sponsorship
+
+        agg = {
+            "num_holders": 6170,
+            "ownership_pct": 61.6,
+            # SUPERINVESTORS are famous active managers (Berkshire, Baupost, ...),
+            # not passive index funds, so this name triggers the bonus.
+            "top_holders": [
+                {"holder": "BLACKROCK, INC.", "shares": 90, "change": 1},
+                {"holder": "BERKSHIRE HATHAWAY INC", "shares": 50, "change": 0},
+            ],
+        }
+        result = calculate_institutional_sponsorship(agg, profile={}, use_finviz_fallback=False)
+        assert result["num_holders"] == 6170
+        assert result["ownership_pct"] == 61.6
+        assert result["superinvestor_present"] is True  # matched Berkshire
+        assert result["score"] > 0


### PR DESCRIPTION
## Root cause
FMP retired the legacy `/api/v3/` API; keys issued after **2025-08-31** get `403`. Three `canslim-screener` FMP calls were still on v3 (quote + historical were already migrated to `/stable`).

## Changes
- **`get_income_statement`** → `/stable/income-statement?symbol=&period=&limit=` (+ v3 fallback). `period=quarter/annual` verified on `/stable`.
- **`get_profile`** → `/stable/profile?symbol=` (+ v3 fallback). `/stable` renamed `mktCap` → `marketCap`, so a `mktCap` alias is added — the screener reads `profile[0]["mktCap"]` for the market-cap gate.
- **`get_institutional_holders`** (CANSLIM 'I' component): the v3 `institutional-holder` *full list* has no cheap `/stable` equivalent (the per-holder endpoint is paginated **10/page** — ~630 calls for AAPL). It now uses `/stable` **institutional-ownership**:
  - `symbol-positions-summary` → holder **count** (`investorsHolding`) + **ownership %** (`ownershipPercent`) in one call — *more accurate* than summing a partial list;
  - `extract-analytics/holder` (page 0) → top names for **superinvestor** detection.
  
  Returns an aggregate dict; **falls back to the v3 list** for legacy keys. `calculate_institutional_sponsorship` now accepts that aggregate dict (preferring its count + ownership %) as well as the legacy list shape. A latent `None += str` warning-path bug is fixed along the way.
- Updated the standalone **`check_institutional_endpoint.py`** diagnostic to probe the `/stable` summary endpoint (it was testing the retired v3 path).

## Behavior note (please review)
The 'I' component's data source changes from "fetch the full holder list, count it, sum shares" to FMP's own `investorsHolding` count + `ownershipPercent`. This is **more accurate** and faithful to O'Neil's intent (holder count + institutional ownership %), but it *is* a data-source change to a scoring component — flagging for review. The 6 other CANSLIM components are untouched.

## Verification (live, new key)
- Profile (`mktCap` aliased), quarterly income, and the 'I' component all return real data: **AAPL → 6170 holders, ownership 61.6%, superinvestor detected (Berkshire), I-score 60.**
- Tests: **73 pass** (67 existing + 6 new in `tests/test_fmp_stable_migration.py`). The 6 new pass **with and without** bs4 (canslim is a CI `KNOWN_SKIP` due to the optional bs4 dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
