### PR TITLE
fix(theme-detector): migrate FMP /api/v3 → /stable

### DIFF
--- a/skills/theme-detector/scripts/etf_scanner.py
+++ b/skills/theme-detector/scripts/etf_scanner.py
@@ -11,6 +11,7 @@ FMP API key is optional; without it, yfinance is used exclusively.
 
 import sys
 import time
+from datetime import date, timedelta
 from typing import Any, Optional
 
 try:
@@ -52,8 +53,15 @@ def _v3_quote_url(base: str, symbols_str: str, params: dict) -> tuple[str, dict]
 
 
 def _stable_hist_url(base: str, symbols_str: str, params: dict) -> tuple[str, dict]:
-    """stable/historical-price-full?symbol=A,B&..."""
+    """stable/historical-price-eod/full?symbol=SYM&from=&to="""
     params["symbol"] = symbols_str
+    # The /stable EOD endpoint ignores `timeseries`; convert it to a from/to
+    # range (~2x calendar days to cover N trading days, +10 slack).
+    days = params.pop("timeseries", None)
+    if days is not None:
+        today = date.today()
+        params["from"] = (today - timedelta(days=int(days) * 2 + 10)).isoformat()
+        params["to"] = today.isoformat()
     return base, params
 
 
@@ -62,13 +70,34 @@ def _v3_hist_url(base: str, symbols_str: str, params: dict) -> tuple[str, dict]:
     return f"{base}/{symbols_str}", params
 
 
+def _normalize_eod_flat_list(data: Any, symbols_str: str) -> Any:
+    """Convert a /stable historical-price-eod/full flat list to the v3 shape.
+
+    Input  : [{"symbol": "AAPL", "date": .., "close": .., ...}, ...]
+    Output : {"symbol": "AAPL", "historical": [...]}
+    Non-list input (v3 dict / historicalStockList) passes through unchanged;
+    returns None when no row matches the requested symbol.
+    """
+    if not isinstance(data, list):
+        return data
+    norm = symbols_str.replace("-", ".")
+    rows = [
+        r
+        for r in data
+        if isinstance(r, dict) and (r.get("symbol") or symbols_str).replace("-", ".") == norm
+    ]
+    if not rows:
+        return None
+    return {"symbol": symbols_str, "historical": rows}
+
+
 _FMP_ENDPOINTS = {
     "quote": [
         ("https://financialmodelingprep.com/stable/quote", _stable_quote_url),
         ("https://financialmodelingprep.com/api/v3/quote", _v3_quote_url),
     ],
     "historical": [
-        ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
+        ("https://financialmodelingprep.com/stable/historical-price-eod/full", _stable_hist_url),
         ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
     ],
 }
@@ -80,8 +109,11 @@ class ETFScanner:
     Supports FMP API (preferred) with automatic yfinance fallback.
     """
 
-    FMP_HIST_BATCH_SIZE = 5
-    FMP_QUOTE_BATCH_SIZE = 50
+    # One symbol per request: FMP's /stable endpoints do not support
+    # comma-batched symbols (that is a paid legacy feature that silently
+    # returns []), so quotes/history are fetched individually.
+    FMP_HIST_BATCH_SIZE = 1
+    FMP_QUOTE_BATCH_SIZE = 1
 
     _ENDPOINT_FAILURE_THRESHOLD = 3  # disable endpoint after N consecutive failures
 
@@ -171,6 +203,10 @@ class ETFScanner:
                 )
                 if resp.status_code == 200:
                     data = resp.json()
+                    if endpoint_key == "historical":
+                        # /stable returns a flat OHLCV list; reshape to the v3
+                        # {"symbol", "historical"} dict the parser expects.
+                        data = _normalize_eod_flat_list(data, symbols_str)
                     if data:
                         # Reset failure count on success
                         self._endpoint_failures[base_url] = 0

--- a/skills/theme-detector/scripts/representative_stock_selector.py
+++ b/skills/theme-detector/scripts/representative_stock_selector.py
@@ -464,16 +464,27 @@ class RepresentativeStockSelector:
         self._rate_limit()
         self._source_states["fmp"].total_queries += 1
 
-        url = f"https://financialmodelingprep.com/api/v3/etf-holder/{etf_symbol}"
+        # stable: /etf/holdings?symbol= ; v3 fallback (legacy keys): /etf-holder/{symbol}.
+        # Both return a list of holdings with `asset` (ticker) and `marketValue`.
+        endpoints = [
+            ("https://financialmodelingprep.com/stable/etf/holdings", {"symbol": etf_symbol}),
+            (f"https://financialmodelingprep.com/api/v3/etf-holder/{etf_symbol}", None),
+        ]
 
         try:
-            resp = requests.get(url, headers={"apikey": self._fmp_api_key}, timeout=15)
-            if resp.status_code != 200:
-                self._record_failure("fmp")
-                return []
+            data = None
+            for url, params in endpoints:
+                resp = requests.get(
+                    url, params=params, headers={"apikey": self._fmp_api_key}, timeout=15
+                )
+                if resp.status_code != 200:
+                    continue
+                payload = resp.json()
+                if isinstance(payload, list) and payload:
+                    data = payload
+                    break
 
-            data = resp.json()
-            if not isinstance(data, list):
+            if not data:
                 self._record_failure("fmp")
                 return []
 

--- a/skills/theme-detector/scripts/tests/test_etf_scanner.py
+++ b/skills/theme-detector/scripts/tests/test_etf_scanner.py
@@ -172,7 +172,7 @@ class TestFMPEndpointFallback:
 
         result = scanner._fmp_request("quote", "AAPL")
         assert result is None
-        assert scanner._stats["fmp_failures"] == 2
+        assert scanner.backend_stats()["fmp_failures"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -636,21 +636,30 @@ class TestSymbolLevelFallback:
         quote_resp.json.return_value = [
             {"symbol": "AAPL", "pe": 30, "price": 150, "yearHigh": 180, "yearLow": 120},
         ]
-        hist_resp = MagicMock()
-        hist_resp.status_code = 200
-        # Historical with enough data for RSI (newest-first from FMP)
-        hist_resp.json.return_value = {
-            "historicalStockList": [
-                {"symbol": "AAPL", "historical": [{"close": float(150 - i)} for i in range(20)]},
-            ]
-        }
-        mock_requests.get.side_effect = [
-            quote_resp,
-            hist_resp,
-            # Per-symbol retry for MSFT (fails)
-            MagicMock(status_code=500),
-            MagicMock(status_code=500),
-        ]
+
+        # Symbols are fetched one per request (no comma-batching on /stable),
+        # so route by symbol/endpoint rather than a fixed call sequence: AAPL
+        # succeeds via FMP, MSFT fails (→ yfinance fallback).
+        def fake_get(url, params=None, headers=None, timeout=None):
+            p = params or {}
+            # symbol is in params for /stable, in the path for the v3 fallback
+            symbol = p.get("symbol") or url.rstrip("/").rsplit("/", 1)[-1]
+            resp = MagicMock()
+            if "AAPL" in symbol:
+                resp.status_code = 200
+                if "quote" in url:
+                    resp.json.return_value = [
+                        {"symbol": "AAPL", "pe": 30, "price": 150, "yearHigh": 180, "yearLow": 120}
+                    ]
+                else:  # /stable historical returns a flat OHLCV list
+                    resp.json.return_value = [
+                        {"symbol": "AAPL", "close": float(150 - i)} for i in range(20)
+                    ]
+            else:  # MSFT → FMP fails on both stable and v3
+                resp.status_code = 500
+            return resp
+
+        mock_requests.get.side_effect = fake_get
 
         # yfinance fallback: download for MSFT
         mock_df = pd.DataFrame(
@@ -675,7 +684,7 @@ class TestSymbolLevelFallback:
         msft = [r for r in results if r["symbol"] == "MSFT"][0]
         assert msft["pe_ratio"] == 35.0
         # Stats show fallback occurred
-        assert scanner._stats["yf_fallbacks"] >= 1
+        assert scanner.backend_stats()["yf_fallbacks"] >= 1
 
     @patch("etf_scanner._requests_lib")
     def test_all_fmp_success_no_yfinance_calls(self, mock_requests):
@@ -700,7 +709,7 @@ class TestSymbolLevelFallback:
             scanner.batch_stock_metrics(["AAPL"])
             mock_yf.download.assert_not_called()
 
-        assert scanner._stats["yf_calls"] == 0
+        assert scanner.backend_stats()["yf_calls"] == 0
 
     @patch("etf_scanner.HAS_REQUESTS", False)
     @patch("etf_scanner.yf")
@@ -723,7 +732,7 @@ class TestSymbolLevelFallback:
 
         results = scanner.batch_stock_metrics(["AAPL"])
         assert len(results) == 1
-        assert scanner._stats["yf_calls"] == 1
+        assert scanner.backend_stats()["yf_calls"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/skills/theme-detector/scripts/tests/test_fmp_stable_migration.py
+++ b/skills/theme-detector/scripts/tests/test_fmp_stable_migration.py
@@ -1,0 +1,98 @@
+"""FMP /stable migration for theme-detector.
+
+Keys issued after 2025-08-31 lose v3 access (403). Fixes:
+- Quotes/history are fetched one symbol per request (FMP /stable does not
+  support comma-batched symbols — that silently returns []).
+- Historical uses /stable/historical-price-eod/full (the prior stable URL,
+  historical-price-full, 404s) with timeseries->from/to and flat-list
+  normalization back to the v3 {"symbol","historical"} shape.
+- ETF holdings: /api/v3/etf-holder/{sym} -> /stable/etf/holdings?symbol=
+  (+ v3 fallback); both expose `asset` and `marketValue`.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import representative_stock_selector as rss
+from etf_scanner import ETFScanner, _normalize_eod_flat_list, _stable_hist_url
+
+
+class TestHistoricalNormalize:
+    def test_flat_list_to_v3_dict(self):
+        flat = [
+            {"symbol": "AAPL", "date": "2026-05-19", "close": 298.97},
+            {"symbol": "AAPL", "date": "2026-05-18", "close": 296.0},
+        ]
+        out = _normalize_eod_flat_list(flat, "AAPL")
+        assert out["symbol"] == "AAPL"
+        assert len(out["historical"]) == 2
+
+    def test_no_match_returns_none(self):
+        assert _normalize_eod_flat_list([{"symbol": "MSFT", "close": 1}], "AAPL") is None
+
+    def test_dict_passthrough(self):
+        d = {"symbol": "AAPL", "historical": [{"close": 1}]}
+        assert _normalize_eod_flat_list(d, "AAPL") is d
+
+    def test_stable_hist_url_converts_timeseries(self):
+        base = "https://financialmodelingprep.com/stable/historical-price-eod/full"
+        url, params = _stable_hist_url(base, "AAPL", {"timeseries": 20})
+        assert url == base
+        assert params["symbol"] == "AAPL"
+        assert "from" in params and "to" in params
+        assert "timeseries" not in params  # converted to a from/to range
+
+
+class TestDeBatch:
+    def test_batch_sizes_are_one(self):
+        assert ETFScanner.FMP_QUOTE_BATCH_SIZE == 1
+        assert ETFScanner.FMP_HIST_BATCH_SIZE == 1
+
+    def test_quotes_fetched_one_symbol_per_request(self):
+        scanner = ETFScanner(fmp_api_key="k")
+        seen = []
+
+        def fake_req(endpoint_key, symbols_str, extra_params=None):
+            seen.append((endpoint_key, symbols_str))
+            return [{"symbol": symbols_str, "price": 100.0}]
+
+        scanner._fmp_request = fake_req
+        scanner._fetch_fmp_quotes(["AAPL", "MSFT", "NVDA"])
+        quote_syms = [s for e, s in seen if e == "quote"]
+        assert all("," not in s for s in quote_syms)  # never comma-batched
+        assert set(quote_syms) >= {"AAPL", "MSFT", "NVDA"}
+
+
+class TestEtfHoldings:
+    def _resp(self, status, payload):
+        r = MagicMock()
+        r.status_code = status
+        r.json.return_value = payload
+        return r
+
+    def test_stable_etf_holdings_first(self):
+        sel = rss.RepresentativeStockSelector(fmp_api_key="k")
+        sel._rate_limit = lambda: None
+        with patch.object(rss, "requests") as mock_requests:
+            mock_requests.get.return_value = self._resp(
+                200, [{"asset": "NVDA", "marketValue": 1_000_000_000}]
+            )
+            holds = sel._fetch_etf_holdings("SPY", limit=5)
+        assert holds[0]["symbol"] == "NVDA"
+        assert mock_requests.get.call_args[0][0].endswith("/stable/etf/holdings")
+        assert mock_requests.get.call_args[1]["params"] == {"symbol": "SPY"}
+
+    def test_falls_back_to_v3_etf_holder(self):
+        sel = rss.RepresentativeStockSelector(fmp_api_key="k")
+        sel._rate_limit = lambda: None
+
+        def fake_get(url, params=None, headers=None, timeout=None):
+            if "/stable/etf/holdings" in url:
+                return self._resp(403, {})
+            return self._resp(200, [{"asset": "AAPL", "marketValue": 5}])
+
+        with patch.object(rss, "requests") as mock_requests:
+            mock_requests.get.side_effect = fake_get
+            holds = sel._fetch_etf_holdings("XLK", limit=5)
+        assert holds[0]["symbol"] == "AAPL"
+        urls = [c[0][0] for c in mock_requests.get.call_args_list]
+        assert any(u.endswith("/api/v3/etf-holder/XLK") for u in urls)


### PR DESCRIPTION
## Root cause
FMP retired the legacy `/api/v3/` API; keys issued after **2025-08-31** get `403`. `theme-detector` had three issues on a new key:

1. **Comma-batched quotes/history.** `etf_scanner` batched up to 50 quote / 5 historical symbols into one request. On `/stable`, comma batching silently returns `[]` — and the quote per-symbol retry only fired when a symbol was *renamed*, so most quotes came back empty.
2. **Historical on the wrong stable path.** It used `/stable/historical-price-full`, which **404s** (the correct endpoint is `historical-price-eod/full`) — so historical returned nothing on a new key (pre-existing).
3. **`etf-holder`** in `representative_stock_selector` used v3 `/etf-holder/{sym}`.

## Fix
- **De-batch:** `FMP_QUOTE_BATCH_SIZE` / `FMP_HIST_BATCH_SIZE` → **1** (one symbol per `/stable` request — the same per-symbol path the retry already used).
- **Historical:** corrected URL to `historical-price-eod/full`, convert `timeseries` → `from/to`, and normalize the flat OHLCV list back to the v3 `{"symbol","historical"}` shape the parser expects.
- **ETF holdings:** `/stable/etf/holdings?symbol=` with a v3 `/etf-holder` fallback — both expose `asset` + `marketValue`, so extraction is unchanged.

## Before / after (key issued after 2025-08-31)
```
before: quotes mostly empty; historical {} ; etf-holder 403
after:  per-symbol quotes (AAPL 298.97, MSFT 417.42, NVDA 220.61),
        historical AAPL/MSFT = 35 bars each,
        etf/holdings SPY -> NVDA/AAPL/MSFT/AMZN/GOOGL with market values
```

## Tests
- New `tests/test_fmp_stable_migration.py` (8): flat-list normalize (+ no-match/passthrough), `timeseries`→`from/to`, per-symbol fetching (no comma), and `etf/holdings` stable-first + v3 fallback.
- **Note:** theme-detector is a CI `KNOWN_SKIP` with 27 pre-existing test failures (e.g. a `KeyError` in some `test_etf_scanner` FMP-fallback tests). Those are **unchanged** — my changes add **zero** new failures (verified against the clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
