### PR TITLE
Improve trade-hypothesis-ideator skill (score 68 -> 100)

### DIFF
--- a/skills/trade-hypothesis-ideator/SKILL.md
+++ b/skills/trade-hypothesis-ideator/SKILL.md
@@ -11,6 +11,19 @@ description: >
 
 Generate 1-5 structured hypothesis cards from a normalized input bundle, critique and rank them, then optionally export `pursue` cards into `strategy.yaml` + `metadata.json` artifacts.
 
+## When to Use
+
+- After gathering trade logs, journal entries, or market observations that suggest a potential edge
+- When you have a structured input bundle (JSON) with evidence snippets and want falsifiable hypotheses
+- To bridge qualitative observations into quantitative experiment designs
+- Before committing capital to validate a new strategy idea with kill criteria
+
+## Prerequisites
+
+- Input JSON bundle with one or more of: `trade_log`, `journal_snippets`, `market_data`, `observations`
+- Python 3.9+ with `pyyaml` installed
+- No external API keys required (pure calculation skill)
+
 ## Workflow
 
 1. Receive input JSON bundle.
@@ -42,7 +55,14 @@ python3 skills/trade-hypothesis-ideator/scripts/run_hypothesis_ideator.py \
   --export-strategies
 ```
 
-## References
+## Output
 
-- `references/hypothesis_types.md`
-- `references/evidence_quality_guide.md`
+- `hypothesis_cards_<date>.json` — Ranked hypothesis cards with verdicts (`pursue`, `revise`, `discard`)
+- `hypothesis_cards_<date>.md` — Human-readable summary with experiment designs and kill criteria
+- `strategy_<hypothesis_id>.yaml` — (Optional) Edge-finder-compatible strategy export for `pursue` cards
+- `metadata_<hypothesis_id>.json` — (Optional) Provenance metadata for exported strategies
+
+## Resources
+
+- `references/hypothesis_types.md` — Taxonomy of hypothesis patterns (mean-reversion, momentum, event-driven, etc.)
+- `references/evidence_quality_guide.md` — Criteria for rating evidence strength and sample size requirements


### PR DESCRIPTION
## Summary
- Skill: `trade-hypothesis-ideator`
- Score: 68 -> 100

## Improvements
- Missing section: `## When to Use`. -> Add `## When to Use` to improve operator guidance.
- Missing section: `## Prerequisites`. -> Add `## Prerequisites` to improve operator guidance.
- Missing section: `## Output`. -> Add `## Output` to improve operator guidance.
- Missing section: `## Resources`. -> Add `## Resources` to improve operator guidance.

Generated by skill self-improvement loop.