### PR TITLE
fix(exposure-coach): read real nested upstream shapes for breadth/top-risk/FTD

### DIFF
--- a/skills/exposure-coach/SKILL.md
+++ b/skills/exposure-coach/SKILL.md
@@ -36,7 +36,7 @@ Collect the most recent JSON outputs from integrated skills. Each file provides 
 | uptrend-analyzer | `uptrend_*.json` | Uptrend participation percentage |
 | macro-regime-detector | `regime_*.json` | Current regime (Concentration, Broadening, etc.) |
 | market-top-detector | `top_risk_*.json` | Distribution day count, top probability score |
-| ftd-detector | `ftd_*.json` | Failure-to-deliver anomalies |
+| ftd-detector | `ftd_*.json` | Follow-Through Day quality (market bottom confirmation) |
 | theme-detector | `theme_*.json` | Active investment themes and rotation |
 | sector-analyst | `sector_*.json` | Sector performance rankings |
 | institutional-flow-tracker | `institutional_*.json` | Net institutional buying/selling |

--- a/skills/exposure-coach/scripts/calculate_exposure.py
+++ b/skills/exposure-coach/scripts/calculate_exposure.py
@@ -59,6 +59,11 @@ def extract_breadth_score(data: Optional[dict]) -> Optional[int]:
         return int(data["breadth_score"])
     if "composite_score" in data:
         return int(data["composite_score"])
+    # market-breadth-analyzer nests its 0-100 health score under "composite"
+    # (100 = healthy). High = bullish, so used directly (no inversion).
+    composite = data.get("composite")
+    if isinstance(composite, dict) and "composite_score" in composite:
+        return int(composite["composite_score"])
     if "ad_ratio" in data and "nh_nl_ratio" in data:
         ad = data["ad_ratio"]
         nh_nl = data["nh_nl_ratio"]
@@ -158,6 +163,12 @@ def extract_top_risk_score(data: Optional[dict]) -> Optional[int]:
         return None
     if "top_risk_score" in data:
         return int(data["top_risk_score"])
+    # market-top-detector nests its 0-100 score under "composite", where HIGH =
+    # higher top risk (>80 = Critical/Top Formation). Invert to the
+    # exposure-friendly convention (high = safe to be exposed).
+    composite = data.get("composite")
+    if isinstance(composite, dict) and "composite_score" in composite:
+        return max(0, min(100, int(100 - composite["composite_score"])))
     if "top_probability" in data:
         prob = data["top_probability"]
         # Invert: high probability = low score
@@ -176,11 +187,20 @@ def extract_top_risk_score(data: Optional[dict]) -> Optional[int]:
 
 
 def extract_ftd_score(data: Optional[dict]) -> Optional[int]:
-    """Extract FTD score (inverted - high FTD = low score)."""
+    """Extract Follow-Through-Day score (high = strong FTD = bullish bottom).
+
+    ftd-detector emits a 0-100 FTD quality score under ``quality_score``
+    (``total_score``); a confirmed Follow-Through Day is a bullish
+    bottom-confirmation signal, so the score is used directly (no inversion).
+    """
     if data is None:
         return None
     if "ftd_score" in data:
         return int(data["ftd_score"])
+    # ftd-detector real shape: {"quality_score": {"total_score": 0-100, ...}}
+    quality = data.get("quality_score")
+    if isinstance(quality, dict) and quality.get("total_score") is not None:
+        return max(0, min(100, int(quality["total_score"])))
     if "anomaly_level" in data:
         level = data["anomaly_level"].lower()
         mapping = {"none": 90, "low": 80, "moderate": 55, "elevated": 35, "critical": 15}

--- a/skills/exposure-coach/scripts/tests/test_calculate_exposure.py
+++ b/skills/exposure-coach/scripts/tests/test_calculate_exposure.py
@@ -12,6 +12,7 @@ from calculate_exposure import (
     determine_participation,
     determine_recommendation,
     extract_breadth_score,
+    extract_ftd_score,
     extract_regime_name,
     extract_regime_score,
     extract_top_risk_score,
@@ -44,6 +45,19 @@ class TestExtractBreadthScore:
     def test_ad_ratio_calculation_low(self):
         data = {"ad_ratio": 0.5, "nh_nl_ratio": 0.3}
         assert extract_breadth_score(data) == 20
+
+    def test_nested_composite_score(self):
+        # market-breadth-analyzer nests its 0-100 health score under "composite"
+        data = {"composite": {"composite_score": 72}}
+        assert extract_breadth_score(data) == 72
+
+    def test_flat_takes_priority_over_nested(self):
+        data = {"breadth_score": 65, "composite": {"composite_score": 10}}
+        assert extract_breadth_score(data) == 65
+
+    def test_non_dict_composite_ignored(self):
+        data = {"composite": "n/a", "ad_ratio": 2.0, "nh_nl_ratio": 4.0}
+        assert extract_breadth_score(data) == 90
 
     def test_none_input(self):
         assert extract_breadth_score(None) is None
@@ -195,6 +209,80 @@ class TestExtractTopRiskScore:
     def test_distribution_days_many(self):
         data = {"distribution_days": 8}
         assert extract_top_risk_score(data) == 15
+
+    def test_nested_composite_inverted_high_risk(self):
+        # market-top-detector composite=85 (Critical/Top Formation) -> low score
+        data = {"composite": {"composite_score": 85}}
+        assert extract_top_risk_score(data) == 15
+
+    def test_nested_composite_inverted_low_risk(self):
+        # composite=15 (Green/Normal) -> high (safe) score
+        data = {"composite": {"composite_score": 15}}
+        assert extract_top_risk_score(data) == 85
+
+    def test_flat_takes_priority_over_nested(self):
+        # explicit top_risk_score is already exposure-friendly; not inverted
+        data = {"top_risk_score": 40, "composite": {"composite_score": 85}}
+        assert extract_top_risk_score(data) == 40
+
+
+class TestExtractFtdScore:
+    """Tests for Follow-Through-Day score extraction (high = bullish, NOT inverted)."""
+
+    def test_direct_ftd_score(self):
+        assert extract_ftd_score({"ftd_score": 70}) == 70
+
+    def test_nested_quality_score_strong(self):
+        # ftd-detector real shape: strong FTD -> high score (bullish, direct)
+        data = {"quality_score": {"total_score": 82, "signal": "Strong FTD"}}
+        assert extract_ftd_score(data) == 82
+
+    def test_nested_quality_score_no_ftd(self):
+        data = {"quality_score": {"total_score": 0, "signal": "No FTD"}}
+        assert extract_ftd_score(data) == 0
+
+    def test_legacy_anomaly_level_still_supported(self):
+        assert extract_ftd_score({"anomaly_level": "none"}) == 90
+
+    def test_none_and_empty(self):
+        assert extract_ftd_score(None) is None
+        assert extract_ftd_score({}) is None
+
+
+class TestRealUpstreamShapesAllCount:
+    """Regression: the real upstream JSON shapes must all produce a score.
+
+    Reproduces the reported bug where breadth/top_risk/ftd silently returned
+    None (only regime + uptrend counted), forcing a missing-critical haircut
+    and a CASH_PRIORITY / LOW-confidence verdict.
+    """
+
+    def test_all_five_inputs_extracted(self):
+        breadth = {"composite": {"composite_score": 70}}  # market-breadth-analyzer
+        uptrend = {"composite": {"composite_score": 65}}  # uptrend-analyzer
+        regime = {"regime": {"current_regime": "broadening"}}  # macro-regime-detector
+        top_risk = {"composite": {"composite_score": 20}}  # market-top-detector (low risk)
+        ftd = {"quality_score": {"total_score": 75}}  # ftd-detector (strong FTD)
+
+        scores = {
+            "breadth": extract_breadth_score(breadth),
+            "uptrend": extract_uptrend_score(uptrend),
+            "regime": extract_regime_score(regime),
+            "top_risk": extract_top_risk_score(top_risk),
+            "ftd": extract_ftd_score(ftd),
+        }
+        # The bug: breadth/top_risk/ftd were None. All five must now resolve.
+        assert all(v is not None for v in scores.values()), scores
+        assert scores["breadth"] == 70
+        assert scores["top_risk"] == 80  # inverted: 100 - 20
+        assert scores["ftd"] == 75  # direct
+
+        composite, provided, missing = calculate_composite_score(
+            {**scores, "institutional": None, "sector": None, "theme": None}
+        )
+        # No critical input missing -> no haircut; healthy composite, not cash-priority
+        assert set(missing).isdisjoint(CRITICAL_INPUTS)
+        assert composite > 50
 
 
 class TestCalculateCompositeScore:


### PR DESCRIPTION
## Problem

`exposure-coach` synthesizes 8 upstream skills into one exposure verdict, but its **headline recommendation silently under-counts inputs** — it reads as LOW confidence / `CASH_PRIORITY` even when the market is fine. The component scores still *display*, so the bug is easy to miss.

**Root cause:** three extractors only match a flat schema the upstream skills never emit, so they return `None` and get dropped:

| Extractor | Looked for (flat) | Skill actually emits |
|---|---|---|
| `extract_breadth_score` | `breadth_score` / top-level `composite_score` | `{"composite": {"composite_score": …}}` |
| `extract_top_risk_score` | `top_risk_score` / `top_probability` / `distribution_days` | `{"composite": {"composite_score": …}}` |
| `extract_ftd_score` | `ftd_score` / `anomaly_level` | `{"quality_score": {"total_score": …}}` |

`extract_uptrend_score` / `extract_regime_score` were already fixed to read the nested shapes; these three were never updated. Since `top_risk` + `breadth` are 2 of 3 `CRITICAL_INPUTS`, their absence triggers the missing-critical **haircut** → LOW confidence / `CASH_PRIORITY` built from just `regime` + `uptrend`.

## Fix — with correct polarity (verified against each skill's source + live runs)

- **breadth** (`market-breadth-analyzer`): `composite.composite_score`, high = healthy → **used directly**.
- **top-risk** (`market-top-detector`): `composite.composite_score`, where **high = more top risk** (`>80` = Critical/Top Formation) → **inverted (`100 − score`)** to the exposure-friendly convention.
- **FTD** (`ftd-detector`): `quality_score.total_score`, where **high = strong Follow-Through Day = bullish bottom** → **used directly, NOT inverted**. (The SKILL.md input table mislabeled this skill as "Failure-to-deliver anomalies"; corrected to "Follow-Through Day quality".)

Flat/legacy shapes still take priority and are preserved for back-compat.

## Validation (live, real reports)

Fed real `market-breadth-analyzer` (composite **32.4**), `market-top-detector` (**40.8**, Orange/Elevated) and `ftd-detector` (**100**, Strong FTD) outputs into the CLI:

```
inputs_provided : ['top_risk', 'breadth', 'ftd']      # were all silently missing before
component_scores: {breadth: 32, top_risk: 59, ftd: 100}   # top_risk inverted 100-40.8≈59
confidence: MEDIUM                                     # was LOW / CASH_PRIORITY
```

Added regression tests: nested-shape extraction for all three, the top-risk inversion vs FTD non-inversion polarity, and a "real upstream shapes all count" test that reproduces the bug. **86 tests pass**; `ruff` + all pre-commit hooks clean. Contained to `skills/exposure-coach/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)