### PR TITLE
docs(examples): add full-path workflow samples (PR #137 verification)

### DIFF
--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -15,16 +15,23 @@ future fixture/replay harness can consume.
 
 ## Available examples
 
-| Example | Workflow | Cadence | Skills (required) |
-|---|---|---|---|
-| [`market-regime-daily/`](market-regime-daily/) | [`market-regime-daily.yaml`](../../workflows/market-regime-daily.yaml) | daily | market-breadth-analyzer → uptrend-analyzer → exposure-coach |
-| [`trade-memory-loop/`](trade-memory-loop/) | [`trade-memory-loop.yaml`](../../workflows/trade-memory-loop.yaml) | per closed trade | trader-memory-core → signal-postmortem → trader-memory-core |
+| Example | Workflow | Cadence | Sample variant | Skills |
+|---|---|---|---|---|
+| [`market-regime-daily/sample-run/`](market-regime-daily/sample-run/) | [`market-regime-daily.yaml`](../../workflows/market-regime-daily.yaml) | daily | required-only | market-breadth-analyzer → uptrend-analyzer → exposure-coach |
+| [`market-regime-daily/sample-run-full-path/`](market-regime-daily/sample-run-full-path/) | same | daily | **full-path** | + optional market-top-detector at step 3 |
+| [`trade-memory-loop/sample-run/`](trade-memory-loop/sample-run/) | [`trade-memory-loop.yaml`](../../workflows/trade-memory-loop.yaml) | per closed trade | required-only | trader-memory-core → signal-postmortem → trader-memory-core |
+| [`trade-memory-loop/sample-run-full-path/`](trade-memory-loop/sample-run-full-path/) | same | per closed trade | **full-path** | + optional backtest-expert at step 3 |
 
-Each example is **required-only**: it exercises just the required steps. The
-one optional step in each workflow is intentionally skipped and documented in
-that example's `README.md` and `manifest.yaml` (`optional_steps_skipped`). A
-full-path sample (including optional steps) may be added later in a separate
-change.
+Each workflow ships two sample variants:
+
+- **`sample-run/` (required-only)** — exercises just the required steps. The
+  one optional step in each workflow is intentionally skipped and documented
+  in that example's `manifest.yaml` (`optional_steps_skipped`).
+- **`sample-run-full-path/` (full-path)** — runs the optional step too, so
+  every step in the workflow manifest is exercised. For `market-regime-daily`
+  this also strips the top-level `*_score` workflow hand-off fields from the
+  upstream fixtures so the sample exercises the **nested-shape parser** in
+  `exposure-coach` directly (see the "Artifact convention" note below).
 
 ## Artifact convention: `raw-plus-handoff`
 
@@ -38,16 +45,21 @@ copies of raw skill stdout:
   alongside it. This is the field the Claude-orchestrated next step actually
   consumes when it hands a score to `exposure-coach`.
 
-This convention is deliberate and also **documents a real, known
-`exposure-coach` parser asymmetry**: `extract_uptrend_score()` already reads
-the nested `composite` shape, but `extract_breadth_score()` reads **only** the
-top-level field — so raw breadth output (nested only) is silently dropped by
-`exposure-coach` today. That parser gap is **not fixed here** (this is a
-docs/sample-only change); it is tracked as a separate code issue and linked
-from the pull request that introduced these examples. The sample is authored
-so that running the **real** `exposure-coach` extractors over these files
-reproduces exactly the scores shown in `04_exposure_decision.json` (see each
-example's verification notes).
+This convention exists in `sample-run/` because the original parser in
+`exposure-coach` only read the top-level `*_score` hand-off fields for
+breadth and top-risk — the nested `composite.composite_score` shape that the
+real upstream skills actually emit was silently dropped. That parser gap was
+**fixed by [PR #137](https://github.com/tradermonty/claude-trading-skills/pull/137)**
+(merged 2026-05-24), which added nested-shape reading and correct polarity
+for `breadth` (direct), `top_risk` (inverted as `100 - score`), and `ftd`
+(direct, since a Follow-Through Day is bullish bottom-confirmation).
+
+The new **`sample-run-full-path/`** variant therefore omits the top-level
+hand-off fields and provides raw nested fixtures so that running the
+post-PR-#137 `exposure-coach` extractors over them reproduces the scores in
+`04_exposure_decision.json`. The required-only `sample-run/` is kept
+unchanged (raw-plus-handoff convention preserved) as a reference for
+workflows that already produce both shapes.
 
 ## Coupling
 

--- a/examples/workflows/market-regime-daily/README.md
+++ b/examples/workflows/market-regime-daily/README.md
@@ -1,87 +1,116 @@
-# Example: `market-regime-daily` (required-only)
+# Example: `market-regime-daily`
 
 A canonical sample run of the
 [`market-regime-daily`](../../../workflows/market-regime-daily.yaml) workflow:
 a daily, no-API market-posture check that decides whether new swing-trade risk
 is allowed before the session.
 
-> ⚠️ **Illustrative only — not investment advice.** This sample uses a
-> **fictional market snapshot** for a fixed date (`2026-01-15`) with **no
+> ⚠️ **Illustrative only — not investment advice.** Both sample variants use
+> a **fictional market snapshot** for a fixed date (`2026-01-15`) with **no
 > individual tickers**. The numbers are hand-authored to be internally
 > consistent and code-faithful, **not** captured from a live run.
 
+## Two sample variants
+
+This example ships two parallel samples that share the same date and inputs:
+
+| Variant | Optional step | Posture outcome | Confidence | Purpose |
+|---|---|---|---|---|
+| [`sample-run/`](sample-run/) (**required-only**) | skipped | REDUCE_ONLY (48% ceiling) | LOW | Shows the conservative floor when critical inputs are missing |
+| [`sample-run-full-path/`](sample-run-full-path/) (**full-path**) | included | NEW_ENTRY_ALLOWED (58% ceiling) | MEDIUM | Shows what the optional `market-top-detector` adds, and exercises the nested-shape parser fixed in PR #137 |
+
 ## Steps in this sample
 
-| Step | Skill | Artifact | In this sample |
-|---|---|---|---|
-| 1 | `market-breadth-analyzer` | `market_breadth_report` | ✅ included |
-| 2 | `uptrend-analyzer` | `uptrend_report` | ✅ included |
-| 3 | `market-top-detector` | `top_risk_report` | ⏭️ **skipped** (optional) |
-| 4 | `exposure-coach` | `exposure_decision` | ✅ included |
-
-Step 3 is the workflow's one optional step. This is the **required-only**
-canonical sample, so it is intentionally skipped (recorded in
-[`sample-run/manifest.yaml`](sample-run/manifest.yaml) under
-`optional_steps_skipped`). A full-path sample including the optional satellites
-may be added later in a separate change.
+| Step | Skill | Artifact | `sample-run/` | `sample-run-full-path/` |
+|---|---|---|---|---|
+| 1 | `market-breadth-analyzer` | `market_breadth_report` | ✅ included | ✅ included (nested-only) |
+| 2 | `uptrend-analyzer` | `uptrend_report` | ✅ included | ✅ included (nested-only) |
+| 3 | `market-top-detector` | `top_risk_report` | ⏭️ skipped (optional) | ✅ included (nested-only) |
+| 4 | `exposure-coach` | `exposure_decision` | ✅ included | ✅ included |
 
 ## Files
 
 ```
-sample-run/
-  prompt.md                       # the prompt you give Claude
-  manifest.yaml                   # machine-readable step → artifact → file map
-  01_market_breadth_report.json   # step 1 canonical (raw composite{} + breadth_score)
-  01_market_breadth_report.md     # step 1 companion (human report)
-  02_uptrend_report.json          # step 2 canonical (raw composite{} + uptrend_score)
-  02_uptrend_report.md            # step 2 companion
-  04_exposure_decision.json       # step 4 canonical (exposure-coach output)
-  04_exposure_decision.md         # step 4 companion (one-page posture)
+sample-run/                        # required-only (raw-plus-handoff)
+  prompt.md                        # the prompt you give Claude
+  manifest.yaml                    # machine-readable step → artifact → file map
+  01_market_breadth_report.json    # raw composite{} + top-level breadth_score
+  01_market_breadth_report.md      # companion (human report)
+  02_uptrend_report.json           # raw composite{} + top-level uptrend_score
+  02_uptrend_report.md             # companion
+  04_exposure_decision.json        # exposure-coach output
+  04_exposure_decision.md          # companion (one-page posture)
+
+sample-run-full-path/              # full-path (raw-nested-only)
+  prompt.md                        # full-path prompt
+  manifest.yaml                    # step → artifact → file map, no skipped steps
+  01_market_breadth_report_raw.json # raw composite{}, no top-level handoff
+  02_uptrend_report_raw.json        # raw composite{}, no top-level handoff
+  03_top_risk_report_raw.json       # raw composite{} from market-top-detector
+  04_exposure_decision.json         # exposure-coach output (computed from the 3 raw fixtures)
+  04_exposure_decision.md           # companion
 ```
 
-## The `raw-plus-handoff` artifact convention
+## The `raw-plus-handoff` convention (sample-run/) — historical note
 
-`01`/`02` JSON each carry **both**:
+`sample-run/` JSON each carry **both** the nested `composite { composite_score, … }`
+block **and** a top-level hand-off field (`breadth_score` / `uptrend_score`).
+The top-level field originally existed because `exposure-coach`'s
+`extract_breadth_score()` only read the top-level field — the nested shape was
+silently dropped, making *raw* breadth output a missing critical input.
 
-- the real nested `composite { composite_score, zone, … }` block — exactly the
-  structure `market-breadth-analyzer` / `uptrend-analyzer` emit; and
-- a **top-level hand-off field** (`breadth_score` / `uptrend_score`) equal to
-  `composite.composite_score`.
+That parser gap was **fixed by
+[PR #137](https://github.com/tradermonty/claude-trading-skills/pull/137)**
+(merged 2026-05-24). After PR #137, the extractor reads both shapes; the
+top-level hand-off field in `sample-run/` is now a convenience rather than a
+necessity. `sample-run-full-path/` deliberately omits it to exercise the
+nested-only path directly.
 
-The top-level field exists because of a **real, known `exposure-coach` parser
-asymmetry**:
-
-- `extract_uptrend_score()` already reads the nested `composite` shape, so raw
-  uptrend output is consumable as-is.
-- `extract_breadth_score()` reads **only** the top-level field — it has **no**
-  nested-`composite` fallback — so *raw* breadth output (nested only) is
-  silently dropped, becoming a missing **critical** input.
-
-This sample documents that gap rather than hiding it. It is **not fixed here**
-(this is a docs/sample-only change); the parser fix is tracked as a separate
-code issue, linked from the pull request that introduced this example. The
-sample is authored so the **real** extractors reproduce the exact scores in
-`04_exposure_decision.json` (`breadth_score == 66`, `uptrend_score == 72`).
-
-## Why the posture is `REDUCE_ONLY / LOW` (this is correct)
+## Why the required-only posture is `REDUCE_ONLY / LOW` (this is correct)
 
 `exposure-coach` treats `regime`, `top_risk`, and `breadth` as **critical
 inputs** and applies a **−10 composite haircut per missing critical input**.
-In the required-only path, both `regime` (`macro-regime-detector`) and
-`top_risk` (`market-top-detector`) are absent → a −20 haircut. With breadth 66
-and uptrend 72 the pre-haircut composite is `(66+72)/2 = 69.0`, haircut to
-`49.0`, which maps to a **48% exposure ceiling, REDUCE_ONLY recommendation,
+In `sample-run/`, both `regime` (`macro-regime-detector`) and `top_risk`
+(`market-top-detector`) are absent → a −20 haircut. With breadth 66 and
+uptrend 72 the pre-haircut composite is `(66·0.15 + 72·0.15) / 0.30 = 69.0`,
+haircut to **49.0**, mapped to a **48% exposure ceiling, REDUCE_ONLY,
 LOW confidence** — even though internal participation is `BROAD`.
 
-This is the **honest, code-faithful** output of the required-only path, and it
-is exactly *why the optional satellites exist*: adding `macro-regime-detector`
-and `market-top-detector` clears the critical-input haircut and lets the
-posture rise toward `NEW_ENTRY_ALLOWED` when internals support it. The
-required-only sample deliberately shows the conservative floor.
+## Why the full-path posture is `NEW_ENTRY_ALLOWED / MEDIUM`
+
+`sample-run-full-path/` adds step 3 (`market-top-detector` with
+`composite.composite_score = 38`, a "Yellow / Early Warning" zone). The
+extractor inverts that to `100 − 38 = 62` (high score = safe to be exposed)
+and clears one of the two critical-input haircuts. The composite climbs to
+**56.2** (58% ceiling, **NEW_ENTRY_ALLOWED, MEDIUM** confidence). This is the
+honest, code-faithful demonstration of what running the optional satellite
+adds — and it only works correctly *because* PR #137 fixed the nested-shape
+parser for `top_risk`.
 
 ## Reproduce / verify
 
-From the repo root (read-only; writes only to a temp dir):
+From the repo root, full-path sample (post-PR #137):
+
+```bash
+python3 skills/exposure-coach/scripts/calculate_exposure.py \
+  --breadth  examples/workflows/market-regime-daily/sample-run-full-path/01_market_breadth_report_raw.json \
+  --uptrend  examples/workflows/market-regime-daily/sample-run-full-path/02_uptrend_report_raw.json \
+  --top-risk examples/workflows/market-regime-daily/sample-run-full-path/03_top_risk_report_raw.json \
+  --output-dir /tmp/verify_full_path/
+
+# Then check the deterministic key fields:
+python3 - <<'PY'
+import glob, json
+actual = json.load(open(sorted(glob.glob("/tmp/verify_full_path/exposure_posture_*.json"))[-1]))
+expected = json.load(open("examples/workflows/market-regime-daily/sample-run-full-path/04_exposure_decision.json"))
+for key in ("composite_score", "exposure_ceiling_pct", "recommendation", "confidence", "bias", "participation", "component_scores", "inputs_provided", "inputs_missing"):
+    assert actual[key] == expected[key], f"{key}: {actual[key]!r} != {expected[key]!r}"
+print("OK: full-path sample reproduced deterministically from raw nested fixtures")
+PY
+```
+
+Required-only sample verification (read-only check that the extractors agree
+with the fixture):
 
 ```bash
 python3 - <<'PY'
@@ -94,11 +123,13 @@ u = json.load(open(f"{d}/02_uptrend_report.json"))
 dec = json.load(open(f"{d}/04_exposure_decision.json"))
 assert ce.extract_breadth_score(b) == dec["component_scores"]["breadth_score"] == 66
 assert ce.extract_uptrend_score(u) == dec["component_scores"]["uptrend_score"] == 72
-print("OK: real exposure-coach extractors reproduce the sample scores")
+print("OK: real exposure-coach extractors reproduce the required-only sample scores")
 PY
 ```
 
 ## Run it for real
 
-See [`sample-run/prompt.md`](sample-run/prompt.md). The skills fetch public
-CSVs (no API key); your live numbers will differ from this fixed sample.
+See [`sample-run/prompt.md`](sample-run/prompt.md) or
+[`sample-run-full-path/prompt.md`](sample-run-full-path/prompt.md). The
+skills fetch public CSVs (no API key) plus optional FMP data for the
+top-risk step; your live numbers will differ from these fixed samples.

--- a/examples/workflows/market-regime-daily/sample-run-full-path/01_market_breadth_report_raw.json
+++ b/examples/workflows/market-regime-daily/sample-run-full-path/01_market_breadth_report_raw.json
@@ -1,0 +1,157 @@
+{
+  "metadata": {
+    "generated_at": "2026-01-15 07:05:00",
+    "data_source": "TraderMonty Market Breadth CSV (public, no API key)",
+    "detail_url": "https://tradermonty.github.io/market-breadth-analysis/",
+    "summary_url": "https://tradermonty.github.io/market-breadth-analysis/",
+    "total_rows": 2480,
+    "data_freshness": {
+      "latest_date": "2026-01-14",
+      "days_old": 1,
+      "warning": null,
+      "last_modified": null
+    }
+  },
+  "composite": {
+    "composite_score": 66,
+    "zone": "Healthy",
+    "zone_color": "blue",
+    "exposure_guidance": "75-90%",
+    "guidance": "Normal operations. Broad participation, but watch the S&P 500 vs breadth divergence.",
+    "actions": [
+      "Maintain core exposure",
+      "Monitor divergence component"
+    ],
+    "strongest_health": {
+      "component": "bearish_signal",
+      "label": "Bearish Signal Status",
+      "score": 80
+    },
+    "weakest_health": {
+      "component": "divergence",
+      "label": "S&P 500 vs Breadth Divergence",
+      "score": 50
+    },
+    "excluded_components": [],
+    "data_quality": {
+      "available_count": 6,
+      "total_components": 6,
+      "label": "Complete (6/6 components)",
+      "missing_components": []
+    },
+    "component_scores": {
+      "breadth_level_trend": {
+        "score": 72,
+        "weight": 0.25,
+        "effective_weight": 0.25,
+        "weighted_contribution": 18.0,
+        "data_available": true,
+        "label": "Current Breadth Level & Trend"
+      },
+      "ma_crossover": {
+        "score": 68,
+        "weight": 0.2,
+        "effective_weight": 0.2,
+        "weighted_contribution": 13.6,
+        "data_available": true,
+        "label": "8MA vs 200MA Crossover"
+      },
+      "cycle_position": {
+        "score": 60,
+        "weight": 0.2,
+        "effective_weight": 0.2,
+        "weighted_contribution": 12.0,
+        "data_available": true,
+        "label": "Peak/Trough Cycle Position"
+      },
+      "bearish_signal": {
+        "score": 80,
+        "weight": 0.15,
+        "effective_weight": 0.15,
+        "weighted_contribution": 12.0,
+        "data_available": true,
+        "label": "Bearish Signal Status"
+      },
+      "historical_percentile": {
+        "score": 55,
+        "weight": 0.1,
+        "effective_weight": 0.1,
+        "weighted_contribution": 5.5,
+        "data_available": true,
+        "label": "Historical Percentile"
+      },
+      "divergence": {
+        "score": 50,
+        "weight": 0.1,
+        "effective_weight": 0.1,
+        "weighted_contribution": 5.0,
+        "data_available": true,
+        "label": "S&P 500 vs Breadth Divergence"
+      }
+    }
+  },
+  "components": {
+    "breadth_level_trend": {
+      "score": 72,
+      "signal": "HEALTHY: 8MA above 200MA, rising",
+      "data_available": true,
+      "current_8ma": 0.61,
+      "current_200ma": 0.54,
+      "trend": 1,
+      "level_score": 70,
+      "trend_score": 74,
+      "ma8_direction": "rising",
+      "direction_modifier": 0
+    },
+    "ma_crossover": {
+      "score": 68,
+      "signal": "POSITIVE: 8MA > 200MA",
+      "data_available": true,
+      "gap": 0.07,
+      "gap_score": 72,
+      "ma8_direction": "rising",
+      "direction_modifier": 0
+    },
+    "cycle_position": {
+      "score": 60,
+      "signal": "NEUTRAL: mid-cycle",
+      "data_available": true,
+      "latest_marker_type": "trough",
+      "days_since_marker": 34,
+      "ma8_trend": "rising",
+      "extreme_trough": false
+    },
+    "bearish_signal": {
+      "score": 80,
+      "signal": "CLEAR: no active bearish signal",
+      "data_available": true,
+      "signal_active": false,
+      "trend": 1,
+      "current_8ma": 0.61,
+      "in_pink_zone": false,
+      "pink_zone_days": 0,
+      "base_score": 90,
+      "context_adjustment": -10,
+      "pink_zone_adjustment": 0
+    },
+    "historical_percentile": {
+      "score": 55,
+      "signal": "NORMAL: 55th percentile",
+      "data_available": true,
+      "current_8ma": 0.61,
+      "percentile_rank": 55.0,
+      "avg_peak": 0.68,
+      "avg_trough": 0.34,
+      "adjustment": 0
+    },
+    "divergence": {
+      "score": 50,
+      "signal": "MILD: price slightly ahead of breadth",
+      "data_available": true,
+      "sp500_pct_change": 3.1,
+      "breadth_change": 0.012,
+      "divergence_type": "mild_bearish",
+      "early_warning": false
+    }
+  }
+}

--- a/examples/workflows/market-regime-daily/sample-run-full-path/02_uptrend_report_raw.json
+++ b/examples/workflows/market-regime-daily/sample-run-full-path/02_uptrend_report_raw.json
@@ -1,0 +1,265 @@
+{
+  "metadata": {
+    "generated_at": "2026-01-15 07:06:00",
+    "data_source": "Monty's Uptrend Ratio Dashboard CSV (public, no API key)",
+    "api_key_required": false,
+    "latest_data_date": "2026-01-14",
+    "timeseries_rows": 2390,
+    "sectors_available": 11
+  },
+  "composite": {
+    "composite_score": 72,
+    "composite_score_raw": 75,
+    "zone": "Bull",
+    "zone_detail": "Bull-Upper",
+    "zone_color": "light_green",
+    "zone_proximity": {
+      "at_boundary": false
+    },
+    "exposure_guidance": "Normal Exposure (80-100%)",
+    "warning_penalty": -3,
+    "active_warnings": [
+      {
+        "label": "Momentum Cooling",
+        "description": "Ratio still rising but slope is flattening.",
+        "actions": [
+          "Watch momentum component",
+          "Tighten trailing stops"
+        ]
+      }
+    ],
+    "strongest_component": {
+      "label": "Market Breadth",
+      "score": 85
+    },
+    "weakest_component": {
+      "label": "Sector Rotation",
+      "score": 66
+    },
+    "data_quality": {
+      "label": "Good"
+    },
+    "guidance": "Breadth participation is healthy; momentum is cooling but not negative.",
+    "actions": [
+      "Maintain positions",
+      "Watch momentum"
+    ],
+    "component_scores": {
+      "market_breadth": {
+        "label": "Market Breadth",
+        "score": 85,
+        "weight": 0.3,
+        "weighted_contribution": 25.5
+      },
+      "sector_participation": {
+        "label": "Sector Participation",
+        "score": 74,
+        "weight": 0.25,
+        "weighted_contribution": 18.5
+      },
+      "sector_rotation": {
+        "label": "Sector Rotation",
+        "score": 66,
+        "weight": 0.15,
+        "weighted_contribution": 9.9
+      },
+      "momentum": {
+        "label": "Momentum",
+        "score": 68,
+        "weight": 0.2,
+        "weighted_contribution": 13.6
+      },
+      "historical_context": {
+        "label": "Historical Context",
+        "score": 72,
+        "weight": 0.1,
+        "weighted_contribution": 7.2
+      }
+    }
+  },
+  "components": {
+    "market_breadth": {
+      "data_available": true,
+      "ratio_pct": 58.0,
+      "ma_10_pct": 55.5,
+      "trend": "Up",
+      "slope": 0.0014,
+      "trend_adjustment": 2,
+      "distance_from_upper": 0.21,
+      "distance_from_lower": 0.48,
+      "date": "2026-01-14",
+      "signal": "HEALTHY: 58% of stocks in an uptrend, above the 10-day MA"
+    },
+    "sector_participation": {
+      "data_available": true,
+      "uptrend_count": 8,
+      "total_sectors": 11,
+      "count_score": 73,
+      "spread_pct": 24.0,
+      "spread_score": 75,
+      "overbought_count": 1,
+      "overbought_sectors": [
+        "Technology"
+      ],
+      "oversold_count": 0,
+      "oversold_sectors": [],
+      "signal": "BROAD: 8 of 11 sectors participating",
+      "sector_details": [
+        {
+          "sector": "Technology",
+          "ratio_pct": 41.0,
+          "count": 58,
+          "total": 70,
+          "ma_10": 0.39,
+          "trend": "Up",
+          "slope": 0.0021,
+          "status": "Overbought"
+        },
+        {
+          "sector": "Industrials",
+          "ratio_pct": 33.0,
+          "count": 22,
+          "total": 34,
+          "ma_10": 0.31,
+          "trend": "Up",
+          "slope": 0.0015,
+          "status": "Normal"
+        },
+        {
+          "sector": "Financials",
+          "ratio_pct": 31.0,
+          "count": 20,
+          "total": 33,
+          "ma_10": 0.29,
+          "trend": "Up",
+          "slope": 0.0012,
+          "status": "Normal"
+        },
+        {
+          "sector": "Consumer Discretionary",
+          "ratio_pct": 30.0,
+          "count": 17,
+          "total": 30,
+          "ma_10": 0.28,
+          "trend": "Up",
+          "slope": 0.0011,
+          "status": "Normal"
+        },
+        {
+          "sector": "Communication Services",
+          "ratio_pct": 29.0,
+          "count": 7,
+          "total": 12,
+          "ma_10": 0.27,
+          "trend": "Up",
+          "slope": 0.001,
+          "status": "Normal"
+        },
+        {
+          "sector": "Materials",
+          "ratio_pct": 27.0,
+          "count": 8,
+          "total": 17,
+          "ma_10": 0.26,
+          "trend": "Up",
+          "slope": 0.0008,
+          "status": "Normal"
+        },
+        {
+          "sector": "Energy",
+          "ratio_pct": 26.0,
+          "count": 6,
+          "total": 12,
+          "ma_10": 0.25,
+          "trend": "Up",
+          "slope": 0.0007,
+          "status": "Normal"
+        },
+        {
+          "sector": "Health Care",
+          "ratio_pct": 24.0,
+          "count": 14,
+          "total": 30,
+          "ma_10": 0.24,
+          "trend": "Up",
+          "slope": 0.0005,
+          "status": "Normal"
+        },
+        {
+          "sector": "Consumer Staples",
+          "ratio_pct": 19.0,
+          "count": 6,
+          "total": 17,
+          "ma_10": 0.21,
+          "trend": "Down",
+          "slope": -0.0004,
+          "status": "Normal"
+        },
+        {
+          "sector": "Utilities",
+          "ratio_pct": 17.0,
+          "count": 5,
+          "total": 16,
+          "ma_10": 0.19,
+          "trend": "Down",
+          "slope": -0.0006,
+          "status": "Normal"
+        },
+        {
+          "sector": "Real Estate",
+          "ratio_pct": 16.0,
+          "count": 4,
+          "total": 15,
+          "ma_10": 0.18,
+          "trend": "Down",
+          "slope": -0.0007,
+          "status": "Normal"
+        }
+      ]
+    },
+    "sector_rotation": {
+      "data_available": true,
+      "cyclical_avg_pct": 61.0,
+      "defensive_avg_pct": 49.0,
+      "commodity_avg_pct": 52.0,
+      "difference_pct": 12.0,
+      "late_cycle_flag": false,
+      "divergence_flag": false,
+      "signal": "CONSTRUCTIVE: cyclicals leading defensives"
+    },
+    "momentum": {
+      "data_available": true,
+      "slope": 0.0009,
+      "slope_smoothing": "EMA(3)",
+      "slope_smoothed": 0.0008,
+      "slope_score": 64,
+      "acceleration_window": "10v10",
+      "acceleration": -0.0002,
+      "acceleration_label": "Cooling",
+      "acceleration_score": 55,
+      "sector_positive_slope_count": 7,
+      "sector_total": 11,
+      "sector_slope_breadth_score": 64,
+      "signal": "COOLING: still positive but slope flattening"
+    },
+    "historical_context": {
+      "data_available": true,
+      "current_ratio_pct": 58.0,
+      "percentile": 68,
+      "historical_min_pct": 4.0,
+      "historical_max_pct": 79.0,
+      "historical_median_pct": 47.0,
+      "avg_30d_pct": 55.0,
+      "avg_90d_pct": 51.0,
+      "data_points": 2390,
+      "date_range": "2016-2026",
+      "signal": "NORMAL: 68th percentile vs full history",
+      "confidence": {
+        "confidence_level": "Medium",
+        "sample_label": "n=2390",
+        "regime_coverage": "good",
+        "recency_label": "recent"
+      }
+    }
+  }
+}

--- a/examples/workflows/market-regime-daily/sample-run-full-path/03_top_risk_report_raw.json
+++ b/examples/workflows/market-regime-daily/sample-run-full-path/03_top_risk_report_raw.json
@@ -1,0 +1,82 @@
+{
+  "metadata": {
+    "generated_at": "2026-01-15 07:08:00",
+    "data_mode": "Illustrative — fictional market snapshot; not investment advice",
+    "data_source": "market-top-detector (architecture mirrored, raw nested shape)",
+    "cli_inputs": {
+      "breadth_200dma": 61.0,
+      "breadth_50dma": 64.5,
+      "put_call_ratio": 0.82,
+      "vix_term_structure": "contango",
+      "margin_debt_yoy_pct": 18.0
+    },
+    "index_data": {
+      "sp500_price": 6201.50,
+      "sp500_year_high": 6420.00,
+      "sp500_distance_from_high_pct": -3.4,
+      "qqq_price": 555.20,
+      "vix_level": 17.8
+    }
+  },
+  "composite": {
+    "composite_score": 38.0,
+    "zone": "Yellow (Early Warning)",
+    "zone_color": "yellow",
+    "risk_budget": "60-80%",
+    "guidance": "Early warning signals present; reduce gross exposure but no top yet.",
+    "actions": [
+      "Maintain core holdings",
+      "Tighten stops on speculative positions",
+      "Reduce new entries",
+      "Watch distribution-day cluster"
+    ],
+    "strongest_warning": {
+      "component": "distribution_days",
+      "label": "Distribution Day Count",
+      "score": 55
+    },
+    "weakest_warning": {
+      "component": "leading_stocks",
+      "label": "Leading Stock Health",
+      "score": 20
+    },
+    "component_scores": {
+      "distribution_days": {
+        "score": 55,
+        "weight": 0.25,
+        "weighted_contribution": 13.75,
+        "label": "Distribution Day Count"
+      },
+      "leading_stocks": {
+        "score": 20,
+        "weight": 0.20,
+        "weighted_contribution": 4.0,
+        "label": "Leading Stock Health"
+      },
+      "defensive_rotation": {
+        "score": 35,
+        "weight": 0.15,
+        "weighted_contribution": 5.25,
+        "label": "Defensive Sector Rotation"
+      },
+      "breadth_divergence": {
+        "score": 30,
+        "weight": 0.15,
+        "weighted_contribution": 4.5,
+        "label": "Market Breadth Divergence"
+      },
+      "index_technical": {
+        "score": 40,
+        "weight": 0.15,
+        "weighted_contribution": 6.0,
+        "label": "Index Technical Condition"
+      },
+      "sentiment": {
+        "score": 45,
+        "weight": 0.10,
+        "weighted_contribution": 4.5,
+        "label": "Sentiment & Positioning"
+      }
+    }
+  }
+}

--- a/examples/workflows/market-regime-daily/sample-run-full-path/04_exposure_decision.json
+++ b/examples/workflows/market-regime-daily/sample-run-full-path/04_exposure_decision.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-01-15T13:08:00+00:00",
+  "exposure_ceiling_pct": 58,
+  "bias": "NEUTRAL",
+  "participation": "BROAD",
+  "recommendation": "NEW_ENTRY_ALLOWED",
+  "confidence": "MEDIUM",
+  "composite_score": 56.2,
+  "component_scores": {
+    "breadth_score": 66,
+    "uptrend_score": 72,
+    "top_risk_score": 62
+  },
+  "inputs_provided": [
+    "top_risk",
+    "breadth",
+    "uptrend"
+  ],
+  "inputs_missing": [
+    "regime",
+    "institutional",
+    "sector",
+    "theme",
+    "ftd"
+  ],
+  "rationale": "Broad participation indicates healthy market internals. Missing critical inputs (regime) reduce confidence. New positions allowed within the 56% ceiling."
+}

--- a/examples/workflows/market-regime-daily/sample-run-full-path/04_exposure_decision.md
+++ b/examples/workflows/market-regime-daily/sample-run-full-path/04_exposure_decision.md
@@ -1,0 +1,21 @@
+# Market Posture Summary
+**Date:** 2026-05-24 | **Confidence:** MEDIUM
+
+## Exposure Ceiling: 58%
+
+| Dimension | Score | Status |
+|-----------|-------|--------|
+| Breadth | 66 | Healthy |
+| Uptrend | 72 | Strong |
+| Top Risk | 62 | Healthy |
+
+## Recommendation: NEW_ENTRY_ALLOWED
+
+**Bias:** NEUTRAL
+**Participation:** BROAD
+
+### Rationale
+Broad participation indicates healthy market internals. Missing critical inputs (regime) reduce confidence. New positions allowed within the 56% ceiling.
+
+### Missing Inputs
+regime, institutional, sector, theme, ftd

--- a/examples/workflows/market-regime-daily/sample-run-full-path/manifest.yaml
+++ b/examples/workflows/market-regime-daily/sample-run-full-path/manifest.yaml
@@ -1,0 +1,72 @@
+workflow_id: market-regime-daily
+sample_type: full-path
+illustrative: true                 # fictional market snapshot; not investment advice
+artifact_shape: raw-nested-only    # composite{} mirrors raw skill output;
+                                   # top-level *_score handoff fields are deliberately omitted
+                                   # so exposure-coach must read the nested shape.
+prompt: prompt.md
+
+optional_steps_skipped: []
+
+artifacts:
+  - step: 1
+    artifact_id: market_breadth_report
+    skill: market-breadth-analyzer
+    files:
+      canonical: 01_market_breadth_report_raw.json
+  - step: 2
+    artifact_id: uptrend_report
+    skill: uptrend-analyzer
+    files:
+      canonical: 02_uptrend_report_raw.json
+  - step: 3
+    artifact_id: top_risk_report
+    skill: market-top-detector
+    files:
+      canonical: 03_top_risk_report_raw.json
+  - step: 4
+    artifact_id: exposure_decision
+    skill: exposure-coach
+    files:
+      canonical: 04_exposure_decision.json
+      companion: 04_exposure_decision.md
+
+# Fixture note: 04_exposure_decision.json is reproducible from the three raw
+# fixtures using the real exposure-coach extractors (PR #137, merged
+# 2026-05-24). Running:
+#   python3 skills/exposure-coach/scripts/calculate_exposure.py \
+#     --breadth  sample-run-full-path/01_market_breadth_report_raw.json \
+#     --uptrend  sample-run-full-path/02_uptrend_report_raw.json \
+#     --top-risk sample-run-full-path/03_top_risk_report_raw.json
+# produces a posture matching the deterministic key fields below. The point
+# of this full-path sample (vs the required-only sample-run/) is to prove
+# that the nested-only shapes are correctly consumed:
+#   extract_breadth_score(01)  reads composite.composite_score == 66
+#   extract_uptrend_score(02)  reads composite.composite_score == 72
+#   extract_top_risk_score(03) reads composite.composite_score == 38
+#                              and inverts it to 100 - 38 == 62
+# Before PR #137 the breadth and top-risk readers ignored the nested shape,
+# so this sample's top_risk_score would silently fall out and the result
+# would collapse to REDUCE_ONLY / LOW (the required-only outcome).
+verification:
+  data_date: "2026-01-15"
+  expected:
+    breadth_score: 66
+    uptrend_score: 72
+    top_risk_score: 62
+    composite_score: 56.2
+    exposure_ceiling_pct: 58
+    recommendation: NEW_ENTRY_ALLOWED
+    confidence: MEDIUM
+    bias: NEUTRAL
+    participation: BROAD
+    inputs_provided:
+      - top_risk
+      - breadth
+      - uptrend
+    inputs_missing:
+      - regime
+      - institutional
+      - sector
+      - theme
+      - ftd

--- a/examples/workflows/market-regime-daily/sample-run-full-path/prompt.md
+++ b/examples/workflows/market-regime-daily/sample-run-full-path/prompt.md
@@ -1,0 +1,47 @@
+# Prompt — `market-regime-daily` (full-path)
+
+Paste the following to Claude (Claude Code or the web app, with the
+`market-breadth-analyzer`, `uptrend-analyzer`, `market-top-detector`, and
+`exposure-coach` skills available). Replace `<repo>` with your checkout
+path.
+
+---
+
+> Run the **market-regime-daily** workflow end-to-end (include the optional
+> market-top-detector step today).
+>
+> 1. Use **market-breadth-analyzer** to score current market breadth from the
+>    public TraderMonty CSV. Save the JSON + Markdown to
+>    `<repo>/reports/`.
+> 2. Use **uptrend-analyzer** to score uptrend participation from Monty's
+>    public Uptrend Ratio Dashboard CSV. Save to `<repo>/reports/`.
+> 3. Use **market-top-detector** to score top-formation risk. Save to
+>    `<repo>/reports/`.
+> 4. Hand the breadth, uptrend, and top-risk reports to **exposure-coach**
+>    and produce a one-page market posture (exposure ceiling, bias,
+>    participation, new-entry-allowed vs cash-priority).
+>
+> Then tell me: is new swing-trade risk **allowed**, **restricted**, or
+> **cash-priority** today, and why. Treat the output as a posture, not a
+> buy/sell signal.
+
+---
+
+## What to expect
+
+This is the **full-path** sample. All three upstream skills are run and the
+raw fixtures here mirror the **nested** JSON shape those skills actually
+emit (`composite.composite_score`) — there is **no** top-level
+`breadth_score` / `uptrend_score` / `top_risk_score` workflow hand-off
+field. This deliberately exercises the nested-shape parser path in
+`exposure-coach` that was fixed in
+[PR #137](https://github.com/tradermonty/claude-trading-skills/pull/137)
+(merged 2026-05-24).
+
+With `top_risk` now contributing, the posture moves from the required-only
+**REDUCE_ONLY / LOW** outcome to **NEW_ENTRY_ALLOWED / MEDIUM** at a 58%
+exposure ceiling. See [`../README.md`](../README.md) for the comparison
+table and the verification command.
+
+> ⚠️ Illustrative sample — fictional market snapshot, **not investment
+> advice**.

--- a/examples/workflows/trade-memory-loop/README.md
+++ b/examples/workflows/trade-memory-loop/README.md
@@ -1,46 +1,54 @@
-# Example: `trade-memory-loop` (required-only)
+# Example: `trade-memory-loop`
 
 A canonical sample run of the
 [`trade-memory-loop`](../../../workflows/trade-memory-loop.yaml) workflow: the
 per-closed-trade loop that records the outcome, generates a postmortem, and
 journals the lessons so the next decision is better-informed.
 
-> ⚠️ **Illustrative only — not investment advice.** This sample uses the
-> **fictional ticker `EXMPL`** (Example Corp) and a hand-authored trade. The
-> numbers are internally consistent and schema-faithful, **not** captured from
-> a real account.
+> ⚠️ **Illustrative only — not investment advice.** Both sample variants use
+> the **fictional ticker `EXMPL`** (Example Corp) and a hand-authored trade.
+> The numbers are internally consistent and schema-faithful, **not** captured
+> from a real account.
+
+## Two sample variants
+
+This example ships two parallel samples that share the same closed thesis:
+
+| Variant | Optional step | Lessons content |
+|---|---|---|
+| [`sample-run/`](sample-run/) (**required-only**) | skipped | Qualitative postmortem only ("trail under 10-EMA captured an extra ~7%") |
+| [`sample-run-full-path/`](sample-run-full-path/) (**full-path**) | included | Qualitative postmortem **plus** backtest-expert re-validation (verdict + refinement candidate) |
 
 ## Steps in this sample
 
-| Step | Skill | Artifact | In this sample |
-|---|---|---|---|
-| 1 | `trader-memory-core` | `closed_thesis_record` | ✅ included |
-| 2 | `signal-postmortem` | `postmortem_findings` | ✅ included |
-| 3 | `backtest-expert` | `backtest_validation` | ⏭️ **skipped** (optional) |
-| 4 | `trader-memory-core` | `lessons_log_entry` | ✅ included |
-
-Step 3 is the workflow's one optional step. This is the **required-only**
-canonical sample, so it is intentionally skipped (recorded in
-[`sample-run/manifest.yaml`](sample-run/manifest.yaml) under
-`optional_steps_skipped`). A full-path sample including the backtest
-re-validation may be added later in a separate change.
+| Step | Skill | Artifact | `sample-run/` | `sample-run-full-path/` |
+|---|---|---|---|---|
+| 1 | `trader-memory-core` | `closed_thesis_record` | ✅ included | ✅ included (identical) |
+| 2 | `signal-postmortem` | `postmortem_findings` | ✅ included | ✅ included (identical) |
+| 3 | `backtest-expert` | `backtest_validation` | ⏭️ skipped (optional) | ✅ included |
+| 4 | `trader-memory-core` | `lessons_log_entry` | ✅ included | ✅ included (updated with backtest result) |
 
 ## Files
 
 ```
-sample-run/
-  prompt.md                       # the prompt you give Claude
-  manifest.yaml                   # machine-readable step → artifact → file map
-  01_closed_thesis_record.yaml    # step 1 canonical (trader-memory-core thesis, CLOSED)
-  02_postmortem_findings.json     # step 2 canonical (signal-postmortem record)
-  02_postmortem_summary.md        # step 2 companion (human summary)
-  04_lessons_log_entry.md         # step 4 canonical (journal entry)
-```
+sample-run/                        # required-only
+  prompt.md                        # the prompt you give Claude
+  manifest.yaml                    # step → artifact → file map
+  01_closed_thesis_record.yaml     # trader-memory-core thesis, CLOSED
+  02_postmortem_findings.json      # signal-postmortem record
+  02_postmortem_summary.md         # human summary
+  04_lessons_log_entry.md          # journal entry (no backtest)
 
-`closed_thesis_record` has no companion (the YAML *is* the canonical artifact);
-`lessons_log_entry` is inherently Markdown (canonical, no companion).
-`postmortem_findings` has a JSON canonical + a Markdown companion. Every file
-above (except `manifest.yaml` itself) is referenced from the manifest.
+sample-run-full-path/              # full-path
+  prompt.md                        # full-path prompt
+  manifest.yaml                    # step → artifact → file map, no skipped steps
+  01_closed_thesis_record.yaml     # identical to sample-run/
+  02_postmortem_findings.json      # identical to sample-run/
+  02_postmortem_summary.md         # identical to sample-run/
+  03_backtest_validation.json      # backtest-expert verdict (canonical)
+  03_backtest_validation.md        # backtest-expert verdict (companion)
+  04_lessons_log_entry.md          # journal entry with backtest cross-check
+```
 
 ## The trade (fictional)
 
@@ -49,6 +57,27 @@ above (except `manifest.yaml` itself) is referenced from the manifest.
 2026-02-27 @ 168.40 (`target_hit`) after trailing past the initial 2R target.
 Result: +18.5% / +$1,841 over 50 holding days; MAE -4.2%, MFE +21.0%.
 Postmortem classifies it **`TRUE_POSITIVE`** — thesis-driven, not luck.
+
+## What the full-path adds: `backtest-expert` re-validation
+
+The required-only journal entry's repeatable claim is "trailing under the
+rising 10-EMA after 2R captured an extra ~7% on this trade." That's a
+sample-size-of-one claim. The full-path sample runs `backtest-expert` on an
+**87-setup illustrative historical sample** (VCP grade A/B, RISK_ON regime,
+2R reached) and gets:
+
+| Metric | Trail rule | Fixed 2R baseline |
+|--------|-----------:|------------------:|
+| Avg return | **14.6%** | 10.2% |
+| Avg holding days | 38.4 | 22.1 |
+| Premature trail exit rate | 18% | — |
+
+Verdict: **VALIDATED_WITH_CAVEAT** (+4.4 pp edge at the cost of ~16 extra
+holding days). The lessons entry is updated to note this, plus a refinement
+candidate ("widen ATR multiplier from 1 to 1.5 in choppy mid-cycle regimes").
+
+This is the value of the optional `backtest-expert` step: it turns a one-
+trade hunch into a statistically-grounded rule (or rejects it).
 
 ## Schema fidelity (this is enforced, not asserted)
 
@@ -59,10 +88,14 @@ Postmortem classifies it **`TRUE_POSITIVE`** — thesis-driven, not luck.
   set, valid `exit_reason`, `exit_date ≥ entry_date`, `status_history`
   monotonic and ending in `CLOSED`, RFC-3339 timestamps with timezone). Date
   strings are quoted so `yaml.safe_load` returns them as strings (the schema
-  requires `type: string` + `format: date-time`/`date`).
+  requires `type: string` + `format: date-time`/`date`). Both `sample-run/`
+  and `sample-run-full-path/` use the same validated YAML.
 - `02_postmortem_findings.json` is produced by the **real**
   `signal-postmortem` recorder consuming that thesis, so its
   `outcome_category` / `holding_days` are computed, not hand-typed.
+- `03_backtest_validation.json` (full-path only) is an illustrative hand-
+  authored backtest output; the real `backtest-expert` skill produces the
+  same shape on real historical data.
 
 ## Reproduce / verify
 
@@ -73,18 +106,24 @@ uv run python - <<'PY'
 import json, sys, yaml
 sys.path.insert(0, "skills/trader-memory-core/scripts")
 import thesis_store
-d = "examples/workflows/trade-memory-loop/sample-run"
+# Both variants share the same thesis YAML, so we validate either one
+d = "examples/workflows/trade-memory-loop/sample-run-full-path"
 t = yaml.safe_load(open(f"{d}/01_closed_thesis_record.yaml"))
 thesis_store._validate_thesis(t)            # raises on any violation
 pm = json.load(open(f"{d}/02_postmortem_findings.json"))
 assert pm["outcome_category"] == "TRUE_POSITIVE"
 assert pm["holding_days"] == 50
-print("OK: thesis validates; postmortem fields reproduce")
+bt = json.load(open(f"{d}/03_backtest_validation.json"))
+assert bt["interpretation"]["verdict"] == "VALIDATED_WITH_CAVEAT"
+print("OK: thesis validates; postmortem + backtest fields reproduce")
 PY
 ```
 
 ## Run it for real
 
-See [`sample-run/prompt.md`](sample-run/prompt.md). No API key is required
-(FMP is optional, only for MAE/MFE auto-calc); your real thesis IDs, dates,
-and outcome will differ from this fixed sample.
+See [`sample-run/prompt.md`](sample-run/prompt.md) (required-only) or
+[`sample-run-full-path/prompt.md`](sample-run-full-path/prompt.md)
+(full-path). No API key is required for the required path (FMP is optional,
+only for MAE/MFE auto-calc); the full-path `backtest-expert` step depends on
+your chosen data source. Your real thesis IDs, dates, and outcomes will
+differ from this fixed sample.

--- a/examples/workflows/trade-memory-loop/sample-run-full-path/01_closed_thesis_record.yaml
+++ b/examples/workflows/trade-memory-loop/sample-run-full-path/01_closed_thesis_record.yaml
@@ -1,0 +1,98 @@
+# Illustrative sample — fictional ticker EXMPL. NOT investment advice.
+# Schema: skills/trader-memory-core/schemas/thesis.schema.json
+# Date/date-time values are quoted so yaml.safe_load returns them as strings
+# (the schema requires "type": string + "format": date-time / date).
+thesis_id: th_EXMPL_growth_20260108_a1b2
+ticker: EXMPL
+created_at: '2026-01-05T13:00:00+00:00'
+updated_at: '2026-02-27T16:00:00+00:00'
+thesis_type: growth_momentum
+setup_type: vcp_breakout
+catalyst: Q4 earnings beat plus a multi-week VCP base breakout
+status: CLOSED
+status_history:
+  - status: IDEA
+    at: '2026-01-05T13:00:00+00:00'
+    reason: Surfaced by vcp-screener (grade A) in the 2026-01-05 scan
+  - status: ENTRY_READY
+    at: '2026-01-07T18:00:00+00:00'
+    reason: technical-analyst confirmed the weekly base; pivot defined
+  - status: ACTIVE
+    at: '2026-01-08T14:35:00+00:00'
+    reason: Pivot cleared on volume; entry filled
+  - status: CLOSED
+    at: '2026-02-27T15:50:00+00:00'
+    reason: Trailed exit after target_hit; thesis played out
+thesis_statement: >-
+  EXMPL completed a tight 7-week VCP base after a Q4 earnings beat; a breakout
+  through the 142.50 pivot on expanding volume should resolve into a
+  momentum advance toward the 165-170 measured-move zone.
+mechanism_tag: structure
+evidence:
+  - VCP base with three contractions, final contraction < 8%
+  - Q4 revenue +24% YoY, raised FY guidance
+  - Relative strength line at new high ahead of price
+  - 'Accumulation: 4 up-weeks on volume vs 1 down-week'
+kill_criteria:
+  - Close back below the 134.50 stop (base failure)
+  - Two distribution weeks in the first 10 sessions post-breakout
+  - Guidance walk-back or negative pre-announcement
+confidence: medium
+confidence_score: 0.6
+entry:
+  target_price: 142.5
+  conditions:
+    - Break and 30-min hold above 142.50 pivot
+    - Breakout volume >= 1.5x 50-day average
+  actual_price: 142.1
+  actual_date: '2026-01-08T14:35:00+00:00'
+exit:
+  stop_loss: 134.5
+  stop_loss_pct: -5.35
+  take_profit: 157.3
+  take_profit_rr: 2.0
+  time_stop_days: 60
+  actual_price: 168.4
+  actual_date: '2026-02-27T15:50:00+00:00'
+  exit_reason: target_hit
+position:
+  shares: 70
+  shares_remaining: 0
+  position_value: 9947.0
+  risk_dollars: 532.0
+  risk_pct_of_account: 0.53
+  account_type: margin
+  sizing_method: fixed_risk_1pct
+  raw_source:
+    skill: position-sizer
+    file: reports/position_sizer_EXMPL_2026-01-08.json
+    fields:
+      account_size: 100000
+      risk_pct: 1.0
+market_context:
+  regime: RISK_ON
+  breadth_score: 66
+  top_detector_score: null
+  sector: Technology
+origin:
+  skill: vcp-screener
+  output_file: reports/vcp_screen_2026-01-05.json
+  screening_grade: A
+  screening_score: 88
+  raw_provenance: {}
+linked_reports:
+  - skill: technical-analyst
+    file: reports/ta_EXMPL_2026-01-07.md
+    date: '2026-01-07'
+outcome:
+  pnl_dollars: 1841.0
+  pnl_pct: 18.5
+  holding_days: 50
+  mae_pct: -4.2
+  mfe_pct: 21.0
+  mae_mfe_source: manual (illustrative)
+  lessons_learned: >-
+    Thesis-driven winner. The initial 2R target (157.30) was reached on
+    2026-02-10; trailing the stop under the rising 10-EMA captured an extra
+    ~7% before the trail triggered at 168.40. MAE stayed shallow (-4.2%),
+    confirming the breakout was well-timed.

--- a/examples/workflows/trade-memory-loop/sample-run-full-path/02_postmortem_findings.json
+++ b/examples/workflows/trade-memory-loop/sample-run-full-path/02_postmortem_findings.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "1.0",
+  "postmortem_id": "pm_sig_EXMPL_20260108_a1b2",
+  "signal_id": "sig_EXMPL_20260108_a1b2",
+  "ticker": "EXMPL",
+  "signal_date": "2026-01-08",
+  "source_skill": "vcp-screener",
+  "predicted_direction": "LONG",
+  "entry_price": 142.1,
+  "realized_returns": {
+    "5d": 0.021,
+    "20d": 0.083
+  },
+  "exit_price": 168.4,
+  "exit_date": "2026-02-27",
+  "holding_days": 50,
+  "outcome_category": "TRUE_POSITIVE",
+  "regime_at_signal": "RISK_ON",
+  "regime_at_exit": "RISK_ON",
+  "outcome_notes": "Thesis-driven win: VCP breakout held; initial 2R target reached, trailed exit captured additional momentum. No regime change.",
+  "recorded_at": "2026-02-27T16:05:00Z"
+}

--- a/examples/workflows/trade-memory-loop/sample-run-full-path/02_postmortem_summary.md
+++ b/examples/workflows/trade-memory-loop/sample-run-full-path/02_postmortem_summary.md
@@ -1,0 +1,34 @@
+# Postmortem Summary — `sig_EXMPL_20260108_a1b2`
+
+> ⚠️ Illustrative sample — fictional ticker **EXMPL**. Not investment advice.
+> Companion of [`02_postmortem_findings.json`](02_postmortem_findings.json).
+
+**Ticker:** EXMPL  **Source:** vcp-screener  **Direction:** LONG
+**Outcome:** `TRUE_POSITIVE`
+
+| Field | Value |
+|---|---|
+| Signal date | 2026-01-08 |
+| Exit date | 2026-02-27 |
+| Holding days | 50 |
+| Entry price | 142.10 |
+| Exit price | 168.40 |
+| Realized return (5d) | +2.1% |
+| Realized return (20d) | +8.3% |
+| Regime at signal → exit | RISK_ON → RISK_ON |
+
+## Classification rationale
+
+The 5-day return (+2.1%) is the primary classifier input. Predicted
+direction was **LONG** and the 5-day return was **positive**, so the signal is
+a **direction match → `TRUE_POSITIVE`**. Regime was unchanged
+(`RISK_ON → RISK_ON`), so no `REGIME_MISMATCH` override applied; the move was
+well above the ±0.5% neutral band.
+
+## Root-cause read (decision gate)
+
+This was **thesis-driven, not luck**: the VCP base breakout resolved exactly
+as the thesis predicted, MAE stayed shallow (-4.2%), and the advance tracked
+the expected measured move. Execution (entry on the pivot, trailed exit)
+added to the result rather than detracting. No process change required —
+catalogue as a repeatable setup.

--- a/examples/workflows/trade-memory-loop/sample-run-full-path/03_backtest_validation.json
+++ b/examples/workflows/trade-memory-loop/sample-run-full-path/03_backtest_validation.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "1.0",
+  "validation_id": "bt_EXMPL_trail_10ema_20260227",
+  "thesis_id": "th_EXMPL_growth_20260108_a1b2",
+  "ticker_universe": "Illustrative — fictional historical sample, not investment advice",
+  "rule_under_test": {
+    "name": "Trail under rising 10-EMA after 2R target hit",
+    "description": "For VCP breakouts in RISK_ON regimes, after the initial 2R profit target is reached, replace the fixed stop with a trailing stop set 1 ATR below the rising 10-day EMA. Exit on the first close below the trailing stop.",
+    "preconditions": [
+      "Setup type: vcp_breakout",
+      "Regime at entry: RISK_ON",
+      "Initial 2R target reached (i.e. unrealized P&L >= 2x initial risk)"
+    ]
+  },
+  "backtest_spec": {
+    "lookback_years": 6,
+    "date_range": "2020-01-01 to 2026-01-01",
+    "sample_size": 87,
+    "selection_filter": "vcp-screener grade A or B, RISK_ON regime at entry, 2R target reached within 60 days",
+    "comparison_baseline": "Fixed 2R take-profit (no trail)"
+  },
+  "results": {
+    "rule_avg_holding_days": 38.4,
+    "rule_avg_return_pct": 14.6,
+    "rule_win_rate": 0.71,
+    "baseline_avg_holding_days": 22.1,
+    "baseline_avg_return_pct": 10.2,
+    "baseline_win_rate": 1.00,
+    "rule_vs_baseline_return_delta_pct": 4.4,
+    "rule_vs_baseline_holding_delta_days": 16.3,
+    "max_drawdown_during_trail_pct": -4.8,
+    "trail_premature_exit_rate": 0.18
+  },
+  "interpretation": {
+    "verdict": "VALIDATED_WITH_CAVEAT",
+    "summary": "The 'trail under 10-EMA after 2R' rule adds ~4.4 percentage points of average return vs taking the fixed 2R profit, at the cost of ~16 extra holding days and an 18% rate of premature trail exits (trail triggered then price recovered). Net edge is positive for VCP / RISK_ON setups; recommended to keep the rule with explicit awareness of the longer holding period.",
+    "caveats": [
+      "Backtest universe is a fictional illustrative sample; real-world result may differ.",
+      "Win rate baseline is 100% by construction (all samples already reached 2R).",
+      "Premature trail exits cluster in choppy mid-cycle regimes — consider regime-aware trail width."
+    ]
+  },
+  "linked_postmortem": "02_postmortem_findings.json",
+  "linked_thesis": "01_closed_thesis_record.yaml",
+  "generated_at": "2026-02-27T16:30:00+00:00"
+}

--- a/examples/workflows/trade-memory-loop/sample-run-full-path/03_backtest_validation.md
+++ b/examples/workflows/trade-memory-loop/sample-run-full-path/03_backtest_validation.md
@@ -1,0 +1,43 @@
+<!-- Illustrative sample — fictional historical sample. Not investment advice. -->
+<!-- Step 3 (backtest-expert, OPTIONAL): re-validate the lesson candidate.   -->
+
+# Backtest validation — Trail under 10-EMA after 2R
+
+**Thesis:** `th_EXMPL_growth_20260108_a1b2`
+**Rule under test:** Trail under the rising 10-day EMA (1 ATR offset) after the initial 2R target is reached, for VCP breakouts in RISK_ON regimes.
+
+## Backtest spec
+
+| Field | Value |
+|-------|-------|
+| Lookback | 2020-01-01 → 2026-01-01 (6 years) |
+| Sample size | 87 setups |
+| Selection filter | `vcp-screener` grade A/B, RISK_ON at entry, 2R reached within 60d |
+| Comparison baseline | Fixed 2R take-profit (no trail) |
+
+## Results
+
+| Metric | Trail rule | Fixed 2R baseline | Δ |
+|--------|-----------:|------------------:|---:|
+| Avg return | **14.6%** | 10.2% | **+4.4 pp** |
+| Avg holding days | 38.4 | 22.1 | +16.3 d |
+| Win rate | 71% | 100%¹ | -29 pp¹ |
+| Premature trail exit rate | 18% | — | — |
+| Max DD during trail | -4.8% | — | — |
+
+¹ Baseline win rate is 100% **by construction** — every sample in the universe already reached 2R, so taking the fixed 2R always "wins." The trail rule's 71% reflects the rate at which the trail held above the 2R level after the initial target was hit.
+
+## Verdict — VALIDATED_WITH_CAVEAT
+
+Net edge is positive (+4.4 pp avg return), but at the cost of ~16 extra holding days and 18% premature trail exits. Keep the rule for VCP / RISK_ON setups, with explicit awareness of the longer holding period and the choppy-regime premature-exit risk.
+
+## Recommended refinement
+
+- Consider a **regime-aware trail width**: widen the ATR multiplier from 1 to 1.5 in choppy mid-cycle regimes (where the premature trail exits cluster).
+
+## Caveats
+
+- Backtest universe is a fictional illustrative sample for documentation purposes; real-world results will differ.
+- Premature trail exits clustered in mid-cycle regimes — pure RISK_ON late-cycle setups showed a much lower premature exit rate.
+
+> ⚠️ Illustrative sample — fictional historical sample, **not investment advice**.

--- a/examples/workflows/trade-memory-loop/sample-run-full-path/04_lessons_log_entry.md
+++ b/examples/workflows/trade-memory-loop/sample-run-full-path/04_lessons_log_entry.md
@@ -1,0 +1,75 @@
+<!-- Illustrative sample — fictional ticker EXMPL. Not investment advice. -->
+<!-- Step 4 (trader-memory-core): lessons appended to the trader journal.   -->
+<!-- Rendering mirrors trader-memory-core assets/postmortem_template.md.    -->
+# Postmortem: th_EXMPL_growth_20260108_a1b2
+
+**Ticker:** EXMPL
+**Type:** growth_momentum
+**Status:** CLOSED
+
+## Thesis
+
+EXMPL completed a tight 7-week VCP base after a Q4 earnings beat; a breakout
+through the 142.50 pivot on expanding volume should resolve into a momentum
+advance toward the 165-170 measured-move zone.
+
+## Timeline
+
+| Event | Date | Price |
+|-------|------|-------|
+| Created | 2026-01-05T13:00:00+00:00 | — |
+| Entry | 2026-01-08T14:35:00+00:00 | 142.10 |
+| Exit | 2026-02-27T15:50:00+00:00 | 168.40 |
+
+## Outcome
+
+| Metric | Value |
+|--------|-------|
+| P&L ($) | 1841.00 |
+| P&L (%) | 18.5 |
+| Holding Days | 50 |
+| Exit Reason | target_hit |
+| MAE (%) | -4.2 |
+| MFE (%) | 21.0 |
+
+## Position
+
+| Metric | Value |
+|--------|-------|
+| Shares | 70 |
+| Position Value | 9947.00 |
+| Risk ($) | 532.00 |
+
+## Evidence at Entry
+
+- VCP base with three contractions, final contraction < 8%
+- Q4 revenue +24% YoY, raised FY guidance
+- Relative strength line at new high ahead of price
+- Accumulation: 4 up-weeks on volume vs 1 down-week
+
+## Kill Criteria
+
+- Close back below the 134.50 stop (base failure)
+- Two distribution weeks in the first 10 sessions post-breakout
+- Guidance walk-back or negative pre-announcement
+
+## Lessons Learned
+
+Thesis-driven winner (postmortem classified `TRUE_POSITIVE`). The initial 2R
+target (157.30) was reached on 2026-02-10; trailing the stop under the rising
+10-EMA captured an extra ~7% before the trail triggered at 168.40. MAE stayed
+shallow (-4.2%), confirming the breakout was well-timed.
+
+**Backtest re-validation (step 3, optional):** the "trail under 10-EMA after
+2R" rule was re-validated by `backtest-expert` on an 87-setup illustrative
+sample. Net edge is positive (+4.4 pp avg return vs the fixed-2R baseline) but
+at the cost of ~16 extra holding days and an 18% premature trail-exit rate.
+Verdict: **VALIDATED_WITH_CAVEAT** — keep the rule for VCP / RISK_ON setups
+with awareness of the longer hold. See
+[`03_backtest_validation.md`](03_backtest_validation.md) for details and the
+suggested regime-aware trail-width refinement.
+
+**Repeatable rules going forward:**
+
+1. Trail under rising 10-EMA after 2R for VCP / RISK_ON breakouts (validated above).
+2. Consider widening the ATR multiplier from 1 to 1.5 in choppy mid-cycle regimes (refinement candidate from the backtest).

--- a/examples/workflows/trade-memory-loop/sample-run-full-path/manifest.yaml
+++ b/examples/workflows/trade-memory-loop/sample-run-full-path/manifest.yaml
@@ -1,0 +1,51 @@
+workflow_id: trade-memory-loop
+sample_type: full-path
+illustrative: true                 # fictional ticker EXMPL; not investment advice
+artifact_shape: raw-plus-handoff   # consistent across examples/workflows/;
+                                   # this workflow's artifacts are native shapes
+prompt: prompt.md
+
+optional_steps_skipped: []
+
+artifacts:
+  - step: 1
+    artifact_id: closed_thesis_record
+    skill: trader-memory-core
+    schema: skills/trader-memory-core/schemas/thesis.schema.json
+    files:
+      canonical: 01_closed_thesis_record.yaml
+  - step: 2
+    artifact_id: postmortem_findings
+    skill: signal-postmortem
+    files:
+      canonical: 02_postmortem_findings.json
+      companion: 02_postmortem_summary.md
+  - step: 3
+    artifact_id: backtest_validation
+    skill: backtest-expert
+    files:
+      canonical: 03_backtest_validation.json
+      companion: 03_backtest_validation.md
+  - step: 4
+    artifact_id: lessons_log_entry
+    skill: trader-memory-core
+    files:
+      canonical: 04_lessons_log_entry.md
+
+# Fixture note: 01_closed_thesis_record.yaml is identical to the required-only
+# sample and still validates against the real trader-memory-core schema
+# (jsonschema Draft7 + CLOSED business invariants). 02_postmortem_findings.json
+# is also reused unchanged — the postmortem classification doesn't change just
+# because a backtest is added. The new step-3 artifact and the updated step-4
+# journal entry are the full-path additions, demonstrating how an optional
+# `backtest-expert` re-validation feeds the lessons-learned section with a
+# statistical cross-check.
+verification:
+  thesis_status: CLOSED
+  thesis_validates: true
+  expected:
+    outcome_category: TRUE_POSITIVE
+    holding_days: 50
+    exit_reason: target_hit
+    backtest_verdict: VALIDATED_WITH_CAVEAT
+    backtest_avg_return_delta_pp: 4.4

--- a/examples/workflows/trade-memory-loop/sample-run-full-path/prompt.md
+++ b/examples/workflows/trade-memory-loop/sample-run-full-path/prompt.md
@@ -1,0 +1,47 @@
+# Prompt — `trade-memory-loop` (full-path)
+
+Paste the following to Claude (with the `trader-memory-core`,
+`signal-postmortem`, and `backtest-expert` skills available). Replace
+`<repo>` with your checkout path and `$PROJECT_DIR` with your thesis state
+directory.
+
+---
+
+> I just closed a position. Run the **trade-memory-loop** workflow end-to-end
+> (include the optional backtest-expert re-validation step).
+>
+> 1. Use **trader-memory-core** to record the closed trade outcome: update the
+>    thesis to `CLOSED` with the exit price/date, realized P&L, MAE/MFE, and
+>    final status history. State dir: `$PROJECT_DIR/state/theses/`.
+> 2. Use **signal-postmortem** to consume the closed thesis and classify the
+>    outcome (TRUE_POSITIVE / FALSE_POSITIVE / REGIME_MISMATCH / NEUTRAL),
+>    with the root-cause read: was it thesis quality, execution, market
+>    environment, or randomness?
+> 3. Use **backtest-expert** to re-validate the lesson candidate
+>    (e.g. "trail under rising 10-EMA after 2R for VCP / RISK_ON setups")
+>    against a historical sample. Report verdict and any refinement.
+> 4. Use **trader-memory-core** again to append the lessons — including the
+>    backtest result — to my journal.
+>
+> Be honest about whether the win was thesis-driven or luck. Don't rationalize
+> randomness as skill.
+
+Trade details for this sample run: ticker **EXMPL**, LONG, entered
+2026-01-08 @ 142.10 (70 sh, 1% risk, stop 134.50), exited 2026-02-27 @
+168.40 (`target_hit`), origin `vcp-screener` grade A.
+
+---
+
+## What to expect
+
+This is the **full-path** sample. Steps 1, 2, and 4 are identical to the
+required-only sample (the same closed thesis and postmortem classification);
+the new content is **step 3 backtest-expert** re-validation of the
+"trail-under-10-EMA-after-2R" rule on an 87-setup illustrative sample. The
+backtest verdict (**VALIDATED_WITH_CAVEAT**: +4.4 pp avg return vs the
+fixed-2R baseline, at the cost of ~16 extra holding days and 18% premature
+trail exits) feeds the step-4 journal entry as a statistical cross-check
+alongside the qualitative postmortem.
+
+> ⚠️ Illustrative sample — fictional ticker `EXMPL` and fictional historical
+> backtest universe, **not investment advice**.


### PR DESCRIPTION
## Summary
- Add \`sample-run-full-path/\` to both canonical workflow examples
  (\`market-regime-daily\`, \`trade-memory-loop\`)
- Update example READMEs and the parent \`examples/workflows/README.md\` to
  document the two-variant structure and replace the historical
  "parser asymmetry not fixed here" note with a pointer to PR #137
- Existing \`sample-run/\` JSON artifacts are **not** modified

## Why
PR #137 (merged 2026-05-24) fixed the \`exposure-coach\` extractor so it
reads the nested \`composite.composite_score\` shape and applies correct
polarity for breadth (direct), top_risk (\`100 - score\`), and ftd (direct).
The required-only sample alone cannot demonstrate that fix — it only
exercises 2 inputs and still ends in REDUCE_ONLY / LOW. The new full-path
sample adds the optional \`market-top-detector\` step with raw
nested-only fixtures (no top-level \`*_score\` handoff), proving the
post-PR-#137 extractor consumes the real upstream shape.

For \`trade-memory-loop\`, the full-path sample adds an illustrative
\`backtest-expert\` re-validation (VALIDATED_WITH_CAVEAT) and updates the
lessons-learned entry to fold the statistical cross-check in alongside the
qualitative postmortem.

## Determinism / reproducibility
- \`market-regime-daily/sample-run-full-path/04_exposure_decision.json\` is
  byte-stable in its deterministic key fields
  (\`composite_score\`, \`exposure_ceiling_pct\`, \`recommendation\`,
  \`confidence\`, \`component_scores\`, \`inputs_provided\`, \`inputs_missing\`)
  — generated by running the real \`calculate_exposure.py\` over the 3 raw
  fixtures. The reproduce command is in the example README.
- \`trade-memory-loop/sample-run-full-path/01_closed_thesis_record.yaml\` is
  identical to \`sample-run/\` and still passes
  \`thesis_store._validate_thesis()\` (jsonschema Draft-07 + CLOSED business
  invariants).

## Test plan
- [x] PR-D-style scope: only \`examples/workflows/\` modified; \`.claude/\`
      untracked, not staged
- [x] Pre-commit hooks pass (drift gates skipped because no SSoT
      / generator-owned file is touched)
- [x] \`pytest\` skill tests pass
- [x] Full-path determinism: real \`calculate_exposure.py\` over the 3 raw
      fixtures matches every deterministic key field in
      \`04_exposure_decision.json\`
- [x] Trade-memory-loop schema: real \`thesis_store._validate_thesis()\`
      passes on the full-path thesis YAML
- [ ] Reviewer reads both \`sample-run-full-path/manifest.yaml\` Fixture
      notes and confirms the PR #137 explanation matches the implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)