### PR TITLE
docs(navigation): add Find Your Workflow on-ramp (en + ja)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -48,7 +48,7 @@ English README is available at [`README.md`](README.md).
 | 約定後にトレードを記録して学ぶ | [`trade-memory-loop`](workflows/trade-memory-loop.yaml) | trader-memory-core, signal-postmortem | API なし可 |
 | 月次でパフォーマンスとルールを見直す | [`monthly-performance-review`](workflows/monthly-performance-review.yaml) | trader-memory-core, signal-postmortem, backtest-expert | API なし可 |
 
-manifest の読み方や手動実行手順は [`workflows/README.md`](workflows/README.md) を参照してください。
+manifest の読み方や手動実行手順は [`workflows/README.md`](workflows/README.md) を参照してください。「自分の状況にどのワークフローが合うか」を 1 ページで知りたい場合は [ワークフローの選び方](docs/ja/find-your-workflow.md)（[English](docs/en/find-your-workflow.md)）を参照してください。
 
 ### API キー不要の入口
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ New users should start with one of these operational workflows. Each link points
 | Record and learn from every closed trade | [`trade-memory-loop`](workflows/trade-memory-loop.yaml) | trader-memory-core, signal-postmortem | No API for manual path |
 | Review monthly performance and adjust rules | [`monthly-performance-review`](workflows/monthly-performance-review.yaml) | trader-memory-core, signal-postmortem, backtest-expert | No API for manual path |
 
-See [`workflows/README.md`](workflows/README.md) for how to read a manifest and run it manually.
+See [`workflows/README.md`](workflows/README.md) for how to read a manifest and run it manually. For a one-page "which workflow fits my situation?" guide, see [Find Your Workflow](docs/en/find-your-workflow.md) ([日本語](docs/ja/find-your-workflow.md)).
 
 ### No API Key Starter Path
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -505,6 +505,9 @@ Current `nav_order` assignments for top-level en/ pages:
 | 1 | Getting Started |
 | 2 | Skill Catalog |
 | 3 | Skill Guides (index) |
+| 4 | Workflows |
+| 5 | Skillsets |
+| 6 | Find Your Workflow |
 
 Skill guide pages use `nav_order` values from 1 to ~50. To avoid conflicts:
 1. Check existing values in `docs/en/skills/` before assigning

--- a/docs/en/find-your-workflow.md
+++ b/docs/en/find-your-workflow.md
@@ -1,0 +1,110 @@
+---
+layout: default
+title: Find Your Workflow
+parent: English
+nav_order: 3
+lang_peer: /ja/find-your-workflow/
+permalink: /en/find-your-workflow/
+---
+
+# Find Your Workflow
+{: .no_toc }
+
+A static "choose-your-entry-point" guide for the Solo Trader OS. Before you
+browse the [Skill Catalog](skill-catalog.md) or [Workflows](workflows.md)
+page, this page maps your situation to the right starting workflow in one
+short scan.
+
+If your situation does not match any line below, jump to
+[**`trading-skills-navigator`**](skills/trading-skills-navigator.md) and
+describe your goal in natural language — it returns the same workflow
+recommendations programmatically.
+
+---
+
+## Pick by daily rhythm
+
+| Your situation | Start with |
+|---|---|
+| I have 15 minutes each morning before the open | [`market-regime-daily`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/market-regime-daily.yaml) |
+| I want to swing trade only when the regime allows it | [`market-regime-daily`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/market-regime-daily.yaml) → [`swing-opportunity-daily`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/swing-opportunity-daily.yaml) |
+| I review my long-term portfolio weekly | [`core-portfolio-weekly`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/core-portfolio-weekly.yaml) |
+| I just closed a trade and want to learn from it | [`trade-memory-loop`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/trade-memory-loop.yaml) |
+| I want to look back on the month and adjust my rules | [`monthly-performance-review`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/monthly-performance-review.yaml) |
+
+> Not sure which one applies? Use [`trading-skills-navigator`](skills/trading-skills-navigator.md)
+> and describe your daily rhythm in natural language.
+
+---
+
+## Pick by goal
+
+| Your goal | Skillset | Driving workflow |
+|---|---|---|
+| Know whether today is risk-on or risk-off before doing anything else | [`market-regime`](https://github.com/tradermonty/claude-trading-skills/blob/main/skillsets/market-regime.yaml) | `market-regime-daily` |
+| Run a Core long-term portfolio (dividends, ETFs, long holdings) | [`core-portfolio`](https://github.com/tradermonty/claude-trading-skills/blob/main/skillsets/core-portfolio.yaml) | `core-portfolio-weekly` |
+| Find disciplined Satellite swing-trade candidates only when conditions allow | [`swing-opportunity`](https://github.com/tradermonty/claude-trading-skills/blob/main/skillsets/swing-opportunity.yaml) | `swing-opportunity-daily` |
+| Record every trade, generate postmortems, and journal lessons | [`trade-memory`](https://github.com/tradermonty/claude-trading-skills/blob/main/skillsets/trade-memory.yaml) | `trade-memory-loop`, `monthly-performance-review` |
+
+> Still unsure which goal you fit? [`trading-skills-navigator`](skills/trading-skills-navigator.md)
+> can match your free-form goal to a skillset and workflow.
+
+---
+
+## When the existing workflows don't fit
+
+### No-API-key starter path
+
+If you do not have FMP / FINVIZ / Alpaca subscriptions yet, run these five
+skills manually — the same minimum loop powers the
+[`market-regime-daily`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/market-regime-daily.yaml)
+and [`trade-memory-loop`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/trade-memory-loop.yaml)
+workflows without paid data:
+
+1. [`market-breadth-analyzer`](skills/market-breadth-analyzer.md) — public CSV breadth scoring
+2. [`uptrend-analyzer`](skills/uptrend-analyzer.md) — public CSV uptrend participation
+3. [`position-sizer`](skills/position-sizer.md) — pure calculation
+4. [`trader-memory-core`](skills/trader-memory-core.md) — local YAML journaling
+5. [`signal-postmortem`](skills/signal-postmortem.md) — review framework
+
+"No API" does not mean "no external data" — these skills still need public
+CSVs, chart screenshots, or local files. See each skill's `integrations:`
+entry in [`skills-index.yaml`](https://github.com/tradermonty/claude-trading-skills/blob/main/skills-index.yaml)
+for exact input requirements.
+
+### Honest gaps
+
+Some use cases do not yet have a packaged workflow. These are tracked
+explicitly as upcoming work in
+[`PROJECT_VISION.md`](https://github.com/tradermonty/claude-trading-skills/blob/main/PROJECT_VISION.md):
+
+- **Short-only / risk-off intraday** — covered partially by
+  `parabolic-short-trade-planner`, but no end-to-end short workflow yet
+- **Earnings-week intraday** — covered partially by `earnings-trade-analyzer`
+  and `pead-screener`, but no weekly orchestration workflow yet
+- **Strategy research pipeline** — `edge-pipeline-orchestrator` exists, but
+  there is no canonical "find a new edge" workflow manifest yet
+
+If your situation maps to one of these gaps, treat it as exploratory: pick
+the individual skills you need from the [Skill Catalog](skill-catalog.md)
+and run them ad-hoc until a dedicated workflow ships.
+
+### Free-form natural-language entry
+
+For any situation that does not match the tables above, use the
+[`trading-skills-navigator`](skills/trading-skills-navigator.md) skill. Pass
+it your free-form goal and it returns the most appropriate workflow,
+skillset, API profile, and setup path — backed by the same
+[`skills-index.yaml`](https://github.com/tradermonty/claude-trading-skills/blob/main/skills-index.yaml)
+single source of truth that powers this page.
+
+---
+
+## See also
+
+- [Getting Started](getting-started.md) — install paths for Claude Code,
+  Claude web app, and CLI
+- [Skill Catalog](skill-catalog.md) — full alphabetical catalog of every skill
+- [Workflows](workflows.md) — auto-generated manifest reference for every
+  workflow
+- [Skillsets](skillsets.md) — goal-oriented install bundles

--- a/docs/en/find-your-workflow.md
+++ b/docs/en/find-your-workflow.md
@@ -2,7 +2,7 @@
 layout: default
 title: Find Your Workflow
 parent: English
-nav_order: 3
+nav_order: 6
 lang_peer: /ja/find-your-workflow/
 permalink: /en/find-your-workflow/
 ---

--- a/docs/ja/find-your-workflow.md
+++ b/docs/ja/find-your-workflow.md
@@ -2,7 +2,7 @@
 layout: default
 title: ワークフローの選び方
 parent: 日本語
-nav_order: 3
+nav_order: 6
 lang_peer: /en/find-your-workflow/
 permalink: /ja/find-your-workflow/
 ---

--- a/docs/ja/find-your-workflow.md
+++ b/docs/ja/find-your-workflow.md
@@ -1,0 +1,109 @@
+---
+layout: default
+title: ワークフローの選び方
+parent: 日本語
+nav_order: 3
+lang_peer: /en/find-your-workflow/
+permalink: /ja/find-your-workflow/
+---
+
+# ワークフローの選び方
+{: .no_toc }
+
+Solo Trader OS の静的な「どこから始めるか」ガイドです。[スキル一覧](skill-catalog.md)
+や[ワークフロー](workflows.md)ページを見る前に、本ページで自分の状況に合った
+入口ワークフローを一読で見つけられます。
+
+下の表のどれにも該当しない場合は、
+[**`trading-skills-navigator`**](skills/trading-skills-navigator.md)
+に自然言語で目的を伝えてください。同じ推薦結果を機械的に返します。
+
+---
+
+## 毎日のリズムで選ぶ
+
+| あなたの状況 | 始めるワークフロー |
+|---|---|
+| 寄り付き前の15分間で相場確認したい | [`market-regime-daily`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/market-regime-daily.yaml) |
+| 相場環境が許すときだけスイングトレードしたい | [`market-regime-daily`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/market-regime-daily.yaml) → [`swing-opportunity-daily`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/swing-opportunity-daily.yaml) |
+| 長期ポートフォリオを週次で見直したい | [`core-portfolio-weekly`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/core-portfolio-weekly.yaml) |
+| 約定したトレードから学びたい | [`trade-memory-loop`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/trade-memory-loop.yaml) |
+| 月次でパフォーマンスを振り返ってルールを見直したい | [`monthly-performance-review`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/monthly-performance-review.yaml) |
+
+> 迷う場合は [`trading-skills-navigator`](skills/trading-skills-navigator.md)
+> に自然言語で日常のリズムを伝えてください。
+
+---
+
+## 目的で選ぶ
+
+| あなたの目的 | スキルセット | 駆動ワークフロー |
+|---|---|---|
+| まず今日が risk-on か risk-off かを知りたい | [`market-regime`](https://github.com/tradermonty/claude-trading-skills/blob/main/skillsets/market-regime.yaml) | `market-regime-daily` |
+| Core（配当・ETF・長期保有）の長期ポートフォリオを運用したい | [`core-portfolio`](https://github.com/tradermonty/claude-trading-skills/blob/main/skillsets/core-portfolio.yaml) | `core-portfolio-weekly` |
+| 相場が許すときだけ規律あるサテライト・スイング候補を探したい | [`swing-opportunity`](https://github.com/tradermonty/claude-trading-skills/blob/main/skillsets/swing-opportunity.yaml) | `swing-opportunity-daily` |
+| 全トレードを記録し、ポストモーテムを生成し、学びを journal に残したい | [`trade-memory`](https://github.com/tradermonty/claude-trading-skills/blob/main/skillsets/trade-memory.yaml) | `trade-memory-loop`, `monthly-performance-review` |
+
+> 自分の目的がどれに合うか迷う場合は [`trading-skills-navigator`](skills/trading-skills-navigator.md)
+> に自由記述の目的を伝えれば、スキルセットとワークフローに対応付けてくれます。
+
+---
+
+## 既存ワークフローに当てはまらない場合
+
+### API キー不要の入口
+
+FMP / FINVIZ / Alpaca の有料サブスクをまだ持っていない場合は、まずこの5つの
+スキルを手動で回してください。同じ最小ループが
+[`market-regime-daily`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/market-regime-daily.yaml)
+と
+[`trade-memory-loop`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/trade-memory-loop.yaml)
+を有料データなしで支えます。
+
+1. [`market-breadth-analyzer`](skills/market-breadth-analyzer.md) — 公開 CSV による breadth スコア
+2. [`uptrend-analyzer`](skills/uptrend-analyzer.md) — 公開 CSV の uptrend 参加比率
+3. [`position-sizer`](skills/position-sizer.md) — 純粋計算
+4. [`trader-memory-core`](skills/trader-memory-core.md) — ローカル YAML での journaling
+5. [`signal-postmortem`](skills/signal-postmortem.md) — レビューフレームワーク
+
+「API なし」は「外部データなし」ではありません。これらのスキルは公開 CSV・
+チャート画像・ローカルファイルを必要とします。正確な入力要件は各スキルの
+[`skills-index.yaml`](https://github.com/tradermonty/claude-trading-skills/blob/main/skills-index.yaml)
+の `integrations:` 欄を参照してください。
+
+### 既知のギャップ
+
+一部のユースケースには、まだパッケージ化されたワークフローがありません。これらは
+[`PROJECT_VISION.md`](https://github.com/tradermonty/claude-trading-skills/blob/main/PROJECT_VISION.md)
+で次の作業候補として明示的に追跡されています。
+
+- **ショート専用 / risk-off 日中** — `parabolic-short-trade-planner` で部分的に
+  カバーされていますが、エンドツーエンドのショートワークフローはまだありません
+- **決算週の日中** — `earnings-trade-analyzer` と `pead-screener` で部分的に
+  カバーされていますが、週次のオーケストレーションワークフローはまだありません
+- **戦略リサーチパイプライン** — `edge-pipeline-orchestrator` はありますが、
+  「新しいエッジを発見する」という canonical なワークフロー manifest は
+  まだありません
+
+あなたの状況がこれらのギャップに該当する場合は、探索的に扱ってください。
+[スキル一覧](skill-catalog.md) から必要な個別スキルを選び、専用ワークフローが
+出るまでアドホックに実行してください。
+
+### 自由記述の自然言語による入口
+
+上の表に該当しない状況には、
+[`trading-skills-navigator`](skills/trading-skills-navigator.md)
+スキルを使ってください。自由記述の目的を渡せば、最適なワークフロー、
+スキルセット、API プロファイル、セットアップ手順を返します。
+本ページと同じ
+[`skills-index.yaml`](https://github.com/tradermonty/claude-trading-skills/blob/main/skills-index.yaml)
+の Single Source of Truth に基づいた推薦です。
+
+---
+
+## 関連ページ
+
+- [はじめに](getting-started.md) — Claude Code / Claude ウェブアプリ / CLI 向けインストール手順
+- [スキル一覧](skill-catalog.md) — 全スキルのアルファベット順カタログ
+- [ワークフロー](workflows.md) — 全ワークフローの自動生成 manifest リファレンス
+- [スキルセット](skillsets.md) — 目的別インストールバンドル


### PR DESCRIPTION
## Summary
- Add \`docs/en/find-your-workflow.md\` and \`docs/ja/find-your-workflow.md\`
- Three-section static on-ramp: **Pick by daily rhythm**, **Pick by goal**,
  **When the existing workflows don't fit** (with No-API-key starter path,
  Honest gaps, and a pointer to \`trading-skills-navigator\` for free-form
  entry)
- Add a one-line link from \`README.md\` / \`README.ja.md\` Recommended
  Starting Path section to both pages

## Why
\`PROJECT_VISION.md\` (Near-Term Priorities) lists "Find Your Workflow" as
the next on-ramp gap between the README starting path and the
\`trading-skills-navigator\` runtime skill. This PR fills that slot:

- README starting path = top-level entry, marketing-style
- **Find Your Workflow** = static one-page mapping from situation/goal to workflow
- \`trading-skills-navigator\` = free-form natural-language fallback

Each section in the new docs ends with a pointer to the Navigator so the
static page acts as the on-ramp and the runtime skill stays the catch-all.

## Conventions
- Front matter (\`layout\`, \`title\`, \`parent\`, \`nav_order\`, \`lang_peer\`,
  \`permalink\`) follows \`docs/{en,ja}/workflows.md\` exactly
- \`nav_order: 3\` sits cleanly between Skill Catalog (2) and Workflows (4)
- \`lang_peer\` links the EN/JA pair

## Test plan
- [x] \`pre-commit run --files docs/en/find-your-workflow.md docs/ja/find-your-workflow.md README.md README.ja.md\` passes
- [x] \`python3 scripts/generate_catalog_from_index.py --check\` passes
      (catalog-drift gate is unaffected — the new pages are not catalog-sentinel content)
- [x] \`python3 scripts/validate_skills_index.py --strict-workflows\` passes
- [x] All referenced workflows exist in \`workflows/*.yaml\`
- [ ] Reviewer confirms Jekyll renders \`/en/find-your-workflow/\` and
      \`/ja/find-your-workflow/\` permalinks correctly with the EN/JA toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)