### PR TITLE
feat(workflows): integrate trade-performance-coach into trade-memory-loop + monthly-performance-review

### DIFF
--- a/docs/en/skillsets.md
+++ b/docs/en/skillsets.md
@@ -99,7 +99,7 @@ Purpose-specific skillset bundles for the solo-trader OS. A skillset is a catego
 
 **Required skills:** `trader-memory-core`, `signal-postmortem`
 
-**Recommended skills:** `backtest-expert`
+**Recommended skills:** `backtest-expert`, `trade-performance-coach`
 
 **Optional skills:** `trade-hypothesis-ideator`
 

--- a/docs/en/workflows.md
+++ b/docs/en/workflows.md
@@ -149,7 +149,7 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 
 **Required skills:** `trader-memory-core`, `signal-postmortem`
 
-**Optional skills:** `backtest-expert`, `dual-axis-skill-reviewer`
+**Optional skills:** `trade-performance-coach`, `backtest-expert`, `dual-axis-skill-reviewer`
 
 **Artifacts:**
 
@@ -157,11 +157,14 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 |---|---|---|---|
 | `monthly_aggregate` | 1 | yes | — |
 | `aggregate_postmortem` | 2 | yes | — |
-| `hypothesis_revalidation` | 3 | no | — |
-| `skill_review_findings` | 4 | no | — |
-| `monthly_decision_log` | 5 | yes | — |
-| `rule_changes_for_next_month` | 5 | yes | — |
-| `skill_improvement_backlog` | 5 | no | — |
+| `monthly_performance_coach_report` | 3 | no | — |
+| `monthly_behavior_patterns` | 3 | no | — |
+| `next_month_operating_rules` | 3 | no | — |
+| `hypothesis_revalidation` | 4 | no | — |
+| `skill_review_findings` | 5 | no | — |
+| `monthly_decision_log` | 6 | yes | — |
+| `rule_changes_for_next_month` | 6 | yes | — |
+| `skill_improvement_backlog` | 6 | no | — |
 
 **Steps:**
 
@@ -175,17 +178,23 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 - produces: `aggregate_postmortem`
 - **Decision:** What recurring patterns appear across the month's outcomes? Classify by thesis quality, execution, market environment, and randomness.
 
-**Step 3: Re-validate hypotheses via backtest** (optional) → `backtest-expert`
+**Step 3: Coach monthly process, risk, and behavior patterns** (optional) (decision gate) → `trade-performance-coach`
+
+- consumes: `monthly_aggregate`, `aggregate_postmortem`
+- produces: `monthly_performance_coach_report`, `monthly_behavior_patterns`, `next_month_operating_rules`
+- **Decision:** Which next-month operating rules should be accepted, modified, deferred, or journaled only?
+
+**Step 4: Re-validate hypotheses via backtest** (optional) → `backtest-expert`
 
 - consumes: `aggregate_postmortem`
 - produces: `hypothesis_revalidation`
 
-**Step 4: Review which skills helped or hurt** (optional) → `dual-axis-skill-reviewer`
+**Step 5: Review which skills helped or hurt** (optional) → `dual-axis-skill-reviewer`
 
 - consumes: `aggregate_postmortem`
 - produces: `skill_review_findings`
 
-**Step 5: Produce decision log and rule changes** (decision gate) → `trader-memory-core`
+**Step 6: Produce decision log and rule changes** (decision gate) → `trader-memory-core`
 
 - consumes: `aggregate_postmortem`, `hypothesis_revalidation`, `skill_review_findings`
 - produces: `monthly_decision_log`, `rule_changes_for_next_month`, `skill_improvement_backlog`
@@ -287,13 +296,13 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 
 **`trade-memory-loop`** · ad-hoc · ~30 min · no-api-basic · beginner
 
-**When to run:** Every time a position is closed (full or partial exit). Records the outcome, generates a postmortem, and (optionally) re-validates the original hypothesis via backtest.
+**When to run:** Every time a position is closed (full or partial exit). Records the outcome, generates a postmortem, (optionally) coaches process / risk / execution / behavior patterns, and (optionally) re-validates the original hypothesis via backtest.
 
 **When NOT to run:** Do not run before a position is closed — use trader-memory-core directly to update an open thesis instead. Do not skip this loop after a closed trade, even on winners.
 
 **Required skills:** `trader-memory-core`, `signal-postmortem`
 
-**Optional skills:** `backtest-expert`
+**Optional skills:** `trade-performance-coach`, `backtest-expert`
 
 **Artifacts:**
 
@@ -301,8 +310,10 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 |---|---|---|---|
 | `closed_thesis_record` | 1 | yes | — |
 | `postmortem_findings` | 2 | yes | `monthly-performance-review` |
-| `backtest_validation` | 3 | no | — |
-| `lessons_log_entry` | 4 | yes | `monthly-performance-review` |
+| `performance_coach_report` | 3 | no | `monthly-performance-review` |
+| `next_session_operating_rules` | 3 | no | `monthly-performance-review` |
+| `backtest_validation` | 4 | no | — |
+| `lessons_log_entry` | 5 | yes | `monthly-performance-review` |
 
 **Steps:**
 
@@ -316,12 +327,18 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 - produces: `postmortem_findings`
 - **Decision:** What was the root cause of the outcome — thesis quality, execution, market environment, or randomness? Classify and document.
 
-**Step 3: Re-validate hypothesis via backtest** (optional) → `backtest-expert`
+**Step 3: Coach process, risk, and behavior patterns** (optional) (decision gate) → `trade-performance-coach`
+
+- consumes: `closed_thesis_record`, `postmortem_findings`
+- produces: `performance_coach_report`, `next_session_operating_rules`
+- **Decision:** Which next-session operating rules should the trader accept, modify, defer, or journal only?
+
+**Step 4: Re-validate hypothesis via backtest** (optional) → `backtest-expert`
 
 - consumes: `postmortem_findings`
 - produces: `backtest_validation`
 
-**Step 4: Append lessons to journal** → `trader-memory-core`
+**Step 5: Append lessons to journal** → `trader-memory-core`
 
 - consumes: `postmortem_findings`, `backtest_validation`
 - produces: `lessons_log_entry`

--- a/docs/ja/skillsets.md
+++ b/docs/ja/skillsets.md
@@ -101,7 +101,7 @@ permalink: /ja/skillsets/
 
 **必須スキル:** `trader-memory-core`, `signal-postmortem`
 
-**推奨スキル:** `backtest-expert`
+**推奨スキル:** `backtest-expert`, `trade-performance-coach`
 
 **任意スキル:** `trade-hypothesis-ideator`
 

--- a/docs/ja/workflows.md
+++ b/docs/ja/workflows.md
@@ -151,7 +151,7 @@ permalink: /ja/workflows/
 
 **必須スキル:** `trader-memory-core`, `signal-postmortem`
 
-**任意スキル:** `backtest-expert`, `dual-axis-skill-reviewer`
+**任意スキル:** `trade-performance-coach`, `backtest-expert`, `dual-axis-skill-reviewer`
 
 **artifact 一覧:**
 
@@ -159,11 +159,14 @@ permalink: /ja/workflows/
 |---|---|---|---|
 | `monthly_aggregate` | 1 | あり | — |
 | `aggregate_postmortem` | 2 | あり | — |
-| `hypothesis_revalidation` | 3 | なし | — |
-| `skill_review_findings` | 4 | なし | — |
-| `monthly_decision_log` | 5 | あり | — |
-| `rule_changes_for_next_month` | 5 | あり | — |
-| `skill_improvement_backlog` | 5 | なし | — |
+| `monthly_performance_coach_report` | 3 | なし | — |
+| `monthly_behavior_patterns` | 3 | なし | — |
+| `next_month_operating_rules` | 3 | なし | — |
+| `hypothesis_revalidation` | 4 | なし | — |
+| `skill_review_findings` | 5 | なし | — |
+| `monthly_decision_log` | 6 | あり | — |
+| `rule_changes_for_next_month` | 6 | あり | — |
+| `skill_improvement_backlog` | 6 | なし | — |
 
 **ステップ:**
 
@@ -177,17 +180,23 @@ permalink: /ja/workflows/
 - produces: `aggregate_postmortem`
 - **判断:** What recurring patterns appear across the month's outcomes? Classify by thesis quality, execution, market environment, and randomness.
 
-**ステップ 3: Re-validate hypotheses via backtest** （任意） → `backtest-expert`
+**ステップ 3: Coach monthly process, risk, and behavior patterns** （任意） （判断ゲート） → `trade-performance-coach`
+
+- consumes: `monthly_aggregate`, `aggregate_postmortem`
+- produces: `monthly_performance_coach_report`, `monthly_behavior_patterns`, `next_month_operating_rules`
+- **判断:** Which next-month operating rules should be accepted, modified, deferred, or journaled only?
+
+**ステップ 4: Re-validate hypotheses via backtest** （任意） → `backtest-expert`
 
 - consumes: `aggregate_postmortem`
 - produces: `hypothesis_revalidation`
 
-**ステップ 4: Review which skills helped or hurt** （任意） → `dual-axis-skill-reviewer`
+**ステップ 5: Review which skills helped or hurt** （任意） → `dual-axis-skill-reviewer`
 
 - consumes: `aggregate_postmortem`
 - produces: `skill_review_findings`
 
-**ステップ 5: Produce decision log and rule changes** （判断ゲート） → `trader-memory-core`
+**ステップ 6: Produce decision log and rule changes** （判断ゲート） → `trader-memory-core`
 
 - consumes: `aggregate_postmortem`, `hypothesis_revalidation`, `skill_review_findings`
 - produces: `monthly_decision_log`, `rule_changes_for_next_month`, `skill_improvement_backlog`
@@ -289,13 +298,13 @@ permalink: /ja/workflows/
 
 **`trade-memory-loop`** · ad-hoc · ~30 min · no-api-basic · beginner
 
-**実行タイミング:** Every time a position is closed (full or partial exit). Records the outcome, generates a postmortem, and (optionally) re-validates the original hypothesis via backtest.
+**実行タイミング:** Every time a position is closed (full or partial exit). Records the outcome, generates a postmortem, (optionally) coaches process / risk / execution / behavior patterns, and (optionally) re-validates the original hypothesis via backtest.
 
 **実行してはいけないとき:** Do not run before a position is closed — use trader-memory-core directly to update an open thesis instead. Do not skip this loop after a closed trade, even on winners.
 
 **必須スキル:** `trader-memory-core`, `signal-postmortem`
 
-**任意スキル:** `backtest-expert`
+**任意スキル:** `trade-performance-coach`, `backtest-expert`
 
 **artifact 一覧:**
 
@@ -303,8 +312,10 @@ permalink: /ja/workflows/
 |---|---|---|---|
 | `closed_thesis_record` | 1 | あり | — |
 | `postmortem_findings` | 2 | あり | `monthly-performance-review` |
-| `backtest_validation` | 3 | なし | — |
-| `lessons_log_entry` | 4 | あり | `monthly-performance-review` |
+| `performance_coach_report` | 3 | なし | `monthly-performance-review` |
+| `next_session_operating_rules` | 3 | なし | `monthly-performance-review` |
+| `backtest_validation` | 4 | なし | — |
+| `lessons_log_entry` | 5 | あり | `monthly-performance-review` |
 
 **ステップ:**
 
@@ -318,12 +329,18 @@ permalink: /ja/workflows/
 - produces: `postmortem_findings`
 - **判断:** What was the root cause of the outcome — thesis quality, execution, market environment, or randomness? Classify and document.
 
-**ステップ 3: Re-validate hypothesis via backtest** （任意） → `backtest-expert`
+**ステップ 3: Coach process, risk, and behavior patterns** （任意） （判断ゲート） → `trade-performance-coach`
+
+- consumes: `closed_thesis_record`, `postmortem_findings`
+- produces: `performance_coach_report`, `next_session_operating_rules`
+- **判断:** Which next-session operating rules should the trader accept, modify, defer, or journal only?
+
+**ステップ 4: Re-validate hypothesis via backtest** （任意） → `backtest-expert`
 
 - consumes: `postmortem_findings`
 - produces: `backtest_validation`
 
-**ステップ 4: Append lessons to journal** → `trader-memory-core`
+**ステップ 5: Append lessons to journal** → `trader-memory-core`
 
 - consumes: `postmortem_findings`, `backtest_validation`
 - produces: `lessons_log_entry`

--- a/skills-index.yaml
+++ b/skills-index.yaml
@@ -978,7 +978,9 @@ skills:
   - behavioral_pattern_tags
   - risk_manager_notes
   - next_session_operating_rules
-  workflows: []
+  workflows:
+  - trade-memory-loop
+  - monthly-performance-review
 - id: trader-memory-core
   display_name: Trader Memory Core
   category: trade-memory

--- a/skills/trading-skills-navigator/assets/metadata_snapshot.json
+++ b/skills/trading-skills-navigator/assets/metadata_snapshot.json
@@ -1022,7 +1022,8 @@
         "trade-hypothesis-ideator"
       ],
       "recommended_skills": [
-        "backtest-expert"
+        "backtest-expert",
+        "trade-performance-coach"
       ],
       "related_workflows": [
         "trade-memory-loop",
@@ -1093,6 +1094,7 @@
       "estimated_minutes": 90,
       "id": "monthly-performance-review",
       "optional_skills": [
+        "trade-performance-coach",
         "backtest-expert",
         "dual-axis-skill-reviewer"
       ],
@@ -1140,6 +1142,7 @@
       "estimated_minutes": 30,
       "id": "trade-memory-loop",
       "optional_skills": [
+        "trade-performance-coach",
         "backtest-expert"
       ],
       "prerequisite_workflows": [],

--- a/skills/trading-skills-navigator/scripts/recommend.py
+++ b/skills/trading-skills-navigator/scripts/recommend.py
@@ -593,6 +593,16 @@ PERSONAS: tuple[Persona, ...] = (
             "what went wrong with",
             "log my trade",
             "trade review after",
+            # Post-trade coaching entry terms (added 2026-05-25 alongside the
+            # trade-performance-coach skill integration in PR-G); without these,
+            # natural-language queries like "post-trade coaching" fall back to
+            # the beginner persona instead of trade-memory-loop.
+            "post-trade coach",
+            "post-trade coaching",
+            "trade coach",
+            "trade coaching",
+            "performance coach",
+            "trade-performance-coach",
             # JA
             "ジャーナル",
             "トレード記録",
@@ -604,9 +614,13 @@ PERSONAS: tuple[Persona, ...] = (
             "損切り後",
             "反省",
             "教訓",
+            "トレードコーチ",
+            "売買コーチ",
+            "取引後レビュー",
+            "トレード後レビュー",
         ),
         primary="trade-memory-loop",
-        rationale="trade journaling / postmortem loop after a closed position",
+        rationale="trade journaling / postmortem / post-trade coaching loop after a closed position",
     ),
     # Monthly performance review.
     Persona(

--- a/skills/trading-skills-navigator/scripts/tests/test_recommend.py
+++ b/skills/trading-skills-navigator/scripts/tests/test_recommend.py
@@ -181,6 +181,54 @@ def test_ten_question_contract(
         assert manifest is None, f"Q{num} manifest null on deferred"
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        "post-trade coaching",
+        "post-trade coach",
+        "trade coach",
+        "trade coaching",
+        "performance coach",
+        "トレードコーチ",
+        "取引後レビュー",
+    ],
+    ids=[
+        "en-post-trade-coaching",
+        "en-post-trade-coach",
+        "en-trade-coach",
+        "en-trade-coaching",
+        "en-performance-coach",
+        "ja-トレードコーチ",
+        "ja-取引後レビュー",
+    ],
+)
+def test_post_trade_coaching_routes_to_trade_memory_loop(
+    repo_metadata: dict[str, Any], query: str
+) -> None:
+    """Regression (2026-05-25 PR-G review):
+    post-trade coaching entry terms must route to trade-memory-loop with
+    trade-performance-coach surfaced in the setup_bundle.recommended list.
+    Before PR-G's recommend.py update, these queries fell back to the
+    beginner persona (market-regime-daily).
+    """
+    r = recommend(query, repo_metadata)
+    assert r["primary_workflow"] is not None
+    assert r["primary_workflow"]["id"] == "trade-memory-loop", (
+        f"query {query!r} should route to trade-memory-loop, got {r['primary_workflow']['id']!r}"
+    )
+    bundle = r["setup_bundle"]
+    # trade-performance-coach is in the workflow's optional_skills and the
+    # skillset's recommended_skills; it must appear in the setup bundle.
+    bundle_skills = set(bundle.get("recommended", []))
+    bundle_skills.update(bundle.get("required", []))
+    bundle_skills.update(bundle.get("optional", []))
+    assert "trade-performance-coach" in bundle_skills, (
+        f"query {query!r} setup_bundle missing trade-performance-coach; "
+        f"bundle keys = {sorted(bundle.keys())}, recommended = "
+        f"{bundle.get('recommended')}"
+    )
+
+
 def test_honest_gap_returns_suggested_skills(repo_metadata: dict[str, Any]) -> None:
     for query, cat in [
         ("I want to use short strategies", "advanced-satellite"),

--- a/skillsets/trade-memory.yaml
+++ b/skillsets/trade-memory.yaml
@@ -26,6 +26,7 @@ required_skills:
   - signal-postmortem
 recommended_skills:
   - backtest-expert
+  - trade-performance-coach
 optional_skills:
   - trade-hypothesis-ideator
 

--- a/workflows/monthly-performance-review.yaml
+++ b/workflows/monthly-performance-review.yaml
@@ -22,6 +22,7 @@ required_skills:
   - trader-memory-core
   - signal-postmortem
 optional_skills:
+  - trade-performance-coach
   - backtest-expert
   - dual-axis-skill-reviewer
 
@@ -32,20 +33,29 @@ artifacts:
   - id: aggregate_postmortem
     produced_by_step: 2
     required: true
-  - id: hypothesis_revalidation
+  - id: monthly_performance_coach_report
     produced_by_step: 3
     required: false
-  - id: skill_review_findings
+  - id: monthly_behavior_patterns
+    produced_by_step: 3
+    required: false
+  - id: next_month_operating_rules
+    produced_by_step: 3
+    required: false
+  - id: hypothesis_revalidation
     produced_by_step: 4
     required: false
-  - id: monthly_decision_log
+  - id: skill_review_findings
     produced_by_step: 5
+    required: false
+  - id: monthly_decision_log
+    produced_by_step: 6
     required: true
   - id: rule_changes_for_next_month
-    produced_by_step: 5
+    produced_by_step: 6
     required: true
   - id: skill_improvement_backlog
-    produced_by_step: 5
+    produced_by_step: 6
     required: false
 
 # final_outputs separates trade-side improvements from repo-side improvements.
@@ -79,6 +89,22 @@ steps:
       thesis quality, execution, market environment, and randomness.
 
   - step: 3
+    name: Coach monthly process, risk, and behavior patterns
+    skill: trade-performance-coach
+    optional: true
+    consumes:
+      - monthly_aggregate
+      - aggregate_postmortem
+    produces:
+      - monthly_performance_coach_report
+      - monthly_behavior_patterns
+      - next_month_operating_rules
+    decision_gate: true
+    decision_question: >-
+      Which next-month operating rules should be accepted, modified, deferred,
+      or journaled only?
+
+  - step: 4
     name: Re-validate hypotheses via backtest
     skill: backtest-expert
     optional: true
@@ -88,7 +114,7 @@ steps:
       - hypothesis_revalidation
     decision_gate: false
 
-  - step: 4
+  - step: 5
     name: Review which skills helped or hurt
     skill: dual-axis-skill-reviewer
     optional: true
@@ -98,7 +124,7 @@ steps:
       - skill_review_findings
     decision_gate: false
 
-  - step: 5
+  - step: 6
     name: Produce decision log and rule changes
     skill: trader-memory-core
     consumes:

--- a/workflows/trade-memory-loop.yaml
+++ b/workflows/trade-memory-loop.yaml
@@ -12,8 +12,9 @@ api_profile: no-api-basic
 
 when_to_run: >-
   Every time a position is closed (full or partial exit). Records the outcome,
-  generates a postmortem, and (optionally) re-validates the original hypothesis
-  via backtest.
+  generates a postmortem, (optionally) coaches process / risk / execution /
+  behavior patterns, and (optionally) re-validates the original hypothesis via
+  backtest.
 when_not_to_run: >-
   Do not run before a position is closed — use trader-memory-core directly to
   update an open thesis instead. Do not skip this loop after a closed trade,
@@ -23,6 +24,7 @@ required_skills:
   - trader-memory-core
   - signal-postmortem
 optional_skills:
+  - trade-performance-coach
   - backtest-expert
 
 artifacts:
@@ -34,11 +36,21 @@ artifacts:
     required: true
     downstream_hints:
       - monthly-performance-review
-  - id: backtest_validation
+  - id: performance_coach_report
     produced_by_step: 3
     required: false
-  - id: lessons_log_entry
+    downstream_hints:
+      - monthly-performance-review
+  - id: next_session_operating_rules
+    produced_by_step: 3
+    required: false
+    downstream_hints:
+      - monthly-performance-review
+  - id: backtest_validation
     produced_by_step: 4
+    required: false
+  - id: lessons_log_entry
+    produced_by_step: 5
     required: true
     downstream_hints:
       - monthly-performance-review
@@ -64,6 +76,21 @@ steps:
       market environment, or randomness? Classify and document.
 
   - step: 3
+    name: Coach process, risk, and behavior patterns
+    skill: trade-performance-coach
+    optional: true
+    consumes:
+      - closed_thesis_record
+      - postmortem_findings
+    produces:
+      - performance_coach_report
+      - next_session_operating_rules
+    decision_gate: true
+    decision_question: >-
+      Which next-session operating rules should the trader accept, modify,
+      defer, or journal only?
+
+  - step: 4
     name: Re-validate hypothesis via backtest
     skill: backtest-expert
     optional: true
@@ -73,7 +100,7 @@ steps:
       - backtest_validation
     decision_gate: false
 
-  - step: 4
+  - step: 5
     name: Append lessons to journal
     skill: trader-memory-core
     consumes:


### PR DESCRIPTION
## Summary
Apply the upstream package's workflow patch for the post-trade-coaching step that landed standalone in PR #145. `trade-performance-coach` now appears as an **optional step 3** in both `trade-memory-loop` and `monthly-performance-review`, with the existing `backtest-expert` / journal steps **renumbered** accordingly.

## Why now (after PR #145, not bundled with it)
PR #145 shipped the skill standalone with \`skills-index.yaml workflows: []\` deliberately so the catalog and Navigator didn't claim workflow integration before it landed. This PR completes the integration:
- Workflow YAMLs gain the new step + artifact + decision_gate
- `skillsets/trade-memory.yaml` adds the skill to `recommended_skills`
- `skills-index.yaml workflows` is populated with the two workflow IDs
- Generated workflow / skillset docs + Navigator snapshot are regenerated

## Step-level changes

### `trade-memory-loop.yaml`
| Step | Before | After |
|---|---|---|
| 1 | trader-memory-core (record) | unchanged |
| 2 | signal-postmortem (postmortem) | unchanged |
| 3 | **backtest-expert (optional)** | **trade-performance-coach (NEW, optional, decision_gate)** |
| 4 | **trader-memory-core (lessons)** | **backtest-expert (renumbered, unchanged content)** |
| 5 | — | **trader-memory-core (lessons, renumbered)** |

New artifacts at step 3: `performance_coach_report`, `next_session_operating_rules` (both `required: false`, `downstream_hint: monthly-performance-review`). All `produced_by_step` references updated to match the new numbering.

### `monthly-performance-review.yaml`
| Step | Before | After |
|---|---|---|
| 1-2 | trader-memory-core (aggregate), signal-postmortem | unchanged |
| 3 | **backtest-expert (optional)** | **trade-performance-coach (NEW, optional, decision_gate)** |
| 4 | **dual-axis-skill-reviewer (optional)** | **backtest-expert (renumbered)** |
| 5 | **trader-memory-core (decision log)** | **dual-axis-skill-reviewer (renumbered)** |
| 6 | — | **trader-memory-core (decision log, renumbered)** |

New artifacts at step 3: `monthly_performance_coach_report`, `monthly_behavior_patterns`, `next_month_operating_rules` (all `required: false`).

## Scope safety
- Workflow YAML edits limited to the two `trade-memory-loop` / `monthly-performance-review` manifests
- `optional: true` set on all new steps (author patch convention; validator enforces this)
- All step renumbers carry through to `produced_by_step` artifact references
- All four drift gates (workflow-docs-drift, skillset-docs-drift, catalog-drift, navigator-snapshot-drift) pass
- `examples/workflows/trade-memory-loop/` artifacts intentionally **unchanged** (PR #141 samples remain valid for the required-only path; full-path coaching sample is deferred per the plan)

## Test plan
- [x] `python3 scripts/validate_skills_index.py --strict-workflows --strict-metadata` → **OK**
- [x] `python3 scripts/generate_workflow_docs.py` → 5 workflows regenerated cleanly
- [x] `python3 scripts/generate_skillset_docs.py` → 4 skillsets regenerated cleanly
- [x] `python3 skills/trading-skills-navigator/scripts/build_snapshot.py` → metadata snapshot regenerated; both patched workflows reference `trade-performance-coach`
- [x] All pre-commit hooks pass (workflow-docs-drift / skillset-docs-drift / validate-skills-index / validate-skillsets / catalog-drift / navigator-snapshot-drift / skill-frontmatter / docs-completeness)
- [x] pre-push `scripts/run_all_tests.sh` pass
- [ ] Reviewer confirms the postmortem → coach → backtest → journal logical order matches author intent
- [ ] Reviewer confirms all `produced_by_step` updates are consistent with the new numbering

## Out of scope (deferred)
- `examples/workflows/trade-memory-loop/sample-run-full-path/` coaching artifact addition → defer (protect PR #141)
- Hermes companion bundle/prompt → external Hermes repo follow-up
- `PROJECT_VISION.md` Phase 5 update mentioning post-trade-coaching → follow-up after this PR merges (avoid premature Done writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)