### PR TITLE
fix(skills): breadth-analyzer mkdir note + top-detector fallback sources + .gitignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ env/
 # Tool configurations
 .idea/
 .vscode/
+.claude/
 .envrc
 .mcp.json
 

--- a/scripts/tests/test_skill_generation_pipeline.py
+++ b/scripts/tests/test_skill_generation_pipeline.py
@@ -638,6 +638,16 @@ def test_daily_flow_success(pipeline_module, tmp_path: Path):
         # build_design_prompt
         if "build_design_prompt" in cmd_str:
             return CompletedProcess(cmd, 0, "design prompt text", "")
+        # reviewer (auto score) — check before "claude -p" because the reviewer command's
+        # --project-root path may contain "claude" and "--project-root" contains "-p"
+        if "run_dual_axis_review" in cmd_str:
+            # Create a report JSON
+            report_dir = tmp_path / "reports"
+            report_dir.mkdir(parents=True, exist_ok=True)
+            report = {"auto_review": {"score": 85, "improvement_items": []}}
+            report_path = report_dir / "skill_review_test-new-skill_2026.json"
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+            return CompletedProcess(cmd, 0, "", "")
         # claude -p (design step) - also create SKILL.md as side effect
         if "claude" in cmd_str and "-p" in cmd_str:
             skill_dir = tmp_path / "skills" / "test-new-skill"
@@ -648,15 +658,6 @@ def test_daily_flow_success(pipeline_module, tmp_path: Path):
         if "diff" in cmd_str and "--name-only" in cmd_str and "HEAD" in cmd_str:
             return CompletedProcess(cmd, 0, "skills/test-new-skill/SKILL.md\n", "")
         if "ls-files" in cmd_str:
-            return CompletedProcess(cmd, 0, "", "")
-        # reviewer (auto score)
-        if "run_dual_axis_review" in cmd_str:
-            # Create a report JSON
-            report_dir = tmp_path / "reports"
-            report_dir.mkdir(parents=True, exist_ok=True)
-            report = {"auto_review": {"score": 85, "improvement_items": []}}
-            report_path = report_dir / "skill_review_test-new-skill_2026.json"
-            report_path.write_text(json.dumps(report), encoding="utf-8")
             return CompletedProcess(cmd, 0, "", "")
         # ruff
         if "ruff" in cmd_str:

--- a/skills/market-breadth-analyzer/SKILL.md
+++ b/skills/market-breadth-analyzer/SKILL.md
@@ -50,13 +50,17 @@ Quantify market breadth health using a data-driven 6-component scoring system (0
 
 ### Phase 1: Execute Python Script
 
-Run the analysis script:
+Run the analysis script. If using a nested or date-stamped `--output-dir` in cron runs, create it first; the history writer expects the directory to already exist.
 
 ```bash
+mkdir -p reports/<routine-or-date>
 python3 skills/market-breadth-analyzer/scripts/market_breadth_analyzer.py \
   --detail-url "https://tradermonty.github.io/market-breadth-analysis/market_breadth_data.csv" \
-  --summary-url "https://tradermonty.github.io/market-breadth-analysis/market_breadth_summary.csv"
+  --summary-url "https://tradermonty.github.io/market-breadth-analysis/market_breadth_summary.csv" \
+  --output-dir reports/<routine-or-date>
 ```
+
+For a simple ad-hoc run, omit `--output-dir` or use an existing directory.
 
 The script will:
 1. Fetch detail CSV (~2,500 rows, 2016-present) and summary CSV (8 metrics)

--- a/skills/market-top-detector/SKILL.md
+++ b/skills/market-top-detector/SKILL.md
@@ -75,6 +75,7 @@ Before running the Python script, collect the following data using WebSearch.
    Valid range: 20-100
    Primary search: "S&P 500 percent stocks above 50 day moving average"
    Fallback: "market breadth 50dma site:barchart.com"
+   Direct fallback when search snippets are poor: fetch `https://www.barchart.com/stocks/quotes/$S5FI/overview` and extract the embedded `lastPrice` / `tradeTime` for “S&P 500 Stocks Above 50-Day Average”.
    Record the data date
 
 3. [REQUIRED] CBOE Equity Put/Call Ratio
@@ -82,6 +83,7 @@ Before running the Python script, collect the following data using WebSearch.
    Primary search: "CBOE equity put call ratio today"
    Fallback: "CBOE total put call ratio current"
    Fallback: "put call ratio site:cboe.com"
+   Direct fallback when Cboe CSV endpoints are stale: fetch `https://ycharts.com/indicators/cboe_equity_put_call_ratio` and parse the “Last Value” / “Latest Period” table fields. Treat this as a secondary source and cite it in freshness notes.
    Record the data date
 
 4. [OPTIONAL] VIX Term Structure


### PR DESCRIPTION
## Summary

- **market-breadth-analyzer SKILL.md**: Add `mkdir -p` instruction before the example command so cron/routine runs with a nested or date-stamped `--output-dir` don't fail because the directory doesn't exist. Update the example to pass `--output-dir reports/<routine-or-date>`, and add a note for simple ad-hoc runs.

- **market-top-detector SKILL.md**: Two new data-source fallbacks when primary search returns poor results or stale data:
  - S&P 500 50DMA breadth → fetch Barchart `$S5FI` overview page, extract `lastPrice` / `tradeTime`.
  - CBOE Equity Put/Call Ratio → fetch YCharts indicator page, parse "Last Value" / "Latest Period" table.

- **.gitignore**: Add `.claude/` so Claude Code local settings (`settings.local.json`, lock files) are never accidentally committed.

Also includes the same `fake_run` check-order fix for `test_daily_flow_success` (cherry-picked from #148) since this branch splits from main.

## Test plan

- [ ] Pre-push hook (all 46 skill test suites + repo tests) → green ✓
- [ ] `test_daily_flow_success` → PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)