### PR TITLE
fix: correct skill name typo in Strategic Positioning workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The main Core + Satellite starting path is described above. The examples below s
 4. Use **Backtest Expert** to validate entry/exit strategies before position sizing
 
 ### Strategic Positioning
-1. Use **Stanley Druckenmiller Investment Advisor** for macro theme identification
+1. Use **Stanley Druckenmiller Investment** for macro theme identification
 2. Use **Economic Calendar Fetcher** to time entries around major data releases
 3. Use **Breadth Chart Analyst** and **Technical Analyst** for confirmation signals
 4. Use **US Market Bubble Detector** for risk management and profit-taking guidance


### PR DESCRIPTION
## Summary

- Fixes an incorrect skill name in the **Strategic Positioning** workflow section of README.md
- `Stanley Druckenmiller Investment Advisor` -> `Stanley Druckenmiller Investment`
- The skill is named `stanley-druckenmiller-investment` in skills-index.yaml and the catalog; 'Advisor' was a stray extra word in this one line

## Test plan

- [x] Corrected name matches the catalog entry (README.md line 192)
- [x] No other occurrences of the incorrect name exist in the repo