### PR TITLE
docs(playbook): cross-asset quant strategy + multi-asset-opportunity-daily workflow

### DIFF
--- a/docs/en/playbooks/quant-strategy-framework.md
+++ b/docs/en/playbooks/quant-strategy-framework.md
@@ -1,0 +1,278 @@
+---
+layout: default
+title: Quant Strategy Framework
+parent: English
+nav_order: 10
+lang_peer: /ja/playbooks/quant-strategy-framework/
+permalink: /en/playbooks/quant-strategy-framework/
+---
+
+# Cross-Asset Quant Strategy — Pre / During / Post Framework
+{: .no_toc }
+
+The playbook that wires this project's skills + API clients into one process across equities, forex (research-only), commodities, options, and thematic plays.
+{: .fs-6 .fw-300 }
+
+**This framework is research-and-decision-support only.** All execution stays manual — every artifact carries `manual_review_required: true` and a `data_gaps[]` array. You always pull the trigger.
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## The spine — applies to every asset class
+
+Three loops run continuously:
+
+| Loop | Cadence | Output |
+|---|---|---|
+| Macro regime | Weekly | Risk-on / risk-off / transitioning posture |
+| Idea generation | Daily | Ranked candidates with hypothesis cards |
+| Position lifecycle | Per trade | Pre → During → Post |
+
+### The 7-layer signal stack
+
+A trade only earns capital if **layers 1–5 align**:
+
+```
+1. Macro regime          → BISClient, BLSClient, BEAClient, EIAClient
+2. Theme / sector        → theme-detector, sector-analyst
+3. Asset-class screener  → VCP / CANSLIM / PEAD / Dividend / Parabolic
+4. Setup confirmation    → technical-analyst (chart), breakout-trade-planner
+5. What's priced in      → PolymarketClient, NewsClient, FMP consensus
+                          (see references/what-is-priced-in-framework.md)
+6. Sizing                → position-sizer (R-multiples), exposure-coach
+7. Postmortem            → signal-postmortem, trader-memory-core
+```
+
+### The kill rule
+
+Every trade must have a **written thesis** before entry, a **kill criterion** (what makes this wrong), and a **journal entry** after exit. No exceptions. This *is* the manual review gate.
+
+---
+
+## 1. Equities — Industry / Single Stock / Sector
+
+**Scope:** US-listed stocks + sector/thematic ETFs. Swing (3–30 days) or position (1–6 months).
+
+### PRE
+
+| Step | Tool | Output |
+|---|---|---|
+| 1. Idea source | `vcp-screener` (bullish swing), `canslim-screener` (growth), `pead-screener` (earnings drift), `parabolic-short-trade-planner` (mean-reversion shorts), `dividend-growth-pullback-screener` (quality dip) | Ranked candidates |
+| 2. Theme context | `theme-detector` | Filter to top-3 accelerating themes |
+| 3. Chart confirmation | `technical-analyst` (chart image) | Yes/no on visual pattern |
+| 4. Trigger levels | `breakout-trade-planner` | 5-min ORL, breakout extension, invalidation level |
+| 5. Earnings reaction history | `earnings-trade-analyzer` | Don't fight buy-rumor-sell-news patterns |
+| 6. What's priced in | `PolymarketClient`, `NewsClient`, FMP consensus vs your estimate | Gap = (your view − consensus) × reaction function |
+| 7. Hypothesis card | `trade-hypothesis-ideator` → `trader-memory-core` IDEA → ENTRY_READY | Thesis + kill criterion + R-target + time-stop |
+| 8. Sizing | `position-sizer` (stop-loss or Kelly) | Shares + dollar risk |
+| 9. Portfolio check | `exposure-coach` | Sector cap, breadth posture, ceiling % |
+
+### DURING
+
+- **Daily morning:** run `market-regime-daily` workflow (breadth + uptrend + exposure). If composite drops a tier → tighten stops, no new entries.
+- **News monitor:** `NewsClient.get_market_news(tickers=[...], days=1)` — any thesis-killing headline.
+- **PEAD plays:** watch SIGNAL_READY → BREAKOUT transitions.
+- **Earnings during hold:** size down to ⅓ or close before print, unless earnings *is* the thesis.
+
+### POST
+
+- `trader-memory-core` → CLOSED with realized R, MAE/MFE.
+- `signal-postmortem`: what worked, what didn't, was the kill criterion respected, was sizing correct.
+- Roll lessons into `monthly-performance-review`.
+
+---
+
+## 2. Forex — Research Only
+
+**Scope:** Directional bias for USD/JPY, EUR/USD, GBP/USD, AUD/USD, USD/CAD. **Output is a research artifact**, not orders. Execution lives in a separate project; this project must never import from it.
+
+### PRE (research)
+
+| Step | Tool | Signal |
+|---|---|---|
+| 1. Rate differential | `BISClient.rate_differential("US", "JP")` | Carry tailwind / headwind in pp |
+| 2. US macro | `BLSClient.get_named("unemployment_rate")`, `BLSClient.get_named("cpi_core")`, `BEAClient.real_gdp_growth()` | Fed hawkish/dovish bias |
+| 3. Counterparty macro | `EStatClient.cpi_national()` for JPY; commodity for AUD/CAD | Cross-country surprise potential |
+| 4. Commodity beta | `EIAClient.natural_gas_spot()`, `CommodityClient.latest(["WTI", "GOLD"])` | AUD = iron-ore + copper; CAD = WTI; gold = USD inverse |
+| 5. Catalyst pricing | `PolymarketClient.search_markets("Fed cut")` | Implied probability of policy move |
+| 6. Research artifact | Markdown report with `manual_review_required: true` + `data_gaps[]` | Directional bias score (−5 … +5), no trade ticket |
+
+### DURING (monitoring research)
+
+- Watch BLS NFP, CPI prints (Finnhub econ calendar)
+- BIS rate revisions monthly
+- News via `NewsClient`
+
+### POST (research calibration)
+
+- Did the rate-differential thesis play out?
+- Calibrate: which BIS countries / BLS series have the highest hit rate for predicting direction?
+- Log to `trader-memory-core` with `research_only: true`
+
+### Explicitly OUT
+
+Order placement, stops, broker code — lives in the separate forex project. Release gate enforces this.
+
+---
+
+## 3. Commodities
+
+**Scope:** Energy (WTI, Brent, nat gas), precious (gold, silver), industrial (copper). Trade via **equity proxy ETFs/stocks** (XLE, USO, GLD, GDX, FCX) — futures are out of scope.
+
+### PRE
+
+| Step | Tool | Signal |
+|---|---|---|
+| 1. Fundamental driver | `EIAClient.electricity_demand("PJM")` (AI power demand), `EIAClient.natural_gas_spot()` (gas), `EIAClient.power_demand_yoy()` | YoY inflection? |
+| 2. Spot prices | `CommodityClient.latest(["BRENT", "GOLD", "COPPER"])` | Where are we vs 30-day range |
+| 3. Series trend | `CommodityClient.time_series("BRENT", start, end)` | Direction over last 30d |
+| 4. Theme context | `theme-detector` — Oil & Gas, Gold & Precious Metals, Power Infrastructure | Confirm theme heat ≥ 60, lifecycle = Accelerating |
+| 5. Spark spread (for IPPs) | `(power_price) − (gas_price × heat_rate)` using EIA data | Widening = bullish VST/NRG/TLN; compressing = bearish |
+| 6. Equity expression | Pick proxies — energy long: XLE/XOP/OIH or VST/CEG/EQT; gold: GDX/GLD/NEM; copper: FCX | One equity per thesis |
+| 7. What's priced in | Polymarket OPEC + Fed cut markets, implied vol of commodity ETF | Surprise potential |
+
+### DURING
+
+- Spark spread on a weekly watch — widening confirms thesis on IPPs
+- News for geopolitical (Mid-East, Russia, OPEC) via `NewsClient`
+- EIA inventory prints (weekly)
+
+### POST
+
+- Did EIA prints confirm the demand thesis?
+- Calibrate your power-demand model vs actual
+- Roll to `trader-memory-core`
+
+---
+
+## 4. Options
+
+**Scope:** Defined-risk strategies on liquid US tickers. **No naked options** (uncapped risk).
+
+### PRE
+
+**1. Underlying must already be a §1 high-conviction equity setup.** Options are an *expression*, not a thesis source.
+
+**2. Strategy selection — decision tree:**
+
+| Bias | IV regime | Strategy |
+|---|---|---|
+| Bullish | High IV | **Bull put spread** (sell premium, defined risk) |
+| Bullish | Low IV | **Bull call spread** or **long call** (buy cheap directional) |
+| Bullish + own stock | any | **Covered call** (yield enhancement) |
+| Range-bound | High IV | **Iron condor** |
+| Bearish | High IV | **Bear call spread** |
+| Bearish | Low IV | **Bear put spread** or **long put** |
+
+**3. Validation:** `options-strategy-advisor` for Black-Scholes pricing + Greeks + scenario analysis. **Probability of profit ≥ 60%** as the floor.
+
+**4. Sizing:** max loss per trade = `position-sizer` R amount. Net debit OR max-loss of credit spread ≤ R.
+
+**5. What's priced in:** IV percentile vs 1Y range (premium-rich vs cheap). At earnings: straddle price = market's expected move — compare to your own move estimate.
+
+### DURING
+
+- Monitor **delta** (directional risk) and **theta** (decay benefit)
+- **Close winners at 50% max profit** (don't squeeze last 25%)
+- Adjust on **tested short strike**: roll out + down/up
+- **Earnings during hold:** close or roll. Never hold short-vol through binary event.
+
+### POST
+
+- Realized P&L vs theoretical max
+- **Greek attribution**: how much P&L came from delta vs theta vs vega
+- `signal-postmortem` with IV regime context
+
+---
+
+## 5. Thematic / Sector Rotation
+
+**Scope:** Multi-week thematic plays via ETFs or basket of top constituents.
+
+### PRE
+
+| Step | Tool | Output |
+|---|---|---|
+| 1. Theme scan | `theme-detector --dynamic-stocks` | Ranked themes by heat + lifecycle |
+| 2. Lifecycle filter | Avoid **Exhausting**, favor **Emerging / Accelerating** | Late-cycle is crowded trade risk |
+| 3. Constituent picks | Top 3-5 stocks per theme by relative strength | Equal-weight basket |
+| 4. ETF expression | Proxy ETF from `skills/theme-detector/references/cross_sector_themes.md` | Single-line expression |
+| 5. Industry confirmation | Industry rank top quartile on FINVIZ | Cross-check on theme detector output |
+| 6. Volume confirmation | `PolygonClient.get_grouped_daily()` | Real institutional flow |
+
+### DURING
+
+- Daily breadth check (`market-breadth-analyzer`) — themes are first to roll when breadth contracts
+- Theme lifecycle drift watch: **exit before Exhausting**, not after
+
+### POST
+
+- Did the proxy ETF outperform SPY by ≥ 5% over the hold?
+- Update theme model with realized success/failure
+
+---
+
+## Cadence — when each routine runs
+
+| When | Routine | Skills / Workflows |
+|---|---|---|
+| **15 min before US open** | Daily regime check | `market-regime-daily` workflow |
+| **Daily, post-close** | News scan, position monitor | `NewsClient.get_market_news(tickers=open_positions)` |
+| **Daily (post-regime)** | Multi-asset opportunity scan | `multi-asset-opportunity-daily` workflow (this playbook in flow form) |
+| **Weekly (Sunday)** | Fresh candidates + macro refresh | `swing-opportunity-daily`, `theme-detector`, BIS/BLS/BEA refresh |
+| **Monthly** | Performance + calibration | `monthly-performance-review`, `signal-postmortem` aggregation |
+| **Per trade — Pre** | Hypothesis card + sizing | `trade-hypothesis-ideator`, `position-sizer`, `exposure-coach`, `trader-memory-core` IDEA → ENTRY_READY |
+| **Per trade — During** | Daily kill check, news monitor | `trader-memory-core` review-due, `NewsClient` |
+| **Per trade — Post** | Close, MAE/MFE, lessons | `trader-memory-core` CLOSED, `signal-postmortem` |
+
+---
+
+## Toolchain map — every step has exactly one tool
+
+| Need | Tool |
+|---|---|
+| OHLCV (replace yfinance) | `PolygonClient.get_aggs()` |
+| US macro (GDP, savings) | `BEAClient` |
+| US labor + inflation | `BLSClient` |
+| Cross-country rates | `BISClient.rate_differential()` |
+| Energy / power | `EIAClient` |
+| Commodity spot | `CommodityClient.latest()` |
+| Japan macro | `EStatClient` |
+| News + sentiment | `NewsClient` (Marketaux + Newsdata) |
+| Catalyst probability | `PolymarketClient` |
+| Calendars (econ + earnings) | `FinnhubClient` (free) or FMP |
+| Theme detection | `theme-detector` skill |
+| Stock screening | VCP / CANSLIM / PEAD / Dividend / Parabolic skills |
+| Hypothesis card | `trade-hypothesis-ideator` |
+| Sizing | `position-sizer` |
+| Posture / exposure | `exposure-coach` |
+| Memory / journal | `trader-memory-core` |
+| Postmortem | `signal-postmortem` |
+| Backtest | `backtest-expert` |
+
+---
+
+## Out-of-scope (the manual review gate)
+
+- Auto-trade / broker execution / order placement
+- OANDA / forex execution (lives in a separate project)
+- Binance / crypto auto-trade
+- Any closed-loop without human sign-off
+
+Every artifact this framework produces carries `manual_review_required: true` and `data_gaps[]`. You always pull the trigger.
+
+---
+
+## Reference docs in the project
+
+- `skills/theme-detector/references/cross_sector_themes.md` — theme definitions + constituents
+- `skills/theme-detector/references/energy-power-market-signals.md` — spark spread, capacity auctions, LMP mechanics
+- `skills/trade-hypothesis-ideator/references/what-is-priced-in-framework.md` — three model-to-trade frameworks
+- `scripts/api_clients/README.md` — full API client catalog
+- `workflows/` — canonical workflow definitions

--- a/docs/en/workflows.md
+++ b/docs/en/workflows.md
@@ -23,6 +23,7 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 | [`core-portfolio-weekly`](#core-portfolio-weekly) — Core Portfolio Weekly | weekly | 60 | mixed | beginner |
 | [`market-regime-daily`](#market-regime-daily) — Market Regime Daily | daily | 15 | no-api-basic | beginner |
 | [`monthly-performance-review`](#monthly-performance-review) — Monthly Performance Review | monthly | 90 | no-api-basic | intermediate |
+| [`multi-asset-opportunity-daily`](#multi-asset-opportunity-daily) — Multi-Asset Opportunity Daily | daily | 45 | mixed | intermediate |
 | [`swing-opportunity-daily`](#swing-opportunity-daily) — Swing Opportunity Daily | daily | 30 | fmp-required | intermediate |
 | [`trade-memory-loop`](#trade-memory-loop) — Trade Memory Loop | ad-hoc | 30 | no-api-basic | beginner |
 
@@ -212,6 +213,78 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 - `monthly_decision_log` — What trades worked / what did not, by category
 - `rule_changes_for_next_month` — Adjustments to position sizing, entry rules, regime gates
 - `skill_improvement_backlog` — Optional feedback into repo improvement loop (skills / workflows)
+
+**Journal destination:** `trader-memory-core`
+
+---
+
+## Multi-Asset Opportunity Daily {#multi-asset-opportunity-daily}
+
+**`multi-asset-opportunity-daily`** · daily · ~45 min · mixed · intermediate
+
+**When to run:** Only after market-regime-daily has produced a non-restrictive exposure decision. Sweeps macro + themes + news to surface multi-asset ideas (equities, commodities-via-equity-proxies, options expressions) and synthesizes them into ranked hypothesis cards.
+
+**When NOT to run:** Do not run when the latest market-regime-daily exposure_decision is cash-priority. Do not treat hypothesis cards as buy/sell signals — they carry manual_review_required and must pass human sign-off before any capital moves. Forex output is research-only; never feed it into a broker.
+
+**Required skills:** `macro-regime-detector`, `theme-detector`, `trade-hypothesis-ideator`, `position-sizer`, `trader-memory-core`
+
+**Optional skills:** `market-news-analyst`, `market-environment-analysis`, `sector-analyst`, `scenario-analyzer`, `stanley-druckenmiller-investment`
+
+**Prerequisite workflows (informational):**
+
+- `market-regime-daily` expects `exposure_decision` — Multi-asset opportunity scanning requires a non-restrictive exposure posture. Skip on cash-priority days; reduce scope on restrict days.
+
+**Artifacts:**
+
+| Artifact | Produced by step | Required | Downstream hints |
+|---|---|---|---|
+| `macro_regime_brief` | 1 | yes | `swing-opportunity-daily`, `monthly-performance-review` |
+| `hot_themes` | 2 | yes | `swing-opportunity-daily` |
+| `catalyst_news_brief` | 3 | no | — |
+| `hypothesis_cards` | 4 | yes | `swing-opportunity-daily`, `trade-memory-loop` |
+| `sized_hypotheses` | 5 | yes | — |
+| `opportunity_journal_entries` | 6 | yes | `trade-memory-loop`, `monthly-performance-review` |
+
+**Steps:**
+
+**Step 1: Refresh macro regime context** → `macro-regime-detector`
+
+- produces: `macro_regime_brief`
+
+**Step 2: Detect hot themes + sector rotation** → `theme-detector`
+
+- consumes: `macro_regime_brief`
+- produces: `hot_themes`
+
+**Step 3: Scan news + catalyst landscape** (optional) → `market-news-analyst`
+
+- consumes: `hot_themes`
+- produces: `catalyst_news_brief`
+
+**Step 4: Synthesize ranked hypothesis cards** (decision gate) → `trade-hypothesis-ideator`
+
+- consumes: `macro_regime_brief`, `hot_themes`, `catalyst_news_brief`
+- produces: `hypothesis_cards`
+- **Decision:** For each hypothesis, does layer 1 (macro) align with layer 2 (theme) and is what-is-priced-in still favorable? Reject any card where the gap to consensus is unclear or already closed.
+
+**Step 5: Apply risk-based sizing to hypothesis cards** → `position-sizer`
+
+- consumes: `hypothesis_cards`
+- produces: `sized_hypotheses`
+
+**Step 6: Persist as IDEA / ENTRY_READY entries** (decision gate) → `trader-memory-core`
+
+- consumes: `hypothesis_cards`, `sized_hypotheses`
+- produces: `opportunity_journal_entries`
+- **Decision:** Which hypotheses should be promoted from IDEA to ENTRY_READY, which stay as IDEA pending more confirmation, and which are rejected?
+
+**Manual review:**
+
+- Confirm the regime brief does not contradict the exposure_decision from market-regime-daily.
+- Confirm each hypothesis has a written thesis AND a kill criterion.
+- Confirm position sizing respects portfolio risk caps (per-position and per-sector).
+- For forex-related output, confirm research_only=true; never wire to a broker.
+- Confirm IDEA → ENTRY_READY transitions are explicit and reviewed.
 
 **Journal destination:** `trader-memory-core`
 

--- a/docs/ja/workflows.md
+++ b/docs/ja/workflows.md
@@ -25,6 +25,7 @@ permalink: /ja/workflows/
 | [`core-portfolio-weekly`](#core-portfolio-weekly) — Core Portfolio Weekly | weekly | 60 | mixed | beginner |
 | [`market-regime-daily`](#market-regime-daily) — Market Regime Daily | daily | 15 | no-api-basic | beginner |
 | [`monthly-performance-review`](#monthly-performance-review) — Monthly Performance Review | monthly | 90 | no-api-basic | intermediate |
+| [`multi-asset-opportunity-daily`](#multi-asset-opportunity-daily) — Multi-Asset Opportunity Daily | daily | 45 | mixed | intermediate |
 | [`swing-opportunity-daily`](#swing-opportunity-daily) — Swing Opportunity Daily | daily | 30 | fmp-required | intermediate |
 | [`trade-memory-loop`](#trade-memory-loop) — Trade Memory Loop | ad-hoc | 30 | no-api-basic | beginner |
 
@@ -214,6 +215,78 @@ permalink: /ja/workflows/
 - `monthly_decision_log` — What trades worked / what did not, by category
 - `rule_changes_for_next_month` — Adjustments to position sizing, entry rules, regime gates
 - `skill_improvement_backlog` — Optional feedback into repo improvement loop (skills / workflows)
+
+**Journal 出力先:** `trader-memory-core`
+
+---
+
+## Multi-Asset Opportunity Daily {#multi-asset-opportunity-daily}
+
+**`multi-asset-opportunity-daily`** · daily · ~45 min · mixed · intermediate
+
+**実行タイミング:** Only after market-regime-daily has produced a non-restrictive exposure decision. Sweeps macro + themes + news to surface multi-asset ideas (equities, commodities-via-equity-proxies, options expressions) and synthesizes them into ranked hypothesis cards.
+
+**実行してはいけないとき:** Do not run when the latest market-regime-daily exposure_decision is cash-priority. Do not treat hypothesis cards as buy/sell signals — they carry manual_review_required and must pass human sign-off before any capital moves. Forex output is research-only; never feed it into a broker.
+
+**必須スキル:** `macro-regime-detector`, `theme-detector`, `trade-hypothesis-ideator`, `position-sizer`, `trader-memory-core`
+
+**任意スキル:** `market-news-analyst`, `market-environment-analysis`, `sector-analyst`, `scenario-analyzer`, `stanley-druckenmiller-investment`
+
+**前提ワークフロー（informational）:**
+
+- `market-regime-daily` が期待する artifact `exposure_decision` — Multi-asset opportunity scanning requires a non-restrictive exposure posture. Skip on cash-priority days; reduce scope on restrict days.
+
+**artifact 一覧:**
+
+| Artifact | 生成ステップ | 必須 | 下流ヒント |
+|---|---|---|---|
+| `macro_regime_brief` | 1 | あり | `swing-opportunity-daily`, `monthly-performance-review` |
+| `hot_themes` | 2 | あり | `swing-opportunity-daily` |
+| `catalyst_news_brief` | 3 | なし | — |
+| `hypothesis_cards` | 4 | あり | `swing-opportunity-daily`, `trade-memory-loop` |
+| `sized_hypotheses` | 5 | あり | — |
+| `opportunity_journal_entries` | 6 | あり | `trade-memory-loop`, `monthly-performance-review` |
+
+**ステップ:**
+
+**ステップ 1: Refresh macro regime context** → `macro-regime-detector`
+
+- produces: `macro_regime_brief`
+
+**ステップ 2: Detect hot themes + sector rotation** → `theme-detector`
+
+- consumes: `macro_regime_brief`
+- produces: `hot_themes`
+
+**ステップ 3: Scan news + catalyst landscape** （任意） → `market-news-analyst`
+
+- consumes: `hot_themes`
+- produces: `catalyst_news_brief`
+
+**ステップ 4: Synthesize ranked hypothesis cards** （判断ゲート） → `trade-hypothesis-ideator`
+
+- consumes: `macro_regime_brief`, `hot_themes`, `catalyst_news_brief`
+- produces: `hypothesis_cards`
+- **判断:** For each hypothesis, does layer 1 (macro) align with layer 2 (theme) and is what-is-priced-in still favorable? Reject any card where the gap to consensus is unclear or already closed.
+
+**ステップ 5: Apply risk-based sizing to hypothesis cards** → `position-sizer`
+
+- consumes: `hypothesis_cards`
+- produces: `sized_hypotheses`
+
+**ステップ 6: Persist as IDEA / ENTRY_READY entries** （判断ゲート） → `trader-memory-core`
+
+- consumes: `hypothesis_cards`, `sized_hypotheses`
+- produces: `opportunity_journal_entries`
+- **判断:** Which hypotheses should be promoted from IDEA to ENTRY_READY, which stay as IDEA pending more confirmation, and which are rejected?
+
+**手動レビュー:**
+
+- Confirm the regime brief does not contradict the exposure_decision from market-regime-daily.
+- Confirm each hypothesis has a written thesis AND a kill criterion.
+- Confirm position sizing respects portfolio risk caps (per-position and per-sector).
+- For forex-related output, confirm research_only=true; never wire to a broker.
+- Confirm IDEA → ENTRY_READY transitions are explicit and reviewed.
 
 **Journal 出力先:** `trader-memory-core`
 

--- a/skills/trading-skills-navigator/assets/metadata_snapshot.json
+++ b/skills/trading-skills-navigator/assets/metadata_snapshot.json
@@ -1110,6 +1110,36 @@
       ]
     },
     {
+      "api_profile": "mixed",
+      "cadence": "daily",
+      "difficulty": "intermediate",
+      "display_name": "Multi-Asset Opportunity Daily",
+      "estimated_minutes": 45,
+      "id": "multi-asset-opportunity-daily",
+      "optional_skills": [
+        "market-news-analyst",
+        "market-environment-analysis",
+        "sector-analyst",
+        "scenario-analyzer",
+        "stanley-druckenmiller-investment"
+      ],
+      "prerequisite_workflows": [
+        "market-regime-daily"
+      ],
+      "required_skills": [
+        "macro-regime-detector",
+        "theme-detector",
+        "trade-hypothesis-ideator",
+        "position-sizer",
+        "trader-memory-core"
+      ],
+      "target_users": [
+        "part-time-swing-trader",
+        "growth-investor",
+        "macro-discretionary-trader"
+      ]
+    },
+    {
       "api_profile": "fmp-required",
       "cadence": "daily",
       "difficulty": "intermediate",

--- a/skills/trading-skills-navigator/scripts/tests/test_recommend.py
+++ b/skills/trading-skills-navigator/scripts/tests/test_recommend.py
@@ -721,14 +721,15 @@ def test_snapshot_not_drifted_from_ssot(repo_root: Path) -> None:
 def test_resolve_metadata_prefers_ssot(repo_root: Path) -> None:
     md, source = resolve_metadata(repo_root)
     assert source == "ssot"
-    assert len(md["workflows"]) == 5
+    # Expect at least 5 workflows; new workflows can be added without churning this test.
+    assert len(md["workflows"]) >= 5
 
 
 def test_resolve_metadata_falls_back_to_snapshot(tmp_path: Path) -> None:
     # tmp_path has no skills-index.yaml/workflows -> must use bundled snapshot.
     md, source = resolve_metadata(tmp_path)
     assert source == "snapshot"
-    assert len(md["workflows"]) == 5
+    assert len(md["workflows"]) >= 5
 
 
 # ---------------------------------------------------------------------------

--- a/workflows/multi-asset-opportunity-daily.yaml
+++ b/workflows/multi-asset-opportunity-daily.yaml
@@ -1,0 +1,158 @@
+schema_version: 1
+id: multi-asset-opportunity-daily
+display_name: Multi-Asset Opportunity Daily
+cadence: daily
+estimated_minutes: 45
+target_users:
+  - part-time-swing-trader
+  - growth-investor
+  - macro-discretionary-trader
+difficulty: intermediate
+api_profile: mixed
+
+when_to_run: >-
+  Only after market-regime-daily has produced a non-restrictive exposure
+  decision. Sweeps macro + themes + news to surface multi-asset ideas
+  (equities, commodities-via-equity-proxies, options expressions) and
+  synthesizes them into ranked hypothesis cards.
+when_not_to_run: >-
+  Do not run when the latest market-regime-daily exposure_decision is
+  cash-priority. Do not treat hypothesis cards as buy/sell signals — they
+  carry manual_review_required and must pass human sign-off before any
+  capital moves. Forex output is research-only; never feed it into a broker.
+
+required_skills:
+  - macro-regime-detector
+  - theme-detector
+  - trade-hypothesis-ideator
+  - position-sizer
+  - trader-memory-core
+optional_skills:
+  - market-news-analyst
+  - market-environment-analysis
+  - sector-analyst
+  - scenario-analyzer
+  - stanley-druckenmiller-investment
+
+# Informational only — validator does NOT enforce inter-workflow ordering.
+prerequisite_workflows:
+  - id: market-regime-daily
+    artifact: exposure_decision
+    rationale: >-
+      Multi-asset opportunity scanning requires a non-restrictive exposure
+      posture. Skip on cash-priority days; reduce scope on restrict days.
+
+artifacts:
+  - id: macro_regime_brief
+    schema_id: macro_regime_report
+    produced_by_step: 1
+    required: true
+    downstream_hints:
+      - swing-opportunity-daily
+      - monthly-performance-review
+
+  - id: hot_themes
+    schema_id: screen_candidate
+    produced_by_step: 2
+    required: true
+    downstream_hints:
+      - swing-opportunity-daily
+
+  - id: catalyst_news_brief
+    schema_id: scenario_analysis
+    produced_by_step: 3
+    required: false
+
+  - id: hypothesis_cards
+    schema_id: trade_thesis
+    produced_by_step: 4
+    required: true
+    downstream_hints:
+      - swing-opportunity-daily
+      - trade-memory-loop
+
+  - id: sized_hypotheses
+    schema_id: position_sizing_plan
+    produced_by_step: 5
+    required: true
+
+  - id: opportunity_journal_entries
+    schema_id: journal_entry
+    produced_by_step: 6
+    required: true
+    downstream_hints:
+      - trade-memory-loop
+      - monthly-performance-review
+
+steps:
+  - step: 1
+    name: Refresh macro regime context
+    skill: macro-regime-detector
+    produces:
+      - macro_regime_brief
+    decision_gate: false
+
+  - step: 2
+    name: Detect hot themes + sector rotation
+    skill: theme-detector
+    consumes:
+      - macro_regime_brief
+    produces:
+      - hot_themes
+    decision_gate: false
+
+  - step: 3
+    name: Scan news + catalyst landscape
+    skill: market-news-analyst
+    optional: true
+    consumes:
+      - hot_themes
+    produces:
+      - catalyst_news_brief
+    decision_gate: false
+
+  - step: 4
+    name: Synthesize ranked hypothesis cards
+    skill: trade-hypothesis-ideator
+    consumes:
+      - macro_regime_brief
+      - hot_themes
+      - catalyst_news_brief
+    produces:
+      - hypothesis_cards
+    decision_gate: true
+    decision_question: >-
+      For each hypothesis, does layer 1 (macro) align with layer 2 (theme)
+      and is what-is-priced-in still favorable? Reject any card where the
+      gap to consensus is unclear or already closed.
+
+  - step: 5
+    name: Apply risk-based sizing to hypothesis cards
+    skill: position-sizer
+    consumes:
+      - hypothesis_cards
+    produces:
+      - sized_hypotheses
+    decision_gate: false
+
+  - step: 6
+    name: Persist as IDEA / ENTRY_READY entries
+    skill: trader-memory-core
+    consumes:
+      - hypothesis_cards
+      - sized_hypotheses
+    produces:
+      - opportunity_journal_entries
+    decision_gate: true
+    decision_question: >-
+      Which hypotheses should be promoted from IDEA to ENTRY_READY, which
+      stay as IDEA pending more confirmation, and which are rejected?
+
+manual_review:
+  - Confirm the regime brief does not contradict the exposure_decision from market-regime-daily.
+  - Confirm each hypothesis has a written thesis AND a kill criterion.
+  - Confirm position sizing respects portfolio risk caps (per-position and per-sector).
+  - For forex-related output, confirm research_only=true; never wire to a broker.
+  - Confirm IDEA → ENTRY_READY transitions are explicit and reviewed.
+
+journal_destination: trader-memory-core


### PR DESCRIPTION
## Summary

**Split H of 8** from PR #147 per maintainer review.

Two paired additions wiring the existing skills into a runnable cross-asset routine. Pure documentation + one new workflow YAML; no code, no skill behavior changes.

## 1. `docs/en/playbooks/quant-strategy-framework.md` (Jekyll-published)

Cross-asset Pre/During/Post discipline covering 5 asset classes:

- **Equities** — VCP / CANSLIM / PEAD / Dividend / Parabolic screeners → confirmation → hypothesis card → sizing → memory entry
- **Forex (research-only)** — explicitly outputs research artifacts, not orders; broker execution stays out of this project per hard-constraint
- **Commodities** — EIA power demand + spark spread for IPP names, CommodityClient for spot prices, equity-proxy expression
- **Options** — defined-risk strategies only; IV-regime decision tree; 50% max-profit close discipline
- **Thematic / sector rotation** — theme-detector lifecycle filter (avoid Exhausting, favor Emerging/Accelerating)

Plus a 7-layer signal stack (macro → theme → screener → confirmation → what-is-priced-in → sizing → postmortem), the kill rule, a cadence table, and a toolchain map.

## 2. `workflows/multi-asset-opportunity-daily.yaml` (canonical workflow)

6 steps wiring existing skills into a 45-minute daily routine:

1. `macro-regime-detector` → macro_regime_brief
2. `theme-detector` → hot_themes
3. `market-news-analyst` *(optional)* → catalyst_news_brief
4. `trade-hypothesis-ideator` *(decision gate)* → hypothesis_cards
5. `position-sizer` → sized_hypotheses
6. `trader-memory-core` *(decision gate)* → opportunity_journal_entries

Declares `prerequisite_workflows: market-regime-daily` (skip on cash-priority days). Manual review checklist includes "for forex output, confirm `research_only=true`; never wire to a broker".

## Files

- `docs/en/playbooks/quant-strategy-framework.md` — NEW (Jekyll page)
- `workflows/multi-asset-opportunity-daily.yaml` — NEW (canonical workflow)
- `docs/en/workflows.md` + `docs/ja/workflows.md` — regenerated (drift-tracked, now 6 workflows)
- `skills/trading-skills-navigator/assets/metadata_snapshot.json` — regenerated (drift-tracked)
- `skills/trading-skills-navigator/scripts/tests/test_recommend.py` — loosened `len(workflows) == 5` to `>= 5` so future workflow additions don't churn the test

## Verification

- Pre-commit: PASS (ruff/format/codespell/detect-secrets/no-absolute-paths + skills-index + skillsets validators)
- `pytest skills/trading-skills-navigator/scripts/tests/` → **70/70 PASS** (incl. the loosened assertion)
- YAML syntax verified: `yaml.safe_load()` clean
- Drift checks: workflow_docs + navigator_metadata PASS

## NOT in this PR

- The strict workflow validator (`scripts/workflow_runner.py validate`) is part of the institutional hardening (split A, separate PR). Once split A merges, this workflow becomes subject to the WF*** strict-validator rules. I've spot-checked the YAML against the documented schema (`docs/dev/metadata-and-workflow-schema.md`) — required_skills/optional_skills are correctly partitioned (optional-step skills live in optional_skills per WF009).

## Test plan

- [ ] Read the playbook at `docs/en/playbooks/quant-strategy-framework.md` and confirm the pre/during/post discipline matches your operational intent
- [ ] Confirm the workflow YAML follows the schema (compare against existing `market-regime-daily.yaml` / `swing-opportunity-daily.yaml`)
- [ ] Confirm the forex "research-only" framing matches the project's hard-constraint posture
- [ ] Run `pytest skills/trading-skills-navigator/scripts/tests/` → expect 70/70

🤖 Generated with [Claude Code](https://claude.com/claude-code)