### PR TITLE
feat(vcp-screener): FMP free-tier fixes and zero-cost yfinance default provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ env/
 .vscode/
 .claude/
 .envrc
+.env
 .mcp.json
 
 # Logs & temp

--- a/skills/vcp-screener/scripts/fmp_client.py
+++ b/skills/vcp-screener/scripts/fmp_client.py
@@ -122,6 +122,21 @@ def _normalize_eod_flat_list(data, symbols_str: str, limit: Optional[int] = None
     return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
+def _categorize_failure(status: int, body: str) -> str:
+    """Map an HTTP status + body snippet to a human-readable error category."""
+    if status == 403 and "Legacy Endpoint" in body:
+        return "legacy_endpoint_retired"
+    if status == 402 or "Premium" in body or "subscription" in body.lower():
+        return "paid_tier_required"
+    if status == 404:
+        return "symbol_not_found"
+    if status == 429:
+        return "rate_limit_exceeded"
+    if status == 0:
+        return "no_endpoint_available"
+    return f"http_{status}"
+
+
 class FMPClient:
     """Client for Financial Modeling Prep API with rate limiting and caching"""
 
@@ -148,6 +163,11 @@ class FMPClient:
         # Circuit breaker: track consecutive failures per endpoint URL prefix
         self._endpoint_failures: dict[str, int] = {}
         self._disabled_endpoints: set[str] = set()
+        # Track status/body of most recent HTTP call for failure categorisation
+        self._last_request_status: int = 0
+        self._last_request_body: str = ""
+        # Per-symbol quote failure log (symbol, http_status, error_category, endpoint)
+        self.quote_failures: list[dict] = []
 
     def _rate_limited_get(
         self, url: str, params: Optional[dict] = None, quiet: bool = False
@@ -169,8 +189,12 @@ class FMPClient:
 
             if response.status_code == 200:
                 self.retry_count = 0
+                self._last_request_status = 200
+                self._last_request_body = ""
                 return response.json()
             elif response.status_code == 429:
+                self._last_request_status = 429
+                self._last_request_body = response.text[:200]
                 self.retry_count += 1
                 if self.retry_count <= self.max_retries:
                     print("WARNING: Rate limit exceeded. Waiting 60 seconds...", file=sys.stderr)
@@ -181,6 +205,8 @@ class FMPClient:
                     self.rate_limit_reached = True
                     return None
             else:
+                self._last_request_status = response.status_code
+                self._last_request_body = response.text[:200]
                 if not quiet:
                     print(
                         f"ERROR: API request failed: {response.status_code} - {response.text[:200]}",
@@ -196,10 +222,17 @@ class FMPClient:
 
         Returns parsed JSON in v3-compatible shape, or None if all fail.
         Non-last endpoints use quiet=True to suppress expected 403 stderr.
+
+        For quote requests, records per-symbol failures in self.quote_failures.
+        v3 endpoints are disabled immediately on the first "Legacy Endpoint" 403
+        (post-Aug-2025 API keys) rather than waiting for the normal threshold.
         """
         params = dict(extra_params) if extra_params else {}
         endpoints = _FMP_ENDPOINTS[endpoint_key]
         is_single = "," not in symbols_str
+
+        best_fail_status: int = 0
+        best_fail_body: str = ""
 
         for i, (base_url, url_builder) in enumerate(endpoints):
             # Circuit breaker: skip endpoints with too many consecutive failures
@@ -210,7 +243,18 @@ class FMPClient:
             is_last = i == len(endpoints) - 1
             data = self._rate_limited_get(url, final_params, quiet=not is_last)
             if not data:  # falsy (None, [], {}) — try next endpoint
-                self._record_endpoint_failure(base_url)
+                status = self._last_request_status
+                body = self._last_request_body
+                # Keep the most informative failure status seen across endpoints
+                if status > best_fail_status:
+                    best_fail_status = status
+                    best_fail_body = body
+                # Immediately disable v3 on "Legacy Endpoint" 403 — don't wait for threshold.
+                # This avoids silently burning failure budget on a known-dead fallback.
+                if status == 403 and "Legacy Endpoint" in body:
+                    self._disabled_endpoints.add(base_url)
+                else:
+                    self._record_endpoint_failure(base_url)
                 continue
 
             # Normalize new stable EOD flat-list shape to v3-compatible dict.
@@ -263,7 +307,22 @@ class FMPClient:
             if valid:
                 self._endpoint_failures[base_url] = 0
                 return data
+            # Shape-invalid response still counts as a failure
+            status = self._last_request_status
+            body = self._last_request_body
+            if status > best_fail_status:
+                best_fail_status = status
+                best_fail_body = body
             self._record_endpoint_failure(base_url)
+
+        # All endpoints exhausted — record per-symbol failure for quote requests
+        if endpoint_key == "quote":
+            self.quote_failures.append({
+                "symbol": symbols_str,
+                "http_status": best_fail_status,
+                "error_category": _categorize_failure(best_fail_status, best_fail_body),
+                "endpoint": endpoint_key,
+            })
         return None
 
     def _record_endpoint_failure(self, base_url: str) -> None:
@@ -341,6 +400,14 @@ class FMPClient:
         if len(prices) < period:
             return sum(prices) / len(prices)
         return sum(prices[:period]) / period
+
+    def get_quote_failures(self) -> list[dict]:
+        """Return per-symbol quote failures recorded during this session.
+
+        Each entry: {"symbol": str, "http_status": int,
+                     "error_category": str, "endpoint": str}
+        """
+        return list(self.quote_failures)
 
     def get_api_stats(self) -> dict:
         return {

--- a/skills/vcp-screener/scripts/fmp_client.py
+++ b/skills/vcp-screener/scripts/fmp_client.py
@@ -317,7 +317,7 @@ class FMPClient:
     def get_batch_quotes(self, symbols: list[str]) -> dict[str, dict]:
         """Fetch quotes for a list of symbols, batching up to 5 per request"""
         results = {}
-        batch_size = 5
+        batch_size = 1  # stable/quote multi-symbol is paid-only; force single calls
         for i in range(0, len(symbols), batch_size):
             batch = symbols[i : i + batch_size]
             batch_str = ",".join(batch)

--- a/skills/vcp-screener/scripts/report_generator.py
+++ b/skills/vcp-screener/scripts/report_generator.py
@@ -14,7 +14,11 @@ from typing import Optional
 
 
 def generate_json_report(
-    results: list[dict], metadata: dict, output_file: str, all_results: Optional[list[dict]] = None
+    results: list[dict],
+    metadata: dict,
+    output_file: str,
+    all_results: Optional[list[dict]] = None,
+    skipped: Optional[list[dict]] = None,
 ):
     """Generate JSON report with screening results.
 
@@ -23,6 +27,7 @@ def generate_json_report(
         metadata: Screening metadata
         output_file: Output file path
         all_results: Full candidate list for summary stats (defaults to results)
+        skipped: Per-symbol quote failures from FMPClient.get_quote_failures()
     """
     summary_source = all_results if all_results is not None else results
     sector_counts = {}
@@ -30,22 +35,28 @@ def generate_json_report(
         s = stock.get("sector", "Unknown")
         sector_counts[s] = sector_counts.get(s, 0) + 1
 
+    skipped_list = skipped or []
     report = {
         "schema_version": "1.0",
         "metadata": metadata,
         "results": results,
+        "skipped_symbols": skipped_list,
         "summary": _generate_summary(summary_source),
         "sector_distribution": sector_counts,
     }
 
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         json.dump(report, f, indent=2, default=str)
 
     print(f"  JSON report saved to: {output_file}")
 
 
 def generate_markdown_report(
-    results: list[dict], metadata: dict, output_file: str, all_results: Optional[list[dict]] = None
+    results: list[dict],
+    metadata: dict,
+    output_file: str,
+    all_results: Optional[list[dict]] = None,
+    skipped: Optional[list[dict]] = None,
 ):
     """Generate Markdown report with VCP screening results.
 
@@ -54,8 +65,19 @@ def generate_markdown_report(
         metadata: Screening metadata
         output_file: Output file path
         all_results: Full candidate list for summary stats (defaults to results)
+        skipped: Per-symbol quote failures from FMPClient.get_quote_failures()
     """
+    skipped_list = skipped or []
     lines = []
+
+    # Warning banner when symbols were silently skipped
+    if skipped_list:
+        lines.append(
+            f"> **WARNING:** {len(skipped_list)} symbol(s) could not be quoted and are "
+            "excluded from rankings. Results may be incomplete. "
+            "See **Skipped Symbols** section below."
+        )
+        lines.append("")
 
     # Header
     lines.append("# VCP Screener Report - Minervini Volatility Contraction Pattern")
@@ -72,10 +94,31 @@ def generate_markdown_report(
     lines.append("| Stage | Count |")
     lines.append("|-------|-------|")
     lines.append(f"| Universe | {funnel.get('universe', 'N/A')} |")
+    lines.append(f"| Quotes fetched | {funnel.get('quotes_fetched', 'N/A')} |")
+    if funnel.get("symbols_skipped", 0):
+        lines.append(f"| Symbols skipped (no quote) | {funnel['symbols_skipped']} ⚠️ |")
     lines.append(f"| Pre-filter passed | {funnel.get('pre_filter_passed', 'N/A')} |")
     lines.append(f"| Trend Template passed | {funnel.get('trend_template_passed', 'N/A')} |")
     lines.append(f"| VCP candidates | {funnel.get('vcp_candidates', len(results))} |")
     lines.append("")
+
+    # Skipped symbols table
+    if skipped_list:
+        lines.append("## Skipped Symbols")
+        lines.append("")
+        lines.append(
+            "These symbols were excluded because the FMP API returned no quote data. "
+            "Rankings are based on the quoted universe only."
+        )
+        lines.append("")
+        lines.append("| Symbol | HTTP Status | Reason |")
+        lines.append("|--------|-------------|--------|")
+        for entry in skipped_list:
+            sym = entry.get("symbol", "?")
+            status = entry.get("http_status", "?")
+            cat = entry.get("error_category", "unknown")
+            lines.append(f"| {sym} | {status} | {cat} |")
+        lines.append("")
 
     # Show "top X of Y" when not all results are displayed
     total_candidates = len(all_results) if all_results is not None else len(results)
@@ -210,7 +253,7 @@ def generate_markdown_report(
     )
     lines.append("")
 
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         f.write("\n".join(lines))
 
     print(f"  Markdown report saved to: {output_file}")

--- a/skills/vcp-screener/scripts/screen_vcp.py
+++ b/skills/vcp-screener/scripts/screen_vcp.py
@@ -220,7 +220,7 @@ def pre_filter_stock(quote: dict) -> tuple:
     price = quote.get("price", 0)
     year_high = quote.get("yearHigh", 0)
     year_low = quote.get("yearLow", 0)
-    avg_volume = quote.get("avgVolume", 0)
+    avg_volume = quote.get("avgVolume") or quote.get("volume", 0)  # stable omits avgVolume
 
     if price <= 10:
         return False, 0

--- a/skills/vcp-screener/scripts/screen_vcp.py
+++ b/skills/vcp-screener/scripts/screen_vcp.py
@@ -532,7 +532,10 @@ def main():
     # Batch fetch quotes
     print("  Fetching quotes...", end=" ", flush=True)
     all_quotes = client.get_batch_quotes(symbols)
-    print(f"OK ({len(all_quotes)} quotes)")
+    quote_failures = client.get_quote_failures()
+    skipped_count = len(quote_failures)
+    suffix = f", {skipped_count} skipped" if skipped_count else ""
+    print(f"OK ({len(all_quotes)} quotes{suffix})")
 
     # Apply pre-filter
     print("  Applying pre-filter...", end=" ", flush=True)
@@ -750,6 +753,8 @@ def main():
         },
         "funnel": {
             "universe": len(symbols),
+            "quotes_fetched": len(all_quotes),
+            "symbols_skipped": len(quote_failures),
             "pre_filter_passed": len(pre_filtered),
             "trend_template_passed": len(trend_passed),
             "vcp_candidates": len(results),
@@ -759,8 +764,8 @@ def main():
 
     top_results = results[: args.top]
 
-    generate_json_report(top_results, metadata, json_file, all_results=results)
-    generate_markdown_report(top_results, metadata, md_file, all_results=results)
+    generate_json_report(top_results, metadata, json_file, all_results=results, skipped=quote_failures)
+    generate_markdown_report(top_results, metadata, md_file, all_results=results, skipped=quote_failures)
 
     # ========================================================================
     # Summary

--- a/skills/vcp-screener/scripts/screen_vcp.py
+++ b/skills/vcp-screener/scripts/screen_vcp.py
@@ -2,18 +2,21 @@
 """
 VCP Stock Screener - Main Orchestrator
 
-Screens S&P 500 stocks for Mark Minervini's Volatility Contraction Pattern (VCP).
+Screens stocks for Mark Minervini's Volatility Contraction Pattern (VCP).
 Uses a 3-phase pipeline: Pre-filter -> Trend Template -> VCP Detection & Scoring.
 
 Usage:
-    # Default (S&P 500, top 100 candidates, free tier API)
-    python3 screen_vcp.py --api-key YOUR_KEY
+    # Default: yfinance provider, curated ~100-stock starter universe (no API key needed)
+    python3 screen_vcp.py
 
-    # Custom universe
+    # Custom universe (yfinance, no API key needed)
     python3 screen_vcp.py --universe AAPL NVDA MSFT AMZN META
 
-    # Full S&P 500 (requires paid API tier)
-    python3 screen_vcp.py --full-sp500
+    # FMP provider (requires FMP API key)
+    python3 screen_vcp.py --provider fmp --api-key YOUR_KEY
+
+    # Full S&P 500 via FMP (requires paid FMP tier)
+    python3 screen_vcp.py --provider fmp --api-key YOUR_KEY --full-sp500
 
 Output:
     - JSON: vcp_screener_YYYY-MM-DD_HHMMSS.json
@@ -39,9 +42,9 @@ from calculators.relative_strength_calculator import (
 from calculators.trend_template_calculator import calculate_trend_template
 from calculators.vcp_pattern_calculator import calculate_vcp_pattern
 from calculators.volume_pattern_calculator import calculate_volume_pattern
-from fmp_client import FMPClient
 from report_generator import generate_json_report, generate_markdown_report
 from scorer import calculate_composite_score
+from universe import NAME_MAP, SECTOR_MAP, STARTER_UNIVERSE
 
 
 def parse_arguments():
@@ -50,7 +53,13 @@ def parse_arguments():
     )
 
     parser.add_argument(
-        "--api-key", help="FMP API key (defaults to FMP_API_KEY environment variable)"
+        "--provider",
+        choices=["yfinance", "fmp"],
+        default="yfinance",
+        help="Data provider: 'yfinance' (default, no key needed) or 'fmp' (requires API key)",
+    )
+    parser.add_argument(
+        "--api-key", help="FMP API key (defaults to FMP_API_KEY environment variable). Required only for --provider fmp."
     )
     parser.add_argument(
         "--max-candidates",
@@ -193,6 +202,15 @@ def parse_arguments():
         parser.error("--lookback-days must be 30-365")
 
     return args
+
+
+def _derive_quote_yf(symbol: str, hist: list[dict]) -> dict:
+    """Derive pre-filter quote fields from OHLCV history (yfinance path).
+
+    Wraps yf_client._derive_quote so screen_vcp.py owns the import.
+    """
+    from yf_client import _derive_quote
+    return _derive_quote(symbol, hist)
 
 
 def passes_trend_filter(tt_result: dict, trend_min_score: float = 85.0) -> bool:
@@ -477,6 +495,37 @@ def compute_entry_ready(
     return True
 
 
+def _check_full_sp500_yfinance(args) -> None:
+    """Hard-stop when --full-sp500 is used with --provider yfinance.
+
+    yfinance v1 supports only the curated starter universe (~100 stocks).
+    Full S&P 500 scanning via yfinance is deferred to a future release.
+    """
+    if args.full_sp500 and args.provider == "yfinance":
+        print(
+            "\nERROR: --full-sp500 is not supported with --provider yfinance in v1.\n\n"
+            "The yfinance provider currently supports the curated starter universe of\n"
+            "~100 liquid U.S. stocks only. Full S&P 500 scanning via yfinance is\n"
+            "deferred to a future release.\n\n"
+            "Options:\n"
+            "  • Use the default curated starter universe (omit --full-sp500).\n"
+            "  • Screen specific symbols:  --universe AAPL MSFT NVDA ...\n"
+            "  • Switch to FMP provider:   --provider fmp --api-key YOUR_KEY --full-sp500",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _init_fmp_client(api_key: Optional[str]):
+    """Import and initialise FMPClient; exit on missing key."""
+    from fmp_client import FMPClient
+    try:
+        return FMPClient(api_key=api_key)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
 def main():
     args = parse_arguments()
 
@@ -484,60 +533,109 @@ def main():
         print("ERROR: --ext-threshold must be between 0 and 50 (exclusive)", file=sys.stderr)
         sys.exit(1)
 
+    # Guard: --full-sp500 is not supported with yfinance in v1
+    _check_full_sp500_yfinance(args)
+
     print("=" * 70)
     print("VCP Stock Screener")
     print("Mark Minervini's Volatility Contraction Pattern")
     print("=" * 70)
     print()
 
-    # Initialize FMP client
-    try:
-        client = FMPClient(api_key=args.api_key)
-        print("FMP API client initialized")
-    except ValueError as e:
-        print(f"ERROR: {e}", file=sys.stderr)
-        sys.exit(1)
+    use_yfinance = (args.provider == "yfinance")
 
     # ========================================================================
-    # Phase 1: Pre-Filter (API-efficient)
+    # Phase 1: Pre-Filter
     # ========================================================================
-    print()
     print("Phase 1: Pre-Filter")
     print("-" * 70)
 
-    # Determine universe
-    if args.universe:
-        symbols = args.universe
-        universe_desc = f"Custom ({len(symbols)} stocks)"
-        print(f"  Using custom universe: {len(symbols)} stocks")
+    if use_yfinance:
+        # ── yfinance path ──────────────────────────────────────────────────
+        from yf_client import YFinanceClient
+        yf_client = YFinanceClient()
+
+        if args.universe:
+            symbols = args.universe
+            universe_desc = f"Custom ({len(symbols)} stocks)"
+            universe_type = "custom"
+            print(f"  Using custom universe: {len(symbols)} stocks")
+        else:
+            symbols = [e["symbol"] for e in STARTER_UNIVERSE]
+            universe_desc = f"Starter universe ({len(symbols)} stocks)"
+            universe_type = "starter_100"
+            print(f"  Using curated starter universe: {len(symbols)} stocks")
+
+        # Sector/name lookup: starter universe has full metadata; custom falls back to symbol
+        sector_map = dict(SECTOR_MAP)
+        name_map = dict(NAME_MAP)
+        for sym in symbols:
+            sector_map.setdefault(sym, "Unknown")
+            name_map.setdefault(sym, sym)
+
+        # Single bulk download covers both Phase 1 and Phase 2 data needs
+        print(
+            f"  Downloading 1y daily OHLCV for {len(symbols)} symbol(s) via yfinance "
+            "(one bulk call, multiple internal HTTP connections)...",
+            flush=True,
+        )
+        t0 = datetime.now()
+        all_hist = yf_client.bulk_download(symbols, period="1y")
+        elapsed_dl = (datetime.now() - t0).total_seconds()
+        skipped_syms = yf_client.get_skipped_symbols()
+        skipped_count = len(skipped_syms)
+        suffix = f", {skipped_count} skipped" if skipped_count else ""
+        print(f"  Download complete in {elapsed_dl:.1f}s ({len(all_hist)} symbols{suffix})")
+
+        # Derive quote dicts from OHLCV (no extra HTTP calls)
+        all_quotes = {sym: _derive_quote_yf(sym, hist) for sym, hist in all_hist.items() if hist}
+
+        # SPY benchmark for RS calculation (separate call; uses cache if already warm)
+        print("  Fetching SPY 1y history for RS benchmark...", end=" ", flush=True)
+        spy_hist_map = yf_client.bulk_download(["SPY"], period="1y")
+        sp500_history = spy_hist_map.get("SPY", [])
+        print(f"OK ({len(sp500_history)} days)" if sp500_history else "WARN - unavailable")
+
+        # candidate_histories: same data already in memory, no second download
+        candidate_histories = all_hist
+
+        quote_failures = skipped_syms  # uniform name for report generation
+
     else:
-        print("  Fetching S&P 500 constituents...", end=" ", flush=True)
-        constituents = client.get_sp500_constituents()
-        if not constituents:
-            print("FAILED")
-            print("ERROR: Unable to fetch S&P 500 constituents", file=sys.stderr)
-            sys.exit(1)
-        symbols = [c["symbol"] for c in constituents]
-        universe_desc = f"S&P 500 ({len(symbols)} stocks)"
-        print(f"OK ({len(symbols)} stocks)")
+        # ── FMP path (unchanged behaviour) ────────────────────────────────
+        fmp_client = _init_fmp_client(args.api_key)
+        print("FMP API client initialized")
 
-    # Build sector/name lookup
-    sector_map = {}
-    name_map = {}
-    if not args.universe and constituents:
-        for c in constituents:
-            sector_map[c["symbol"]] = c.get("sector", "Unknown")
-            name_map[c["symbol"]] = c.get("name", c["symbol"])
+        if args.universe:
+            symbols = args.universe
+            universe_desc = f"Custom ({len(symbols)} stocks)"
+            universe_type = "custom"
+            print(f"  Using custom universe: {len(symbols)} stocks")
+            sector_map = {}
+            name_map = {}
+        else:
+            print("  Fetching S&P 500 constituents...", end=" ", flush=True)
+            constituents = fmp_client.get_sp500_constituents()
+            if not constituents:
+                print("FAILED")
+                print("ERROR: Unable to fetch S&P 500 constituents", file=sys.stderr)
+                sys.exit(1)
+            symbols = [c["symbol"] for c in constituents]
+            universe_desc = f"S&P 500 ({len(symbols)} stocks)"
+            universe_type = "sp500"
+            print(f"OK ({len(symbols)} stocks)")
+            sector_map = {c["symbol"]: c.get("sector", "Unknown") for c in constituents}
+            name_map = {c["symbol"]: c.get("name", c["symbol"]) for c in constituents}
 
-    # Batch fetch quotes
-    print("  Fetching quotes...", end=" ", flush=True)
-    all_quotes = client.get_batch_quotes(symbols)
-    quote_failures = client.get_quote_failures()
-    skipped_count = len(quote_failures)
-    suffix = f", {skipped_count} skipped" if skipped_count else ""
-    print(f"OK ({len(all_quotes)} quotes{suffix})")
+        print("  Fetching quotes...", end=" ", flush=True)
+        all_quotes = fmp_client.get_batch_quotes(symbols)
+        quote_failures = fmp_client.get_quote_failures()
+        skipped_count = len(quote_failures)
+        suffix = f", {skipped_count} skipped" if skipped_count else ""
+        print(f"OK ({len(all_quotes)} quotes{suffix})")
+        candidate_histories = {}  # populated below in Phase 2
 
-    # Apply pre-filter
+    # Apply pre-filter (shared between providers)
     print("  Applying pre-filter...", end=" ", flush=True)
     pre_filtered = []
     for sym in symbols:
@@ -548,11 +646,9 @@ def main():
         if passed:
             pre_filtered.append((sym, likelihood, quote))
 
-    # Sort by Stage 2 likelihood, take top candidates
     pre_filtered.sort(key=lambda x: x[1], reverse=True)
     max_candidates = len(pre_filtered) if args.full_sp500 else args.max_candidates
     candidates = pre_filtered[:max_candidates]
-
     print(f"{len(pre_filtered)} passed, taking top {len(candidates)}")
     print()
 
@@ -562,28 +658,22 @@ def main():
     print("Phase 2: Trend Template Filter")
     print("-" * 70)
 
-    # Fetch SPY historical for RS calculation
-    print("  Fetching SPY 260-day history...", end=" ", flush=True)
-    spy_data = client.get_historical_prices("SPY", days=260)
-    sp500_history = spy_data.get("historical", []) if spy_data else []
-    if sp500_history:
-        print(f"OK ({len(sp500_history)} days)")
-    else:
-        print("WARN - SPY data unavailable, RS calculations will be limited")
+    if not use_yfinance:
+        # FMP: fetch SPY and per-symbol histories (original flow)
+        print("  Fetching SPY 260-day history...", end=" ", flush=True)
+        spy_data = fmp_client.get_historical_prices("SPY", days=260)
+        sp500_history = spy_data.get("historical", []) if spy_data else []
+        print(f"OK ({len(sp500_history)} days)" if sp500_history else "WARN - unavailable")
 
-    # Fetch historical data for candidates
-    candidate_symbols = [c[0] for c in candidates]
-    print(f"  Fetching 260-day histories for {len(candidate_symbols)} candidates...")
+        candidate_symbols = [c[0] for c in candidates]
+        print(f"  Fetching 260-day histories for {len(candidate_symbols)} candidates...")
+        for i, sym in enumerate(candidate_symbols):
+            if (i + 1) % 20 == 0 or i == len(candidate_symbols) - 1:
+                print(f"    Progress: {i + 1}/{len(candidate_symbols)}", flush=True)
+            data = fmp_client.get_historical_prices(sym, days=260)
+            if data and "historical" in data:
+                candidate_histories[sym] = data["historical"]
 
-    candidate_histories = {}
-    for i, sym in enumerate(candidate_symbols):
-        if (i + 1) % 20 == 0 or i == len(candidate_symbols) - 1:
-            print(f"    Progress: {i + 1}/{len(candidate_symbols)}", flush=True)
-        data = client.get_historical_prices(sym, days=260)
-        if data and "historical" in data:
-            candidate_histories[sym] = data["historical"]
-
-    # Apply Trend Template filter
     print("  Applying 7-point Trend Template...", end=" ", flush=True)
     trend_passed = []
 
@@ -591,11 +681,8 @@ def main():
         hist = candidate_histories.get(sym, [])
         if not hist or len(hist) < 50:
             continue
-
-        # Quick RS calculation for criterion 7
         rs_result = calculate_relative_strength(hist, sp500_history)
         rs_rank = rs_result.get("rs_rank_estimate", 0)
-
         tt_result = calculate_trend_template(
             hist, quote, rs_rank=rs_rank, ext_threshold=args.ext_threshold
         )
@@ -617,13 +704,11 @@ def main():
         sector = sector_map.get(sym, "Unknown")
         name = name_map.get(sym, sym)
 
-        # For custom universe, try to get name from quote
         if not name or name == sym:
             name = quote.get("name", sym)
         if not sector or sector == "Unknown":
             sector = quote.get("sector", "Unknown")
 
-        # Skip stale/acquired stocks
         if is_stale_price(hist, threshold=args.min_atr_pct):
             print(f"  Skipping {sym} (stale price - likely acquired/pinned)")
             continue
@@ -663,7 +748,6 @@ def main():
         ranked_rs = rank_relative_strength_universe(rs_map)
         for r in results:
             r["relative_strength"] = ranked_rs[r["symbol"]]
-            # Recalculate composite score with updated RS (preserving state caps)
             composite = calculate_composite_score(
                 trend_score=r["trend_template"].get("score", 0),
                 contraction_score=r["vcp_pattern"].get("score", 0),
@@ -688,7 +772,6 @@ def main():
             r["state_cap_applied"] = composite.get("state_cap_applied", False)
             r["cap_reason"] = composite.get("cap_reason")
 
-    # Compute entry_ready using CLI thresholds
     require_vcp = not args.no_require_valid_vcp
     for r in results:
         r["entry_ready"] = compute_entry_ready(
@@ -698,17 +781,14 @@ def main():
             require_valid_vcp=require_vcp,
         )
 
-    # Sort by composite score
     results.sort(key=lambda x: x["composite_score"], reverse=True)
 
-    # Apply prebreakout filter if requested
     if args.mode == "prebreakout":
         total_before = len(results)
         results = [r for r in results if r.get("entry_ready", False)]
         print(f"  Pre-breakout filter: {total_before} -> {len(results)} candidates")
         print()
 
-    # Apply strict mode filter if requested
     if args.strict:
         total_before = len(results)
         results = [
@@ -731,11 +811,22 @@ def main():
     json_file = os.path.join(args.output_dir, f"vcp_screener_{timestamp}.json")
     md_file = os.path.join(args.output_dir, f"vcp_screener_{timestamp}.md")
 
-    api_stats = client.get_api_stats()
+    if use_yfinance:
+        provider_stats = yf_client.get_provider_stats()
+    else:
+        fmp_raw = fmp_client.get_api_stats()
+        provider_stats = {
+            "provider": "fmp",
+            "api_calls_made": fmp_raw["api_calls_made"],
+            "cache_entries": fmp_raw["cache_entries"],
+            "rate_limit_reached": fmp_raw["rate_limit_reached"],
+        }
 
     metadata = {
         "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "provider": args.provider,
         "universe_description": universe_desc,
+        "universe_type": universe_type,
         "max_candidates": max_candidates,
         "ext_threshold": args.ext_threshold,
         "tuning_params": {
@@ -759,11 +850,10 @@ def main():
             "trend_template_passed": len(trend_passed),
             "vcp_candidates": len(results),
         },
-        "api_stats": api_stats,
+        "api_stats": provider_stats,
     }
 
     top_results = results[: args.top]
-
     generate_json_report(top_results, metadata, json_file, all_results=results, skipped=quote_failures)
     generate_markdown_report(top_results, metadata, md_file, all_results=results, skipped=quote_failures)
 
@@ -775,7 +865,6 @@ def main():
     print("VCP Screening Complete")
     print("=" * 70)
 
-    # Top 5 display
     if results:
         print()
         print(f"Top {min(5, len(results))} Results:")
@@ -791,12 +880,12 @@ def main():
         print("  No VCP candidates found in this screening run.")
 
     print()
-    print(f"  JSON Report:    {json_file}")
+    print(f"  JSON Report:     {json_file}")
     print(f"  Markdown Report: {md_file}")
     print()
-    print("API Usage:")
-    print(f"  API calls made: {api_stats['api_calls_made']}")
-    print(f"  Cache entries:  {api_stats['cache_entries']}")
+    print("Provider Stats:")
+    for k, v in provider_stats.items():
+        print(f"  {k}: {v}")
     print()
 
 

--- a/skills/vcp-screener/scripts/tests/test_quote_failure_tracking.py
+++ b/skills/vcp-screener/scripts/tests/test_quote_failure_tracking.py
@@ -1,0 +1,231 @@
+"""Tests for free-tier FMP reliability patch:
+- v3 legacy-403 triggers immediate endpoint disable (not threshold-based)
+- per-symbol quote failures are recorded with correct category
+- get_quote_failures() returns the full failure log
+- _categorize_failure() maps status+body to the right category
+"""
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from fmp_client import FMPClient, _categorize_failure
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+LEGACY_403_BODY = '{"Error Message": "Legacy Endpoint : Due to Legacy endpoints being no longer supported"}'
+PAID_402_BODY = "Premium Query Parameter: This value set for 'symbol' is not available under your current subscription"
+
+
+def _make_response(status: int, body: str) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.text = body
+    r.json.return_value = None  # won't be called for non-200
+    return r
+
+
+def _make_client() -> FMPClient:
+    return FMPClient(api_key="test_key_placeholder")
+
+
+# ---------------------------------------------------------------------------
+# _categorize_failure
+# ---------------------------------------------------------------------------
+
+class TestCategorizFailure:
+    def test_legacy_403(self):
+        assert _categorize_failure(403, LEGACY_403_BODY) == "legacy_endpoint_retired"
+
+    def test_paid_402(self):
+        assert _categorize_failure(402, PAID_402_BODY) == "paid_tier_required"
+
+    def test_premium_in_body_any_status(self):
+        assert _categorize_failure(200, "Premium content") == "paid_tier_required"
+
+    def test_404(self):
+        assert _categorize_failure(404, "") == "symbol_not_found"
+
+    def test_429(self):
+        assert _categorize_failure(429, "") == "rate_limit_exceeded"
+
+    def test_no_endpoint(self):
+        assert _categorize_failure(0, "") == "no_endpoint_available"
+
+    def test_generic_status(self):
+        assert _categorize_failure(500, "") == "http_500"
+
+
+# ---------------------------------------------------------------------------
+# v3 immediate disable on Legacy 403
+# ---------------------------------------------------------------------------
+
+class TestLegacy403ImmediateDisable:
+    def test_v3_disabled_after_single_legacy_403(self):
+        """v3 endpoint must be disabled after the FIRST Legacy 403, not after threshold=3."""
+        client = _make_client()
+        v3_base = "https://financialmodelingprep.com/api/v3/quote"
+
+        # Stable returns 402 (paid), v3 returns Legacy 403
+        stable_resp = _make_response(402, PAID_402_BODY)
+        v3_resp = _make_response(403, LEGACY_403_BODY)
+
+        call_responses = [stable_resp, v3_resp]
+        call_idx = [0]
+
+        def fake_get(url, params=None, timeout=30):
+            resp = call_responses[call_idx[0]]
+            call_idx[0] += 1
+            return resp
+
+        client.session.get = fake_get
+
+        result = client.get_quote("AAPL")
+
+        assert result is None
+        assert v3_base in client._disabled_endpoints, (
+            "v3 should be immediately disabled after one Legacy 403"
+        )
+        assert client._endpoint_failures.get(v3_base, 0) == 0, (
+            "failure counter should not be incremented for immediate-disable"
+        )
+
+    def test_v3_not_disabled_on_regular_403(self):
+        """A non-Legacy 403 still goes through the normal threshold."""
+        client = _make_client()
+        v3_base = "https://financialmodelingprep.com/api/v3/quote"
+
+        generic_403_resp = _make_response(403, '{"error": "Unauthorized"}')
+        stable_resp = _make_response(402, PAID_402_BODY)
+
+        call_responses = [stable_resp, generic_403_resp]
+        call_idx = [0]
+
+        def fake_get(url, params=None, timeout=30):
+            resp = call_responses[call_idx[0] % len(call_responses)]
+            call_idx[0] += 1
+            return resp
+
+        client.session.get = fake_get
+        client.get_quote("AAPL")
+
+        assert v3_base not in client._disabled_endpoints, (
+            "v3 must NOT be immediately disabled for a non-Legacy 403"
+        )
+        assert client._endpoint_failures.get(v3_base, 0) == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-symbol failure tracking
+# ---------------------------------------------------------------------------
+
+class TestQuoteFailureTracking:
+    def _run_failed_quote(self, symbol: str, stable_status: int, stable_body: str) -> FMPClient:
+        client = _make_client()
+
+        def fake_get(url, params=None, timeout=30):
+            r = MagicMock()
+            r.status_code = stable_status
+            r.text = stable_body
+            r.json.return_value = None
+            return r
+
+        # Disable the v3 fallback so only stable is attempted
+        v3_base = "https://financialmodelingprep.com/api/v3/quote"
+        client._disabled_endpoints.add(v3_base)
+        client.session.get = fake_get
+        client.get_quote(symbol)
+        return client
+
+    def test_failure_recorded_on_402(self):
+        client = self._run_failed_quote("AVGO", 402, PAID_402_BODY)
+        failures = client.get_quote_failures()
+        assert len(failures) == 1
+        assert failures[0]["symbol"] == "AVGO"
+        assert failures[0]["http_status"] == 402
+        assert failures[0]["error_category"] == "paid_tier_required"
+
+    def test_no_failure_on_success(self):
+        client = _make_client()
+
+        def fake_get(url, params=None, timeout=30):
+            r = MagicMock()
+            r.status_code = 200
+            r.text = ""
+            r.json.return_value = [{"symbol": "AAPL", "price": 300}]
+            return r
+
+        client.session.get = fake_get
+        result = client.get_quote("AAPL")
+        assert result is not None
+        assert client.get_quote_failures() == []
+
+    def test_multiple_failures_accumulated(self):
+        client = _make_client()
+        v3_base = "https://financialmodelingprep.com/api/v3/quote"
+        client._disabled_endpoints.add(v3_base)
+
+        def fake_get(url, params=None, timeout=30):
+            r = MagicMock()
+            r.status_code = 402
+            r.text = PAID_402_BODY
+            r.json.return_value = None
+            return r
+
+        client.session.get = fake_get
+        client.get_quote("AVGO")
+        client.get_quote("HD")
+        client.get_quote("CAT")
+
+        failures = client.get_quote_failures()
+        assert len(failures) == 3
+        symbols = [f["symbol"] for f in failures]
+        assert "AVGO" in symbols
+        assert "HD" in symbols
+        assert "CAT" in symbols
+
+    def test_get_quote_failures_returns_copy(self):
+        """Mutating the returned list must not affect internal state."""
+        client = _make_client()
+        v3_base = "https://financialmodelingprep.com/api/v3/quote"
+        client._disabled_endpoints.add(v3_base)
+
+        def fake_get(url, params=None, timeout=30):
+            r = MagicMock()
+            r.status_code = 402
+            r.text = PAID_402_BODY
+            r.json.return_value = None
+            return r
+
+        client.session.get = fake_get
+        client.get_quote("AVGO")
+        returned = client.get_quote_failures()
+        returned.clear()
+        assert len(client.get_quote_failures()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Historical endpoint must NOT record quote failures
+# ---------------------------------------------------------------------------
+
+class TestHistoricalDoesNotLogQuoteFailure:
+    def test_historical_failure_not_in_quote_log(self):
+        client = _make_client()
+
+        def fake_get(url, params=None, timeout=30):
+            r = MagicMock()
+            r.status_code = 403
+            r.text = LEGACY_403_BODY
+            r.json.return_value = None
+            return r
+
+        client.session.get = fake_get
+        client.get_historical_prices("SPY", days=10)
+        assert client.get_quote_failures() == [], (
+            "Historical failures must not appear in quote_failures"
+        )

--- a/skills/vcp-screener/scripts/tests/test_skipped_symbols_report.py
+++ b/skills/vcp-screener/scripts/tests/test_skipped_symbols_report.py
@@ -1,0 +1,118 @@
+"""Tests for skipped-symbol reporting in JSON and Markdown reports."""
+import json
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from report_generator import generate_json_report, generate_markdown_report
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_METADATA = {
+    "generated_at": "2026-01-01 00:00:00",
+    "universe_description": "Custom (3 stocks)",
+    "funnel": {
+        "universe": 3,
+        "quotes_fetched": 1,
+        "symbols_skipped": 2,
+        "pre_filter_passed": 1,
+        "trend_template_passed": 0,
+        "vcp_candidates": 0,
+    },
+    "api_stats": {"api_calls_made": 5, "cache_entries": 3},
+}
+
+SKIPPED = [
+    {"symbol": "AVGO", "http_status": 402, "error_category": "paid_tier_required", "endpoint": "quote"},
+    {"symbol": "HD",   "http_status": 402, "error_category": "paid_tier_required", "endpoint": "quote"},
+]
+
+
+# ---------------------------------------------------------------------------
+# JSON report
+# ---------------------------------------------------------------------------
+
+class TestJsonReportSkipped:
+    def test_skipped_symbols_in_json(self, tmp_path):
+        out = str(tmp_path / "report.json")
+        generate_json_report([], MINIMAL_METADATA, out, skipped=SKIPPED)
+        with open(out, encoding="utf-8") as f:
+            data = json.load(f)
+        assert "skipped_symbols" in data
+        assert len(data["skipped_symbols"]) == 2
+        syms = [s["symbol"] for s in data["skipped_symbols"]]
+        assert "AVGO" in syms
+        assert "HD" in syms
+
+    def test_empty_skipped_in_json(self, tmp_path):
+        out = str(tmp_path / "report.json")
+        generate_json_report([], MINIMAL_METADATA, out, skipped=[])
+        with open(out, encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["skipped_symbols"] == []
+
+    def test_skipped_none_defaults_to_empty(self, tmp_path):
+        out = str(tmp_path / "report.json")
+        generate_json_report([], MINIMAL_METADATA, out, skipped=None)
+        with open(out, encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["skipped_symbols"] == []
+
+    def test_skipped_entry_fields_preserved(self, tmp_path):
+        out = str(tmp_path / "report.json")
+        generate_json_report([], MINIMAL_METADATA, out, skipped=SKIPPED)
+        with open(out, encoding="utf-8") as f:
+            data = json.load(f)
+        entry = data["skipped_symbols"][0]
+        assert entry["http_status"] == 402
+        assert entry["error_category"] == "paid_tier_required"
+
+
+# ---------------------------------------------------------------------------
+# Markdown report
+# ---------------------------------------------------------------------------
+
+class TestMarkdownReportSkipped:
+    def _render(self, tmp_path, skipped):
+        out = str(tmp_path / "report.md")
+        generate_markdown_report([], MINIMAL_METADATA, out, skipped=skipped)
+        return open(out, encoding="utf-8").read()
+
+    def test_warning_banner_present_when_skipped(self, tmp_path):
+        md = self._render(tmp_path, SKIPPED)
+        assert "WARNING" in md
+        assert "2 symbol(s)" in md
+
+    def test_no_warning_when_no_skipped(self, tmp_path):
+        md = self._render(tmp_path, [])
+        assert "WARNING" not in md
+
+    def test_skipped_table_present(self, tmp_path):
+        md = self._render(tmp_path, SKIPPED)
+        assert "## Skipped Symbols" in md
+        assert "AVGO" in md
+        assert "HD" in md
+        assert "paid_tier_required" in md
+
+    def test_funnel_shows_skipped_row(self, tmp_path):
+        md = self._render(tmp_path, SKIPPED)
+        assert "Symbols skipped" in md
+
+    def test_funnel_no_skipped_row_when_none(self, tmp_path):
+        meta = dict(MINIMAL_METADATA)
+        meta["funnel"] = dict(MINIMAL_METADATA["funnel"])
+        meta["funnel"]["symbols_skipped"] = 0
+        out = str(tmp_path / "report.md")
+        generate_markdown_report([], meta, out, skipped=[])
+        md = open(out, encoding="utf-8").read()
+        assert "Symbols skipped" not in md
+
+    def test_no_skipped_section_when_empty(self, tmp_path):
+        md = self._render(tmp_path, [])
+        assert "## Skipped Symbols" not in md

--- a/skills/vcp-screener/scripts/tests/test_universe.py
+++ b/skills/vcp-screener/scripts/tests/test_universe.py
@@ -1,0 +1,176 @@
+"""Tests for the curated starter universe (universe.py).
+
+Covers:
+- No duplicate tickers
+- No empty / whitespace-only ticker strings
+- No blank sector labels
+- MA is in Financials (not Information Technology)
+- V is in Financials
+- Universe size is approximately 100 (95–105)
+- At least 8 distinct GICS sectors are represented
+- validate_universe() returns [] for the default universe
+"""
+
+from __future__ import annotations
+
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from universe import STARTER_UNIVERSE, SECTOR_MAP, NAME_MAP, validate_universe
+
+
+class TestNoDuplicates:
+    def test_no_duplicate_tickers(self):
+        symbols = [e["symbol"] for e in STARTER_UNIVERSE]
+        assert len(set(symbols)) == len(symbols), (
+            f"Duplicate tickers found: "
+            f"{[s for s in symbols if symbols.count(s) > 1]}"
+        )
+
+
+class TestTickerValidity:
+    def test_no_empty_ticker_strings(self):
+        for entry in STARTER_UNIVERSE:
+            sym = entry.get("symbol", "")
+            assert isinstance(sym, str) and sym.strip(), (
+                f"Empty or invalid ticker in entry: {entry}"
+            )
+
+    def test_no_whitespace_only_tickers(self):
+        for entry in STARTER_UNIVERSE:
+            assert entry["symbol"] == entry["symbol"].strip(), (
+                f"Ticker has leading/trailing whitespace: {repr(entry['symbol'])}"
+            )
+
+
+class TestSectorLabels:
+    def test_no_blank_sector_labels(self):
+        for entry in STARTER_UNIVERSE:
+            sector = entry.get("sector", "")
+            assert isinstance(sector, str) and sector.strip(), (
+                f"Blank sector in entry: {entry}"
+            )
+
+    def test_all_entries_have_name(self):
+        for entry in STARTER_UNIVERSE:
+            name = entry.get("name", "")
+            assert isinstance(name, str) and name.strip(), (
+                f"Blank name in entry: {entry}"
+            )
+
+
+class TestSectorClassification:
+    def test_ma_in_financials(self):
+        assert SECTOR_MAP.get("MA") == "Financials", (
+            f"MA should be in Financials, got: {SECTOR_MAP.get('MA')}"
+        )
+
+    def test_v_in_financials(self):
+        assert SECTOR_MAP.get("V") == "Financials", (
+            f"V should be in Financials, got: {SECTOR_MAP.get('V')}"
+        )
+
+    def test_ma_not_in_information_technology(self):
+        assert SECTOR_MAP.get("MA") != "Information Technology", (
+            "MA must NOT be classified as Information Technology"
+        )
+
+    def test_v_not_in_information_technology(self):
+        assert SECTOR_MAP.get("V") != "Information Technology", (
+            "V must NOT be classified as Information Technology"
+        )
+
+    def test_aapl_in_information_technology(self):
+        assert SECTOR_MAP.get("AAPL") == "Information Technology"
+
+    def test_jpm_in_financials(self):
+        assert SECTOR_MAP.get("JPM") == "Financials"
+
+    def test_jnj_in_health_care(self):
+        assert SECTOR_MAP.get("JNJ") == "Health Care"
+
+    def test_xom_in_energy(self):
+        assert SECTOR_MAP.get("XOM") == "Energy"
+
+
+class TestUniverseSize:
+    def test_universe_size_approximately_100(self):
+        n = len(STARTER_UNIVERSE)
+        assert 95 <= n <= 105, (
+            f"Expected ~100 stocks, got {n}"
+        )
+
+    def test_universe_has_exactly_100_stocks(self):
+        assert len(STARTER_UNIVERSE) == 100
+
+
+class TestSectorDiversity:
+    def test_at_least_8_sectors_represented(self):
+        sectors = {e["sector"] for e in STARTER_UNIVERSE}
+        assert len(sectors) >= 8, (
+            f"Expected 8+ sectors, got {len(sectors)}: {sorted(sectors)}"
+        )
+
+    def test_all_expected_sectors_present(self):
+        expected = {
+            "Information Technology",
+            "Communication Services",
+            "Consumer Discretionary",
+            "Consumer Staples",
+            "Health Care",
+            "Financials",
+            "Industrials",
+            "Energy",
+            "Materials",
+            "Real Estate",
+            "Utilities",
+        }
+        present = {e["sector"] for e in STARTER_UNIVERSE}
+        missing = expected - present
+        assert not missing, f"Missing sectors: {missing}"
+
+
+class TestLookupMaps:
+    def test_sector_map_covers_all_tickers(self):
+        for entry in STARTER_UNIVERSE:
+            sym = entry["symbol"]
+            assert sym in SECTOR_MAP, f"{sym} missing from SECTOR_MAP"
+            assert SECTOR_MAP[sym] == entry["sector"]
+
+    def test_name_map_covers_all_tickers(self):
+        for entry in STARTER_UNIVERSE:
+            sym = entry["symbol"]
+            assert sym in NAME_MAP, f"{sym} missing from NAME_MAP"
+            assert NAME_MAP[sym] == entry["name"]
+
+
+class TestValidateUniverseFunction:
+    def test_validate_universe_returns_empty_list_for_default(self):
+        errors = validate_universe()
+        assert errors == [], f"validate_universe() reported errors: {errors}"
+
+    def test_validate_detects_duplicate(self):
+        duped = [
+            {"symbol": "AAPL", "name": "Apple", "sector": "Information Technology"},
+            {"symbol": "AAPL", "name": "Apple Dupe", "sector": "Information Technology"},
+        ]
+        errors = validate_universe(duped)
+        assert any("Duplicate" in e for e in errors)
+
+    def test_validate_detects_empty_symbol(self):
+        bad = [{"symbol": "", "name": "Bad", "sector": "Technology"}]
+        errors = validate_universe(bad)
+        assert any("empty" in e.lower() or "invalid" in e.lower() for e in errors)
+
+    def test_validate_detects_blank_sector(self):
+        bad = [{"symbol": "TST", "name": "Test", "sector": ""}]
+        errors = validate_universe(bad)
+        assert any("sector" in e.lower() for e in errors)
+
+    def test_validate_detects_missing_key(self):
+        bad = [{"symbol": "TST", "name": "Test"}]  # missing 'sector'
+        errors = validate_universe(bad)
+        assert any("sector" in e for e in errors)

--- a/skills/vcp-screener/scripts/tests/test_vcp_screener.py
+++ b/skills/vcp-screener/scripts/tests/test_vcp_screener.py
@@ -3351,3 +3351,83 @@ class TestEarlyPostBreakoutCap:
             breakout_volume=False,
         )
         assert result["state"] == "Early-post-breakout"
+
+
+# ===========================================================================
+# --provider / --full-sp500 behaviour tests
+# ===========================================================================
+
+
+class TestProviderFullSP500Guard:
+    """Test --full-sp500 guard for yfinance provider and --provider flag."""
+
+    def _run(self, argv: list[str]):
+        """Run parse_arguments() with the given argv list."""
+        import sys as _sys
+        old_argv = _sys.argv
+        _sys.argv = ["screen_vcp.py"] + argv
+        try:
+            return parse_arguments()
+        finally:
+            _sys.argv = old_argv
+
+    # ── --provider default ──────────────────────────────────────────────
+
+    def test_default_provider_is_yfinance(self):
+        """Without --provider, the default should be 'yfinance'."""
+        args = self._run([])
+        assert args.provider == "yfinance"
+
+    def test_explicit_yfinance_provider(self):
+        args = self._run(["--provider", "yfinance"])
+        assert args.provider == "yfinance"
+
+    def test_explicit_fmp_provider(self):
+        args = self._run(["--provider", "fmp"])
+        assert args.provider == "fmp"
+
+    # ── --full-sp500 + yfinance hard-stop ──────────────────────────────
+
+    def test_full_sp500_yfinance_exits_with_code_1(self, capsys):
+        """--provider yfinance --full-sp500 must raise SystemExit(1)."""
+        from screen_vcp import _check_full_sp500_yfinance
+
+        args = self._run(["--provider", "yfinance"])
+        args.full_sp500 = True
+
+        with pytest.raises(SystemExit) as exc_info:
+            _check_full_sp500_yfinance(args)
+        assert exc_info.value.code == 1
+
+    def test_full_sp500_yfinance_error_message_content(self, capsys):
+        """Stderr must explain curated universe and deferred full-S&P-500."""
+        from screen_vcp import _check_full_sp500_yfinance
+
+        args = self._run(["--provider", "yfinance"])
+        args.full_sp500 = True
+
+        with pytest.raises(SystemExit):
+            _check_full_sp500_yfinance(args)
+
+        captured = capsys.readouterr()
+        assert "curated starter universe" in captured.err or "curated" in captured.err
+        assert "deferred" in captured.err
+
+    def test_full_sp500_fmp_does_not_exit(self):
+        """--provider fmp --full-sp500 must NOT raise SystemExit."""
+        from screen_vcp import _check_full_sp500_yfinance
+
+        args = self._run(["--provider", "fmp"])
+        args.full_sp500 = True
+
+        # Should not raise
+        _check_full_sp500_yfinance(args)
+
+    def test_no_full_sp500_yfinance_does_not_exit(self):
+        """--provider yfinance without --full-sp500 must NOT raise SystemExit."""
+        from screen_vcp import _check_full_sp500_yfinance
+
+        args = self._run(["--provider", "yfinance"])
+        args.full_sp500 = False
+
+        _check_full_sp500_yfinance(args)  # should not raise

--- a/skills/vcp-screener/scripts/tests/test_yf_client.py
+++ b/skills/vcp-screener/scripts/tests/test_yf_client.py
@@ -1,0 +1,424 @@
+"""Tests for YFinanceClient (yf_client.py).
+
+Covers:
+- auto_adjust=False is always passed to yf.download()
+- Both Close and Adj Close are preserved in output dicts
+- Adj Close differs from Close when the mock DataFrame says so
+- Retry on missing symbol: succeeds on second attempt
+- Retry exhausted: symbol logged in skipped list
+- Skipped dict has required keys
+- Cache reuse: yf.download() called only once for same args
+- Backoff delays are applied between retries
+"""
+
+from __future__ import annotations
+
+import sys
+import os
+from unittest.mock import MagicMock, call, patch
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from yf_client import YFinanceClient, _df_to_hist, _derive_quote, RETRY_DELAYS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ohlcv_df(
+    symbol: str,
+    n: int = 5,
+    close: float = 100.0,
+    adj_close: float | None = None,
+    multi: bool = True,
+) -> pd.DataFrame:
+    """Build a minimal yfinance-style DataFrame.
+
+    When multi=True, columns are a MultiIndex (ticker, field) matching the
+    real yf.download() output with group_by='ticker': level-0 = ticker,
+    level-1 = field. When multi=False, columns are flat (single-ticker string
+    download format).
+    """
+    dates = pd.date_range("2026-01-01", periods=n, freq="B")
+    adj = adj_close if adj_close is not None else close
+
+    data = {
+        "Open":      [close * 0.99] * n,
+        "High":      [close * 1.01] * n,
+        "Low":       [close * 0.98] * n,
+        "Close":     [close] * n,
+        "Adj Close": [adj] * n,
+        "Volume":    [1_000_000] * n,
+    }
+    df = pd.DataFrame(data, index=dates)
+
+    if multi:
+        # Real yfinance group_by='ticker' layout: ticker at level-0, field at level-1
+        df.columns = pd.MultiIndex.from_tuples(
+            [(symbol, col) for col in df.columns],
+            names=["ticker", "field"],
+        )
+    return df
+
+
+def _make_empty_df() -> pd.DataFrame:
+    return pd.DataFrame()
+
+
+# ---------------------------------------------------------------------------
+# 1. auto_adjust=False always passed
+# ---------------------------------------------------------------------------
+
+class TestAutoAdjustFalse:
+    def test_auto_adjust_false_single_symbol(self):
+        """yf.download must receive auto_adjust=False for a single symbol."""
+        client = YFinanceClient()
+        mock_df = _make_ohlcv_df("AAPL", multi=False)
+
+        with patch("yf_client.yf.download", return_value=mock_df) as mock_dl:
+            client.bulk_download(["AAPL"], period="1y")
+
+        _, kwargs = mock_dl.call_args
+        assert kwargs.get("auto_adjust") is False, (
+            "auto_adjust must be explicitly False"
+        )
+
+    def test_auto_adjust_false_multi_symbol(self):
+        """yf.download must receive auto_adjust=False for multiple symbols."""
+        client = YFinanceClient()
+        syms = ["AAPL", "MSFT"]
+        dfs = {sym: _make_ohlcv_df(sym) for sym in syms}
+        combined = pd.concat(dfs.values(), axis=1)
+
+        with patch("yf_client.yf.download", return_value=combined) as mock_dl:
+            client.bulk_download(syms, period="1y")
+
+        _, kwargs = mock_dl.call_args
+        assert kwargs.get("auto_adjust") is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Close and Adj Close both preserved
+# ---------------------------------------------------------------------------
+
+class TestCloseAndAdjClosePreserved:
+    def test_both_keys_present_single(self):
+        """Output dicts must have 'close' and 'adjClose' keys."""
+        client = YFinanceClient()
+        df = _make_ohlcv_df("AAPL", multi=False)
+
+        with patch("yf_client.yf.download", return_value=df):
+            result = client.bulk_download(["AAPL"])
+
+        hist = result.get("AAPL", [])
+        assert hist, "Expected non-empty history for AAPL"
+        row = hist[0]
+        assert "close" in row
+        assert "adjClose" in row
+
+    def test_adj_close_matches_close_when_same(self):
+        """When Adj Close == Close (no dividends/splits), both values are equal."""
+        client = YFinanceClient()
+        df = _make_ohlcv_df("MSFT", close=300.0, adj_close=300.0, multi=False)
+
+        with patch("yf_client.yf.download", return_value=df):
+            result = client.bulk_download(["MSFT"])
+
+        hist = result["MSFT"]
+        assert hist[0]["close"] == pytest.approx(300.0)
+        assert hist[0]["adjClose"] == pytest.approx(300.0)
+
+    def test_adj_close_differs_when_dividend(self):
+        """When Adj Close != Close (dividend adjusted), both values are distinct."""
+        client = YFinanceClient()
+        # Simulate a stock with a recent dividend: adj_close < close
+        df = _make_ohlcv_df("JNJ", close=160.0, adj_close=155.5, multi=False)
+
+        with patch("yf_client.yf.download", return_value=df):
+            result = client.bulk_download(["JNJ"])
+
+        hist = result["JNJ"]
+        assert hist[0]["close"] == pytest.approx(160.0)
+        assert hist[0]["adjClose"] == pytest.approx(155.5)
+        assert hist[0]["adjClose"] != hist[0]["close"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Retry on missing symbol
+# ---------------------------------------------------------------------------
+
+class TestRetryOnMissingSymbol:
+    def test_retry_succeeds_on_second_attempt(self):
+        """Symbol with empty first download is retried and succeeds; not skipped."""
+        client = YFinanceClient()
+        good_df = _make_ohlcv_df("NVDA", multi=False)
+
+        call_count = [0]
+
+        def fake_download(**kwargs):
+            call_count[0] += 1
+            tickers = kwargs.get("tickers", [])
+            syms = [tickers] if isinstance(tickers, str) else list(tickers)
+            if "NVDA" in syms and call_count[0] == 1:
+                # First call (bulk): return empty → triggers retry
+                return _make_empty_df()
+            # Second call (individual retry): return good data
+            return good_df
+
+        with patch("yf_client.yf.download", side_effect=fake_download):
+            with patch("yf_client.time.sleep"):   # skip real delays
+                result = client.bulk_download(["NVDA"])
+
+        assert result.get("NVDA"), "NVDA should be recovered after retry"
+        skipped = client.get_skipped_symbols()
+        assert not any(s["symbol"] == "NVDA" for s in skipped), (
+            "Successfully retried symbol must not appear in skipped list"
+        )
+
+    def test_retry_count_incremented(self):
+        """_retries_attempted is incremented for each retry attempt."""
+        client = YFinanceClient()
+        good_df = _make_ohlcv_df("AMD", multi=False)
+        call_count = [0]
+
+        def fake_download(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return _make_empty_df()
+            return good_df
+
+        with patch("yf_client.yf.download", side_effect=fake_download):
+            with patch("yf_client.time.sleep"):
+                client.bulk_download(["AMD"])
+
+        assert client._retries_attempted >= 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Retry exhausted → symbol logged as skipped
+# ---------------------------------------------------------------------------
+
+class TestRetryExhausted:
+    def test_symbol_in_skipped_after_all_retries_fail(self):
+        """Symbol that is empty after all retries appears in get_skipped_symbols()."""
+        client = YFinanceClient()
+
+        with patch("yf_client.yf.download", return_value=_make_empty_df()):
+            with patch("yf_client.time.sleep"):
+                result = client.bulk_download(["BADTICKER"])
+
+        assert not result.get("BADTICKER"), "Failed symbol should have no history"
+        skipped = client.get_skipped_symbols()
+        assert any(s["symbol"] == "BADTICKER" for s in skipped), (
+            "Exhausted symbol must appear in skipped list"
+        )
+
+    def test_good_symbols_not_in_skipped(self):
+        """Successful symbols must not appear in the skipped list."""
+        client = YFinanceClient()
+        good_df = _make_ohlcv_df("AAPL", multi=False)
+
+        with patch("yf_client.yf.download", return_value=good_df):
+            client.bulk_download(["AAPL"])
+
+        skipped = client.get_skipped_symbols()
+        assert not any(s["symbol"] == "AAPL" for s in skipped)
+
+
+# ---------------------------------------------------------------------------
+# 5. Skipped dict format
+# ---------------------------------------------------------------------------
+
+class TestSkippedDictFormat:
+    def test_skipped_entry_has_required_keys(self):
+        """Skipped entry must have symbol, http_status, error_category, endpoint."""
+        client = YFinanceClient()
+
+        with patch("yf_client.yf.download", return_value=_make_empty_df()):
+            with patch("yf_client.time.sleep"):
+                client.bulk_download(["GHOST"])
+
+        skipped = client.get_skipped_symbols()
+        assert skipped, "Expected at least one skipped entry"
+        entry = skipped[0]
+        assert "symbol" in entry
+        assert "http_status" in entry
+        assert "error_category" in entry
+        assert "endpoint" in entry
+
+    def test_skipped_error_category_value(self):
+        """error_category for a failed yfinance download should be 'yf_download_failed'."""
+        client = YFinanceClient()
+
+        with patch("yf_client.yf.download", return_value=_make_empty_df()):
+            with patch("yf_client.time.sleep"):
+                client.bulk_download(["GHOST"])
+
+        skipped = client.get_skipped_symbols()
+        entry = next(s for s in skipped if s["symbol"] == "GHOST")
+        assert entry["error_category"] == "yf_download_failed"
+
+    def test_get_skipped_symbols_returns_copy(self):
+        """Mutating the returned list must not affect internal state."""
+        client = YFinanceClient()
+
+        with patch("yf_client.yf.download", return_value=_make_empty_df()):
+            with patch("yf_client.time.sleep"):
+                client.bulk_download(["GHOST"])
+
+        returned = client.get_skipped_symbols()
+        returned.clear()
+        assert len(client.get_skipped_symbols()) == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. Cache reuse
+# ---------------------------------------------------------------------------
+
+class TestCacheReuse:
+    def test_second_call_hits_cache(self):
+        """yf.download called exactly once when bulk_download is called twice with same args."""
+        client = YFinanceClient()
+        df = _make_ohlcv_df("AAPL", multi=False)
+
+        with patch("yf_client.yf.download", return_value=df) as mock_dl:
+            client.bulk_download(["AAPL"], period="1y")
+            client.bulk_download(["AAPL"], period="1y")
+
+        assert mock_dl.call_count == 1, (
+            "yf.download should be called only once; second call uses cache"
+        )
+
+    def test_cache_hit_counter_incremented(self):
+        """_cache_hits is incremented on a cache hit."""
+        client = YFinanceClient()
+        df = _make_ohlcv_df("MSFT", multi=False)
+
+        with patch("yf_client.yf.download", return_value=df):
+            client.bulk_download(["MSFT"])
+            client.bulk_download(["MSFT"])
+
+        assert client._cache_hits == 1
+
+    def test_different_period_not_cached(self):
+        """Different period strings are treated as separate cache entries."""
+        client = YFinanceClient()
+        df = _make_ohlcv_df("AAPL", multi=False)
+
+        with patch("yf_client.yf.download", return_value=df) as mock_dl:
+            client.bulk_download(["AAPL"], period="1y")
+            client.bulk_download(["AAPL"], period="6mo")
+
+        assert mock_dl.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 7. Backoff delays
+# ---------------------------------------------------------------------------
+
+class TestBackoffDelays:
+    def test_sleep_called_with_retry_delays(self):
+        """time.sleep is called with values from RETRY_DELAYS during retries."""
+        client = YFinanceClient()
+        good_df = _make_ohlcv_df("TSLA", multi=False)
+        call_count = [0]
+
+        def fake_download(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return _make_empty_df()  # force retry
+            return good_df
+
+        with patch("yf_client.yf.download", side_effect=fake_download):
+            with patch("yf_client.time.sleep") as mock_sleep:
+                client.bulk_download(["TSLA"])
+
+        sleep_args = [c.args[0] for c in mock_sleep.call_args_list]
+        # First retry sleep should be RETRY_DELAYS[0]
+        assert sleep_args[0] == RETRY_DELAYS[0], (
+            f"First retry delay should be {RETRY_DELAYS[0]}s, got {sleep_args[0]}s"
+        )
+
+    def test_no_sleep_when_no_retry_needed(self):
+        """time.sleep is not called when all symbols download successfully."""
+        client = YFinanceClient()
+        df = _make_ohlcv_df("AAPL", multi=False)
+
+        with patch("yf_client.yf.download", return_value=df):
+            with patch("yf_client.time.sleep") as mock_sleep:
+                client.bulk_download(["AAPL"])
+
+        assert mock_sleep.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 8. _df_to_hist unit tests
+# ---------------------------------------------------------------------------
+
+class TestDfToHist:
+    def test_empty_df_returns_empty_list(self):
+        assert _df_to_hist(_make_empty_df(), "AAPL") == []
+
+    def test_none_returns_empty_list(self):
+        assert _df_to_hist(None, "AAPL") == []
+
+    def test_most_recent_first(self):
+        """Output must be most-recent-first (yfinance returns oldest-first)."""
+        df = _make_ohlcv_df("AAPL", n=3, multi=False)
+        hist = _df_to_hist(df, "AAPL")
+        assert len(hist) == 3
+        # Dates should be in descending order
+        dates = [h["date"] for h in hist]
+        assert dates == sorted(dates, reverse=True)
+
+    def test_standard_keys_present(self):
+        df = _make_ohlcv_df("MSFT", multi=False)
+        hist = _df_to_hist(df, "MSFT")
+        row = hist[0]
+        for key in ("date", "open", "high", "low", "close", "adjClose", "volume"):
+            assert key in row, f"Missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# 9. _derive_quote unit tests
+# ---------------------------------------------------------------------------
+
+class TestDeriveQuote:
+    def _make_hist(self, n=30, close=100.0, high=105.0, low=95.0, volume=1_000_000):
+        return [
+            {"date": f"2026-01-{i+1:02d}", "open": close, "high": high,
+             "low": low, "close": close, "adjClose": close, "volume": volume}
+            for i in range(n)
+        ]
+
+    def test_price_is_most_recent_close(self):
+        hist = self._make_hist(close=150.0)
+        q = _derive_quote("AAPL", hist)
+        assert q["price"] == pytest.approx(150.0)
+
+    def test_year_high_from_hist(self):
+        hist = self._make_hist(high=200.0)
+        q = _derive_quote("AAPL", hist)
+        assert q["yearHigh"] == pytest.approx(200.0)
+
+    def test_year_low_from_hist(self):
+        hist = self._make_hist(low=80.0)
+        q = _derive_quote("AAPL", hist)
+        assert q["yearLow"] == pytest.approx(80.0)
+
+    def test_avg_volume_from_recent_bars(self):
+        hist = self._make_hist(volume=500_000)
+        q = _derive_quote("AAPL", hist)
+        assert q["avgVolume"] == 500_000
+
+    def test_market_cap_is_none(self):
+        hist = self._make_hist()
+        q = _derive_quote("AAPL", hist)
+        assert q["marketCap"] is None
+
+    def test_empty_hist_returns_empty_dict(self):
+        q = _derive_quote("AAPL", [])
+        assert q == {}

--- a/skills/vcp-screener/scripts/universe.py
+++ b/skills/vcp-screener/scripts/universe.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Curated starter universe of ~100 liquid U.S. stocks for the VCP screener.
+
+Organised by GICS sector. MA and V are classified under Financials
+(GICS: Data Processing & Outsourced Services within Financials sector).
+
+Use validate_universe() to assert integrity in tests.
+"""
+
+from __future__ import annotations
+
+STARTER_UNIVERSE: list[dict] = [
+    # ── Information Technology (18) ────────────────────────────────────────
+    {"symbol": "AAPL",  "name": "Apple Inc.",                        "sector": "Information Technology"},
+    {"symbol": "MSFT",  "name": "Microsoft Corporation",             "sector": "Information Technology"},
+    {"symbol": "NVDA",  "name": "NVIDIA Corporation",                "sector": "Information Technology"},
+    {"symbol": "AVGO",  "name": "Broadcom Inc.",                     "sector": "Information Technology"},
+    {"symbol": "AMD",   "name": "Advanced Micro Devices",            "sector": "Information Technology"},
+    {"symbol": "QCOM",  "name": "Qualcomm Inc.",                     "sector": "Information Technology"},
+    {"symbol": "INTC",  "name": "Intel Corporation",                 "sector": "Information Technology"},
+    {"symbol": "ORCL",  "name": "Oracle Corporation",                "sector": "Information Technology"},
+    {"symbol": "CRM",   "name": "Salesforce Inc.",                   "sector": "Information Technology"},
+    {"symbol": "ADBE",  "name": "Adobe Inc.",                        "sector": "Information Technology"},
+    {"symbol": "INTU",  "name": "Intuit Inc.",                       "sector": "Information Technology"},
+    {"symbol": "TXN",   "name": "Texas Instruments",                 "sector": "Information Technology"},
+    {"symbol": "MU",    "name": "Micron Technology",                 "sector": "Information Technology"},
+    {"symbol": "KLAC",  "name": "KLA Corporation",                   "sector": "Information Technology"},
+    {"symbol": "LRCX",  "name": "Lam Research Corporation",          "sector": "Information Technology"},
+    {"symbol": "AMAT",  "name": "Applied Materials Inc.",            "sector": "Information Technology"},
+    {"symbol": "PANW",  "name": "Palo Alto Networks",                "sector": "Information Technology"},
+    {"symbol": "SNPS",  "name": "Synopsys Inc.",                     "sector": "Information Technology"},
+    # ── Communication Services (8) ─────────────────────────────────────────
+    {"symbol": "GOOGL", "name": "Alphabet Inc. Class A",             "sector": "Communication Services"},
+    {"symbol": "META",  "name": "Meta Platforms Inc.",               "sector": "Communication Services"},
+    {"symbol": "NFLX",  "name": "Netflix Inc.",                      "sector": "Communication Services"},
+    {"symbol": "DIS",   "name": "The Walt Disney Company",           "sector": "Communication Services"},
+    {"symbol": "T",     "name": "AT&T Inc.",                         "sector": "Communication Services"},
+    {"symbol": "VZ",    "name": "Verizon Communications",            "sector": "Communication Services"},
+    {"symbol": "CMCSA", "name": "Comcast Corporation",               "sector": "Communication Services"},
+    {"symbol": "CHTR",  "name": "Charter Communications",            "sector": "Communication Services"},
+    # ── Consumer Discretionary (10) ────────────────────────────────────────
+    {"symbol": "AMZN",  "name": "Amazon.com Inc.",                   "sector": "Consumer Discretionary"},
+    {"symbol": "TSLA",  "name": "Tesla Inc.",                        "sector": "Consumer Discretionary"},
+    {"symbol": "HD",    "name": "The Home Depot Inc.",               "sector": "Consumer Discretionary"},
+    {"symbol": "LOW",   "name": "Lowe's Companies Inc.",             "sector": "Consumer Discretionary"},
+    {"symbol": "TJX",   "name": "TJX Companies Inc.",                "sector": "Consumer Discretionary"},
+    {"symbol": "SBUX",  "name": "Starbucks Corporation",             "sector": "Consumer Discretionary"},
+    {"symbol": "MCD",   "name": "McDonald's Corporation",            "sector": "Consumer Discretionary"},
+    {"symbol": "NKE",   "name": "Nike Inc.",                         "sector": "Consumer Discretionary"},
+    {"symbol": "BKNG",  "name": "Booking Holdings Inc.",             "sector": "Consumer Discretionary"},
+    {"symbol": "GM",    "name": "General Motors Company",            "sector": "Consumer Discretionary"},
+    # ── Consumer Staples (8) ───────────────────────────────────────────────
+    {"symbol": "PG",    "name": "Procter & Gamble Co.",              "sector": "Consumer Staples"},
+    {"symbol": "KO",    "name": "The Coca-Cola Company",             "sector": "Consumer Staples"},
+    {"symbol": "PEP",   "name": "PepsiCo Inc.",                      "sector": "Consumer Staples"},
+    {"symbol": "WMT",   "name": "Walmart Inc.",                      "sector": "Consumer Staples"},
+    {"symbol": "COST",  "name": "Costco Wholesale Corporation",      "sector": "Consumer Staples"},
+    {"symbol": "PM",    "name": "Philip Morris International",       "sector": "Consumer Staples"},
+    {"symbol": "MO",    "name": "Altria Group Inc.",                 "sector": "Consumer Staples"},
+    {"symbol": "CL",    "name": "Colgate-Palmolive Company",         "sector": "Consumer Staples"},
+    # ── Health Care (12) ───────────────────────────────────────────────────
+    {"symbol": "UNH",   "name": "UnitedHealth Group Inc.",           "sector": "Health Care"},
+    {"symbol": "JNJ",   "name": "Johnson & Johnson",                 "sector": "Health Care"},
+    {"symbol": "LLY",   "name": "Eli Lilly and Company",             "sector": "Health Care"},
+    {"symbol": "ABBV",  "name": "AbbVie Inc.",                       "sector": "Health Care"},
+    {"symbol": "MRK",   "name": "Merck & Co. Inc.",                  "sector": "Health Care"},
+    {"symbol": "TMO",   "name": "Thermo Fisher Scientific",          "sector": "Health Care"},
+    {"symbol": "ABT",   "name": "Abbott Laboratories",               "sector": "Health Care"},
+    {"symbol": "DHR",   "name": "Danaher Corporation",               "sector": "Health Care"},
+    {"symbol": "BMY",   "name": "Bristol-Myers Squibb",              "sector": "Health Care"},
+    {"symbol": "AMGN",  "name": "Amgen Inc.",                        "sector": "Health Care"},
+    {"symbol": "ISRG",  "name": "Intuitive Surgical Inc.",           "sector": "Health Care"},
+    {"symbol": "CVS",   "name": "CVS Health Corporation",            "sector": "Health Care"},
+    # ── Financials (12) ────────────────────────────────────────────────────
+    {"symbol": "JPM",   "name": "JPMorgan Chase & Co.",              "sector": "Financials"},
+    {"symbol": "BAC",   "name": "Bank of America Corp.",             "sector": "Financials"},
+    {"symbol": "WFC",   "name": "Wells Fargo & Company",             "sector": "Financials"},
+    {"symbol": "GS",    "name": "The Goldman Sachs Group",           "sector": "Financials"},
+    {"symbol": "MS",    "name": "Morgan Stanley",                    "sector": "Financials"},
+    {"symbol": "BLK",   "name": "BlackRock Inc.",                    "sector": "Financials"},
+    {"symbol": "AXP",   "name": "American Express Company",          "sector": "Financials"},
+    {"symbol": "SPGI",  "name": "S&P Global Inc.",                   "sector": "Financials"},
+    {"symbol": "MA",    "name": "Mastercard Incorporated",           "sector": "Financials"},
+    {"symbol": "V",     "name": "Visa Inc.",                         "sector": "Financials"},
+    {"symbol": "C",     "name": "Citigroup Inc.",                    "sector": "Financials"},
+    {"symbol": "USB",   "name": "U.S. Bancorp",                      "sector": "Financials"},
+    # ── Industrials (10) ───────────────────────────────────────────────────
+    {"symbol": "CAT",   "name": "Caterpillar Inc.",                  "sector": "Industrials"},
+    {"symbol": "DE",    "name": "Deere & Company",                   "sector": "Industrials"},
+    {"symbol": "HON",   "name": "Honeywell International",           "sector": "Industrials"},
+    {"symbol": "GE",    "name": "GE Aerospace",                      "sector": "Industrials"},
+    {"symbol": "BA",    "name": "The Boeing Company",                "sector": "Industrials"},
+    {"symbol": "UPS",   "name": "United Parcel Service",             "sector": "Industrials"},
+    {"symbol": "FDX",   "name": "FedEx Corporation",                 "sector": "Industrials"},
+    {"symbol": "MMM",   "name": "3M Company",                        "sector": "Industrials"},
+    {"symbol": "LMT",   "name": "Lockheed Martin Corporation",       "sector": "Industrials"},
+    {"symbol": "RTX",   "name": "RTX Corporation",                   "sector": "Industrials"},
+    # ── Energy (7) ────────────────────────────────────────────────────────
+    {"symbol": "XOM",   "name": "Exxon Mobil Corporation",           "sector": "Energy"},
+    {"symbol": "CVX",   "name": "Chevron Corporation",               "sector": "Energy"},
+    {"symbol": "COP",   "name": "ConocoPhillips",                    "sector": "Energy"},
+    {"symbol": "SLB",   "name": "SLB (Schlumberger)",                "sector": "Energy"},
+    {"symbol": "EOG",   "name": "EOG Resources Inc.",                "sector": "Energy"},
+    {"symbol": "PSX",   "name": "Phillips 66",                       "sector": "Energy"},
+    {"symbol": "OXY",   "name": "Occidental Petroleum",              "sector": "Energy"},
+    # ── Materials (5) ─────────────────────────────────────────────────────
+    {"symbol": "LIN",   "name": "Linde plc",                         "sector": "Materials"},
+    {"symbol": "APD",   "name": "Air Products and Chemicals",        "sector": "Materials"},
+    {"symbol": "SHW",   "name": "The Sherwin-Williams Company",      "sector": "Materials"},
+    {"symbol": "ECL",   "name": "Ecolab Inc.",                       "sector": "Materials"},
+    {"symbol": "FCX",   "name": "Freeport-McMoRan Inc.",             "sector": "Materials"},
+    # ── Real Estate (5) ───────────────────────────────────────────────────
+    {"symbol": "AMT",   "name": "American Tower Corporation",        "sector": "Real Estate"},
+    {"symbol": "PLD",   "name": "Prologis Inc.",                     "sector": "Real Estate"},
+    {"symbol": "CCI",   "name": "Crown Castle Inc.",                 "sector": "Real Estate"},
+    {"symbol": "EQIX",  "name": "Equinix Inc.",                      "sector": "Real Estate"},
+    {"symbol": "SPG",   "name": "Simon Property Group",              "sector": "Real Estate"},
+    # ── Utilities (5) ─────────────────────────────────────────────────────
+    {"symbol": "NEE",   "name": "NextEra Energy Inc.",               "sector": "Utilities"},
+    {"symbol": "DUK",   "name": "Duke Energy Corporation",           "sector": "Utilities"},
+    {"symbol": "SO",    "name": "The Southern Company",              "sector": "Utilities"},
+    {"symbol": "AEP",   "name": "American Electric Power",           "sector": "Utilities"},
+    {"symbol": "EXC",   "name": "Exelon Corporation",                "sector": "Utilities"},
+]
+
+# Fast symbol → sector lookup
+SECTOR_MAP: dict[str, str] = {e["symbol"]: e["sector"] for e in STARTER_UNIVERSE}
+
+# Fast symbol → name lookup
+NAME_MAP: dict[str, str] = {e["symbol"]: e["name"] for e in STARTER_UNIVERSE}
+
+
+def validate_universe(universe: list[dict] | None = None) -> list[str]:
+    """Return a list of validation error strings (empty = clean).
+
+    Checks performed:
+    - No duplicate ticker symbols
+    - No empty / whitespace-only ticker strings
+    - No blank sector labels
+    - All entries have 'symbol', 'name', 'sector' keys
+    """
+    if universe is None:
+        universe = STARTER_UNIVERSE
+
+    errors: list[str] = []
+    seen: set[str] = set()
+
+    for i, entry in enumerate(universe):
+        for key in ("symbol", "name", "sector"):
+            if key not in entry:
+                errors.append(f"Entry[{i}] missing key '{key}': {entry}")
+
+        sym = entry.get("symbol", "")
+        if not isinstance(sym, str) or not sym.strip():
+            errors.append(f"Entry[{i}] has empty/invalid symbol: {repr(sym)}")
+            continue
+
+        sym = sym.strip()
+        if sym in seen:
+            errors.append(f"Duplicate ticker: {sym}")
+        seen.add(sym)
+
+        sector = entry.get("sector", "")
+        if not isinstance(sector, str) or not sector.strip():
+            errors.append(f"Entry[{i}] ({sym}) has empty/invalid sector: {repr(sector)}")
+
+    return errors

--- a/skills/vcp-screener/scripts/yf_client.py
+++ b/skills/vcp-screener/scripts/yf_client.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Yahoo Finance client for VCP Screener bulk data download.
+
+Key design decisions
+--------------------
+* yf.download() is ONE function call but internally dispatches multiple HTTP
+  connections (one per ticker or small batch, using a thread pool). A network
+  failure can therefore affect individual symbols while leaving others intact,
+  which is why per-symbol retry and skipped-symbol tracking are necessary.
+* auto_adjust=False is set explicitly so that both Close (unadjusted) and
+  Adj Close (split/dividend adjusted) columns are preserved in the output.
+* All quote fields (price, yearHigh, yearLow, avgVolume) are derived from the
+  bulk OHLCV download — no per-ticker yf.Ticker().info calls in the scan path.
+* marketCap is not available from OHLCV; it is returned as None and the
+  existing report_generator renders it as "N/A".
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from statistics import mean
+from typing import Optional
+
+try:
+    import pandas as pd
+    import yfinance as yf
+except ImportError as exc:
+    print(
+        f"ERROR: Required library not found ({exc}). "
+        "Install with: pip install yfinance pandas",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+# Bounded retry: 3 attempts, exponential backoff
+RETRY_DELAYS: list[int] = [2, 4, 8]
+MAX_RETRIES: int = len(RETRY_DELAYS)
+
+# Rolling volume windows used for derived quote dict
+AVG_VOLUME_DAYS: int = 20
+
+
+def _df_to_hist(df: pd.DataFrame, symbol: str) -> list[dict]:
+    """Convert a single-symbol yfinance DataFrame to most-recent-first list of dicts.
+
+    Preserves both Close (unadjusted) and Adj Close (dividend/split adjusted).
+    Returns [] when the DataFrame is empty or all-NaN for the required columns.
+
+    yf.download() with group_by='ticker' (used in all list-based calls) returns
+    a MultiIndex where level-0 = ticker, level-1 = field, regardless of whether
+    the tickers argument has 1 or N elements.
+    The only exception is a bare string call without group_by, which yields
+    level-0 = field, level-1 = ticker; both cases are handled below.
+    """
+    if df is None or df.empty:
+        return []
+
+    # Normalise MultiIndex columns to a flat per-symbol DataFrame
+    if isinstance(df.columns, pd.MultiIndex):
+        level0 = set(df.columns.get_level_values(0))
+        level1 = set(df.columns.get_level_values(1))
+
+        if symbol in level0:
+            # group_by='ticker' layout: ticker at level-0, field at level-1
+            df = df[symbol]
+        elif symbol in level1:
+            # Bare-string download layout: field at level-0, ticker at level-1
+            df = df.xs(symbol, axis=1, level=1)
+        else:
+            return []
+
+    required = {"Open", "High", "Low", "Close", "Volume"}
+    if not required.issubset(df.columns):
+        return []
+
+    # Drop rows where Close is NaN (incomplete bars)
+    df = df.dropna(subset=["Close"])
+    if df.empty:
+        return []
+
+    rows = []
+    for ts, row in df.iterrows():
+        date_str = ts.strftime("%Y-%m-%d") if hasattr(ts, "strftime") else str(ts)[:10]
+        adj_close = float(row["Adj Close"]) if "Adj Close" in row and pd.notna(row["Adj Close"]) else float(row["Close"])
+        rows.append({
+            "date":     date_str,
+            "open":     float(row["Open"])   if pd.notna(row["Open"])   else None,
+            "high":     float(row["High"])   if pd.notna(row["High"])   else None,
+            "low":      float(row["Low"])    if pd.notna(row["Low"])    else None,
+            "close":    float(row["Close"])  if pd.notna(row["Close"])  else None,
+            "adjClose": adj_close,
+            "volume":   int(row["Volume"])   if pd.notna(row["Volume"]) else 0,
+        })
+
+    # Return most-recent-first (yfinance returns oldest-first)
+    rows.reverse()
+    return rows
+
+
+def _derive_quote(symbol: str, hist: list[dict]) -> dict:
+    """Derive pre-filter quote fields from OHLCV history (no extra HTTP calls).
+
+    Fields returned match what pre_filter_stock() and analyze_stock() expect:
+      price, yearHigh, yearLow, avgVolume, volume, marketCap (None)
+    """
+    if not hist:
+        return {}
+
+    price = hist[0]["close"] or 0.0
+    year_high = max((h["high"] for h in hist if h.get("high")), default=0.0)
+    year_low = min((h["low"] for h in hist if h.get("low") and h["low"] > 0), default=0.0)
+    recent_vols = [h["volume"] for h in hist[:AVG_VOLUME_DAYS] if h.get("volume")]
+    avg_volume = int(mean(recent_vols)) if recent_vols else 0
+
+    return {
+        "symbol":    symbol,
+        "price":     price,
+        "yearHigh":  year_high,
+        "yearLow":   year_low,
+        "avgVolume": avg_volume,
+        "volume":    hist[0].get("volume", 0),
+        "marketCap": None,  # not available from OHLCV; report shows N/A
+        "name":      symbol,
+    }
+
+
+class YFinanceClient:
+    """Bulk yfinance downloader with retry, cache, and skipped-symbol reporting.
+
+    Interface mirrors FMPClient's data methods so screen_vcp.py can route to
+    either provider with minimal branching.
+    """
+
+    def __init__(self) -> None:
+        # Cache keyed by (frozenset(symbols), period); value = {sym: hist_list}
+        self._cache: dict[tuple, dict[str, list[dict]]] = {}
+        self._skipped: list[dict] = []
+        self._retries_attempted: int = 0
+        self._symbols_requested: int = 0
+        self._symbols_downloaded: int = 0
+        self._cache_hits: int = 0
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Public API
+    # ──────────────────────────────────────────────────────────────────────
+
+    def bulk_download(
+        self,
+        symbols: list[str],
+        period: str = "1y",
+    ) -> dict[str, list[dict]]:
+        """Download OHLCV for all symbols in one yf.download() call.
+
+        yf.download() is one function call but internally fires multiple HTTP
+        connections. Symbols that return empty data are retried individually
+        with exponential backoff; those that remain empty after MAX_RETRIES
+        are logged in get_skipped_symbols().
+
+        auto_adjust=False is set explicitly to preserve both Close and Adj Close.
+
+        Returns {symbol: [most-recent-first hist dicts]}.
+        """
+        cache_key = (frozenset(symbols), period)
+        if cache_key in self._cache:
+            self._cache_hits += 1
+            return self._cache[cache_key]
+
+        self._symbols_requested += len(symbols)
+
+        result = self._download_bulk(symbols, period)
+
+        # Identify missing symbols after the initial bulk call
+        missing = [s for s in symbols if not result.get(s)]
+        if missing:
+            result.update(self._retry_missing(missing, period))
+
+        # Log anything still missing as skipped
+        for sym in symbols:
+            if not result.get(sym):
+                self._skipped.append({
+                    "symbol":         sym,
+                    "http_status":    0,
+                    "error_category": "yf_download_failed",
+                    "endpoint":       "yfinance_bulk",
+                })
+            else:
+                self._symbols_downloaded += 1
+
+        self._cache[cache_key] = result
+        return result
+
+    def get_batch_quotes(self, symbols: list[str], period: str = "1y") -> dict[str, dict]:
+        """Return derived quote dicts for all symbols.
+
+        Triggers a bulk download if not already cached. Symbols with no data
+        are silently absent from the returned dict (recorded in skipped list).
+        """
+        hist_map = self.bulk_download(symbols, period=period)
+        quotes = {}
+        for sym, hist in hist_map.items():
+            if hist:
+                quotes[sym] = _derive_quote(sym, hist)
+        return quotes
+
+    def get_historical_prices(self, symbol: str, period: str = "1y") -> Optional[dict]:
+        """Return v3-compatible dict for a single symbol, using the bulk cache if warm.
+
+        Returns {"symbol": sym, "historical": [most-recent-first dicts]} or None.
+        """
+        # Check cache for any bulk download that included this symbol
+        for (syms, p), hist_map in self._cache.items():
+            if symbol in syms and p == period and symbol in hist_map:
+                hist = hist_map[symbol]
+                return {"symbol": symbol, "historical": hist} if hist else None
+
+        # Fall back to individual download
+        hist_map = self.bulk_download([symbol], period=period)
+        hist = hist_map.get(symbol, [])
+        return {"symbol": symbol, "historical": hist} if hist else None
+
+    def get_skipped_symbols(self) -> list[dict]:
+        """Return a copy of the per-symbol failure log.
+
+        Each entry: {"symbol": str, "http_status": int,
+                     "error_category": str, "endpoint": str}
+        Matches the format of FMPClient.get_quote_failures().
+        """
+        return list(self._skipped)
+
+    def get_provider_stats(self) -> dict:
+        """Return download statistics for the summary block."""
+        return {
+            "provider":           "yfinance",
+            "symbols_requested":  self._symbols_requested,
+            "symbols_downloaded": self._symbols_downloaded,
+            "symbols_skipped":    len(self._skipped),
+            "retries_attempted":  self._retries_attempted,
+            "cache_hits":         self._cache_hits,
+        }
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Internal helpers
+    # ──────────────────────────────────────────────────────────────────────
+
+    def _download_bulk(self, symbols: list[str], period: str) -> dict[str, list[dict]]:
+        """Single yf.download() call; parse result into {sym: hist_list}."""
+        try:
+            raw = yf.download(
+                tickers=symbols,
+                period=period,
+                interval="1d",
+                auto_adjust=False,   # explicit: preserve Close AND Adj Close
+                progress=False,
+                group_by="ticker",
+                threads=True,
+            )
+        except Exception as exc:
+            print(f"WARNING: yf.download() raised {type(exc).__name__}: {exc}", file=sys.stderr)
+            return {}
+
+        if raw is None or raw.empty:
+            return {}
+
+        result: dict[str, list[dict]] = {}
+
+        if len(symbols) == 1:
+            # Single-symbol list with group_by='ticker': MultiIndex, ticker at level-0.
+            # _df_to_hist handles level-0 extraction; just pass raw as-is.
+            sym = symbols[0]
+            result[sym] = _df_to_hist(raw, sym)
+        else:
+            # Multi-ticker with group_by='ticker': MultiIndex, ticker at level-0,
+            # field at level-1. Use get_level_values(0) to enumerate tickers.
+            tickers_in_df = set()
+            if isinstance(raw.columns, pd.MultiIndex):
+                tickers_in_df = set(raw.columns.get_level_values(0))
+            for sym in symbols:
+                if sym in tickers_in_df:
+                    result[sym] = _df_to_hist(raw, sym)
+
+        return result
+
+    def _retry_missing(self, missing: list[str], period: str) -> dict[str, list[dict]]:
+        """Retry each missing symbol individually with exponential backoff."""
+        recovered: dict[str, list[dict]] = {}
+        for sym in missing:
+            for attempt, delay in enumerate(RETRY_DELAYS):
+                self._retries_attempted += 1
+                print(
+                    f"  Retry {attempt + 1}/{MAX_RETRIES} for {sym} "
+                    f"(waiting {delay}s)...",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+                batch = self._download_bulk([sym], period)
+                if batch.get(sym):
+                    recovered[sym] = batch[sym]
+                    break
+        return recovered


### PR DESCRIPTION
## Summary

Three connected improvements to the VCP screener across FMP reliability
and zero-cost data access:

**1. FMP free-tier stable-quote fix**
- Force single-symbol calls (batch_size=1) — multi-symbol batching on
  stable/quote returns 402 for free-plan users.
- Fall back to today's volume when avgVolume is absent from stable response,
  preventing all stocks from failing the Phase 1 pre-filter.
- Add .env to .gitignore so local API key files are never committed.

**2. Transparent skipped-symbol reporting for free-tier FMP**
- Disable v3 legacy fallback immediately on the first "Legacy Endpoint" 403
  (was: wait for threshold=3), reducing wasted API calls.
- Track per-symbol quote failures with symbol, http_status, error_category,
  and endpoint via FMPClient.get_quote_failures().
- Surface skipped symbols in both JSON and Markdown reports (warning banner,
  funnel row, Skipped Symbols table).

**3. Zero-cost yfinance default provider**
- New default: --provider yfinance — runs with no API key using a curated
  100-stock starter universe across all 11 GICS sectors.
- YFinanceClient: one bulk-download operation through yf.download()
  (auto_adjust=False), bounded retry (3 attempts, 2/4/8 s backoff),
  in-process cache, skipped-symbol reporting compatible with FMPClient
  interface.
- FMP remains fully available via --provider fmp for users who need the
  full S&P 500 or paid-tier endpoints.
- --full-sp500 with yfinance is blocked with a clear error and alternatives.

## Test plan

- [x] 311/311 VCP screener tests pass.
- [x] AAPL MSFT NVDA smoke test: 0 skipped, 0 retries, no API key.
- [x] 100-stock starter scan: 101 symbols downloaded, 0 skipped, 0 retries.
- [x] FMP free-tier verified: 25-stock universe → 19 quotes, 6 skipped,
      reports correctly annotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
