### PR TITLE
feat(market-top-detector): yfinance fallback for paid-tier-gated symbols

### DIFF
--- a/skills/market-top-detector/scripts/fmp_client.py
+++ b/skills/market-top-detector/scripts/fmp_client.py
@@ -116,6 +116,18 @@ def _normalize_eod_flat_list(data, symbols_str: str, limit: Optional[int] = None
     return {"symbol": matched_symbol or symbols_str, "historical": historical}
 
 
+def _has_usable_history(data) -> bool:
+    """True only when `data` is a dict carrying a non-empty `historical` list.
+
+    A dict with an empty `historical` list (e.g. an index/ETF unavailable on the
+    caller's FMP plan) is treated as unusable so the caller can fall back to
+    yfinance instead of caching an empty result.
+    """
+    return bool(
+        isinstance(data, dict) and isinstance(data.get("historical"), list) and data["historical"]
+    )
+
+
 class FMPClient:
     """Client for Financial Modeling Prep API with rate limiting and caching"""
 
@@ -268,26 +280,126 @@ class FMPClient:
             self._disabled_endpoints.add(base_url)
 
     def get_quote(self, symbols: str) -> Optional[list[dict]]:
-        """Fetch real-time quote data for one or more symbols (comma-separated)"""
+        """Fetch real-time quote data for one or more symbols (comma-separated).
+
+        Falls back to a yfinance-derived quote when FMP returns nothing (e.g. an
+        index like ^GSPC/^VIX gated behind a paid FMP plan). Fallback is
+        single-symbol only — comma lists are left to FMP.
+        """
         cache_key = f"quote_{symbols}"
         if cache_key in self.cache:
             return self.cache[cache_key]
 
         data = self._request_with_fallback("quote", symbols)
+        if not data and "," not in symbols:
+            data = self._get_quote_from_yfinance(symbols)
         if data:
             self.cache[cache_key] = data
         return data
 
+    def _get_quote_from_yfinance(self, symbol: str) -> Optional[list[dict]]:
+        """Fallback quote derived from recent yfinance daily bars.
+
+        Returns the FMP quote shape (a list with one dict carrying
+        price/previousClose/change/changesPercentage/open/high/low/volume/
+        yearHigh/yearLow), or ``None`` when history is unavailable. Year
+        high/low are approximated from ~252 daily bars.
+        """
+        hist = self._get_hist_from_yfinance(symbol, 260)
+        if not _has_usable_history(hist):
+            return None
+        bars = hist["historical"]  # most-recent-first
+        latest = bars[0]
+        prev_close = bars[1]["close"] if len(bars) > 1 else latest["close"]
+        price = latest["close"]
+        change = price - prev_close
+        pct = (change / prev_close * 100) if prev_close else 0.0
+        window = bars[:252]
+        year_high = max(b["high"] for b in window)
+        year_low = min(b["low"] for b in window)
+        return [
+            {
+                "symbol": symbol,
+                "price": price,
+                "previousClose": prev_close,
+                "change": round(change, 4),
+                "changesPercentage": round(pct, 4),
+                "open": latest["open"],
+                "dayHigh": latest["high"],
+                "dayLow": latest["low"],
+                "high": latest["high"],
+                "low": latest["low"],
+                "volume": latest["volume"],
+                "yearHigh": year_high,
+                "yearLow": year_low,
+            }
+        ]
+
     def get_historical_prices(self, symbol: str, days: int = 365) -> Optional[dict]:
-        """Fetch historical daily OHLCV data"""
+        """Fetch historical daily OHLCV data.
+
+        Falls back to yfinance when the FMP endpoint returns no usable history
+        (e.g. an index/ETF gated behind a paid FMP plan). The yfinance path
+        needs no extra API key; an FMP key is still required to build the client.
+        """
         cache_key = f"prices_{symbol}_{days}"
         if cache_key in self.cache:
             return self.cache[cache_key]
 
         data = self._request_with_fallback("historical", symbol, {"timeseries": days})
-        if data:
+        if not _has_usable_history(data):
+            data = self._get_hist_from_yfinance(symbol, days)
+        if _has_usable_history(data):
             self.cache[cache_key] = data
-        return data
+            return data
+        return None
+
+    def _get_hist_from_yfinance(self, symbol: str, days: int) -> Optional[dict]:
+        """Fallback: fetch daily history via yfinance when FMP is unavailable.
+
+        Returns the FMP-compatible shape ``{"symbol": ..., "historical": [...]}``
+        with most-recent-first bars (date/open/high/low/close/adjClose/volume),
+        or ``None`` on empty/error. ``yfinance`` is imported lazily so the FMP
+        success path never depends on it.
+        """
+        try:
+            import yfinance as yf
+
+            end = date.today()
+            start = end - timedelta(days=int(days * 1.5))  # cover weekends/holidays
+            df = yf.download(
+                symbol,
+                start=start.isoformat(),
+                end=end.isoformat(),
+                auto_adjust=True,
+                progress=False,
+            )
+            if df is None or df.empty:
+                return None
+            # yfinance returns MultiIndex columns for a single ticker.
+            if hasattr(df.columns, "levels"):
+                df.columns = df.columns.droplevel(1)
+            historical = []
+            for idx, row in df.iterrows():
+                close = float(row["Close"])
+                historical.append(
+                    {
+                        "date": idx.strftime("%Y-%m-%d"),
+                        "open": float(row["Open"]),
+                        "high": float(row["High"]),
+                        "low": float(row["Low"]),
+                        "close": close,
+                        "adjClose": close,  # auto_adjust=True -> Close already adjusted
+                        "volume": int(row["Volume"]),
+                    }
+                )
+            if not historical:
+                return None
+            historical.reverse()  # yfinance ascending -> FMP most-recent-first
+            return {"symbol": symbol, "historical": historical[:days]}
+        except Exception as e:
+            print(f"WARNING: yfinance history fallback failed for {symbol}: {e}", file=sys.stderr)
+            return None
 
     def get_batch_quotes(self, symbols: list[str]) -> dict[str, dict]:
         """Fetch quotes for a list of symbols.

--- a/skills/market-top-detector/scripts/tests/test_fmp_client.py
+++ b/skills/market-top-detector/scripts/tests/test_fmp_client.py
@@ -128,13 +128,16 @@ class TestEndpointFallback:
         assert result == v3_data
 
     def test_quote_both_fail(self):
-        """Both endpoints 403 returns None."""
+        """Both FMP endpoints 403 and yfinance unavailable returns None."""
         client = self._make_client()
 
         def mock_get(url, params=None, timeout=None):
             return _mock_response(403, text="Forbidden")
 
         client.session.get = mock_get
+        # Simulate yfinance fallback also unavailable so the "all sources
+        # failed -> None" contract still holds.
+        client._get_hist_from_yfinance = lambda *a, **k: None
         result = client.get_quote("^GSPC")
         assert result is None
 
@@ -213,7 +216,7 @@ class TestEndpointFallback:
         assert result == v3_data
 
     def test_historical_batch_no_match_returns_none_when_v3_also_fails(self):
-        """Stable batch no match + v3 403 returns None."""
+        """Stable batch no match + v3 403 + yfinance unavailable returns None."""
         client = self._make_client()
         batch_data = {
             "historicalStockList": [
@@ -230,6 +233,8 @@ class TestEndpointFallback:
             return _mock_response(403, text="Forbidden")
 
         client.session.get = mock_get
+        # Simulate yfinance fallback also unavailable.
+        client._get_hist_from_yfinance = lambda *a, **k: None
         result = client.get_historical_prices("^GSPC", days=80)
         assert result is None
 
@@ -590,3 +595,137 @@ class TestEODFlatListSuccess:
         assert "historical-price-eod/full" in url
         assert "from" in params and "to" in params
         assert "timeseries" not in params
+
+
+# --- yfinance fallback for paid-tier-gated symbols (indices/ETFs) ---
+
+
+class _FakeColumns:
+    """Plain columns object WITHOUT a `levels` attr (no MultiIndex)."""
+
+
+class _FakeTS:
+    def __init__(self, iso):
+        self._iso = iso
+
+    def strftime(self, fmt):
+        return self._iso  # tests only use %Y-%m-%d
+
+
+class _FakeDF:
+    """Minimal stand-in for a yfinance DataFrame (ascending by date)."""
+
+    def __init__(self, rows):
+        self._rows = rows  # list of (Timestamp-like, dict)
+        self.empty = len(rows) == 0
+        self.columns = _FakeColumns()
+
+    def iterrows(self):
+        return iter(self._rows)
+
+
+def _row(iso, o, h, lo, c, v):
+    return (_FakeTS(iso), {"Open": o, "High": h, "Low": lo, "Close": c, "Volume": v})
+
+
+def _make_client():
+    with patch.dict(os.environ, {"FMP_API_KEY": "test_key"}):
+        from fmp_client import FMPClient
+
+        return FMPClient(api_key="test_key")
+
+
+class TestYFinanceFallback:
+    """get_historical_prices / get_quote fall back to yfinance when FMP returns
+    nothing (e.g. ^GSPC/^VIX or sector ETFs gated behind a paid FMP plan)."""
+
+    @patch("fmp_client.FMPClient._request_with_fallback", return_value=None)
+    def test_historical_fallback_invoked_and_shape(self, _mock_fmp):
+        client = _make_client()
+        fake_df = _FakeDF(
+            [
+                _row("2026-04-27", 1.0, 2.0, 0.5, 1.5, 100),
+                _row("2026-04-28", 1.5, 2.5, 1.0, 2.0, 200),
+                _row("2026-04-29", 2.0, 3.0, 1.5, 2.5, 300),
+            ]
+        )
+        fake_yf = MagicMock()
+        fake_yf.download.return_value = fake_df
+
+        with patch.dict("sys.modules", {"yfinance": fake_yf}):
+            result = client.get_historical_prices("^GSPC", days=10)
+
+        assert isinstance(result, dict)
+        assert result["symbol"] == "^GSPC"
+        hist = result["historical"]
+        assert len(hist) == 3
+        # Most-recent-first (descending) per FMP contract
+        assert hist[0]["date"] == "2026-04-29"
+        assert hist[-1]["date"] == "2026-04-27"
+        for key in ("date", "open", "high", "low", "close", "adjClose", "volume"):
+            assert key in hist[0]
+        assert hist[0]["close"] == hist[0]["adjClose"] == 2.5
+
+    @patch("fmp_client.FMPClient._request_with_fallback", return_value=None)
+    def test_quote_fallback_derives_fields(self, _mock_fmp):
+        client = _make_client()
+        # ascending; latest close 2.5, prev close 2.0 -> +25%
+        fake_df = _FakeDF(
+            [
+                _row("2026-04-27", 1.0, 4.0, 0.5, 1.5, 100),  # yearHigh source
+                _row("2026-04-28", 1.5, 2.5, 0.2, 2.0, 200),  # yearLow source
+                _row("2026-04-29", 2.0, 3.0, 1.5, 2.5, 300),
+            ]
+        )
+        fake_yf = MagicMock()
+        fake_yf.download.return_value = fake_df
+
+        with patch.dict("sys.modules", {"yfinance": fake_yf}):
+            quotes = client.get_quote("^VIX")
+
+        assert isinstance(quotes, list) and len(quotes) == 1
+        q = quotes[0]
+        assert q["symbol"] == "^VIX"
+        assert q["price"] == 2.5
+        assert q["previousClose"] == 2.0
+        assert q["change"] == 0.5
+        assert q["changesPercentage"] == 25.0
+        assert q["yearHigh"] == 4.0
+        assert q["yearLow"] == 0.2
+
+    @patch("fmp_client.FMPClient._request_with_fallback", return_value=None)
+    def test_empty_df_returns_none_and_not_cached(self, _mock_fmp):
+        client = _make_client()
+        fake_yf = MagicMock()
+        fake_yf.download.return_value = _FakeDF([])
+
+        with patch.dict("sys.modules", {"yfinance": fake_yf}):
+            result = client.get_historical_prices("^IXIC", days=5)
+
+        assert result is None
+        assert "prices_^IXIC_5" not in client.cache
+
+    @patch("fmp_client.FMPClient._request_with_fallback")
+    def test_fmp_success_does_not_call_yfinance(self, mock_fmp):
+        mock_fmp.return_value = {
+            "symbol": "SPY",
+            "historical": [{"date": "2026-04-29", "close": 1.0}],
+        }
+        client = _make_client()
+        fake_yf = MagicMock()
+
+        with patch.dict("sys.modules", {"yfinance": fake_yf}):
+            result = client.get_historical_prices("SPY", days=5)
+
+        assert result["symbol"] == "SPY"
+        fake_yf.download.assert_not_called()
+
+    @patch("fmp_client.FMPClient._request_with_fallback", return_value=None)
+    def test_batch_quote_not_single_skips_fallback(self, _mock_fmp):
+        """Comma-separated symbols are left to FMP (no single-symbol fallback)."""
+        client = _make_client()
+        fake_yf = MagicMock()
+        with patch.dict("sys.modules", {"yfinance": fake_yf}):
+            result = client.get_quote("AAA,BBB")
+        assert result is None
+        fake_yf.download.assert_not_called()


### PR DESCRIPTION
## Problem

On the **FMP free tier**, index symbols (`^GSPC`/`^IXIC`/`^VIX`/`^VIX3M`) and many sector/leading ETFs are gated behind a paid plan — `/stable` returns *"Premium Query Parameter"* and `/api/v3` returns `403 "Legacy Endpoint"`. `market-top-detector` has the stable→v3 shim but **no yfinance fallback**, so for free-tier keys two components silently degrade to **INSUFFICIENT DATA**:

- `[2/6] Leading Stock Health`
- `[3/6] Defensive Sector Rotation`

(`macro-regime-detector` already ships a yfinance fallback for exactly this reason — this PR brings `market-top-detector` to parity.)

## Change

Mirrors the macro-regime-detector approach in `skills/market-top-detector/scripts/fmp_client.py`:

- `_has_usable_history()` helper
- `_get_hist_from_yfinance()` — lazy import, FMP-compatible `{"symbol", "historical":[...]}` shape, most-recent-first OHLCV
- `_get_quote_from_yfinance()` — derives an FMP-shaped quote (`price`/`previousClose`/`change`/`changesPercentage`/`open`/`high`/`low`/`volume`/`yearHigh`/`yearLow`) from recent daily bars
- wired into `get_historical_prices()` / `get_quote()` (single-symbol only; comma-separated batches are left to FMP)

`yfinance` needs no extra API key; an FMP key is still required to construct the client, and the FMP success path never imports yfinance.

## Verification

- Live free-tier run: the two degraded components now return real scores (Leading Stock Health / Defensive Sector Rotation), composite no longer partial.
- **Tests:** 5 new fallback cases added; 2 existing *"all sources fail → None"* tests updated to also stub yfinance as unavailable. Full suite **201 passed**.
- `ruff check` + `ruff format --check` clean (line-length 100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)