### PR TITLE
[codex] Add weekly core collector and skill workflow notes

### DIFF
--- a/scripts/tests/test_weekly_core_collect.py
+++ b/scripts/tests/test_weekly_core_collect.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import weekly_core_collect as collector  # noqa: E402
+
+DUMMY_FMP_VALUE = "placeholder"
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload=None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def test_parse_bool_treats_one_as_paper_endpoint() -> None:
+    assert collector.parse_bool("1", "ALPACA_PAPER") is True
+    assert collector.parse_bool("true", "ALPACA_PAPER") is True
+    assert collector.parse_bool("0", "ALPACA_PAPER") is False
+    assert collector.parse_bool("false", "ALPACA_PAPER") is False
+
+
+def test_parse_bool_rejects_invalid_values() -> None:
+    with pytest.raises(SystemExit, match="refusing to choose a live Alpaca endpoint"):
+        collector.parse_bool("maybe", "ALPACA_PAPER")
+
+
+def test_fmp_get_prefers_stable_then_falls_back_to_v3(monkeypatch) -> None:
+    calls = []
+
+    def fake_get(url, params, timeout):
+        calls.append({"url": url, "params": dict(params), "timeout": timeout})
+        if url == "https://financialmodelingprep.com/stable/profile":
+            return FakeResponse(403, text="stable forbidden")
+        return FakeResponse(200, [{"symbol": "AAPL", "sector": "Technology"}])
+
+    monkeypatch.setattr(collector.requests, "get", fake_get)
+
+    client = collector.FmpClient(DUMMY_FMP_VALUE)
+    result = client.get("profile/AAPL")
+
+    assert result == [{"symbol": "AAPL", "sector": "Technology"}]
+    assert calls == [
+        {
+            "url": "https://financialmodelingprep.com/stable/profile",
+            "params": {"symbol": "AAPL", "apikey": DUMMY_FMP_VALUE},
+            "timeout": 30,
+        },
+        {
+            "url": "https://financialmodelingprep.com/api/v3/profile/AAPL",
+            "params": {"apikey": DUMMY_FMP_VALUE},
+            "timeout": 30,
+        },
+    ]
+    assert client.diagnostics()["status"] == "degraded"
+
+
+def test_fmp_cash_flow_normalizes_stable_dividend_field(monkeypatch) -> None:
+    def fake_get(url, params, timeout):
+        return FakeResponse(
+            200,
+            [{"symbol": "AAPL", "netDividendsPaid": -100, "operatingCashFlow": 500}],
+        )
+
+    monkeypatch.setattr(collector.requests, "get", fake_get)
+
+    client = collector.FmpClient(DUMMY_FMP_VALUE)
+    result = client.get("cash-flow-statement/AAPL", limit=4)
+
+    assert result == [
+        {
+            "symbol": "AAPL",
+            "netDividendsPaid": -100,
+            "dividendsPaid": -100,
+            "operatingCashFlow": 500,
+        }
+    ]
+    assert client.diagnostics()["status"] == "ok"
+
+
+def test_fmp_diagnostics_fail_when_all_attempts_fail(monkeypatch) -> None:
+    def fake_get(url, params, timeout):
+        return FakeResponse(403, text="forbidden")
+
+    monkeypatch.setattr(collector.requests, "get", fake_get)
+
+    client = collector.FmpClient(DUMMY_FMP_VALUE)
+    assert client.get("profile/AAPL") is None
+
+    diagnostics = client.diagnostics()
+    assert diagnostics["status"] == "failed"
+    assert diagnostics["attempts"] == 2
+    assert diagnostics["successes"] == 0
+    assert diagnostics["failures"] == 2

--- a/scripts/tests/test_weekly_core_collect.py
+++ b/scripts/tests/test_weekly_core_collect.py
@@ -102,3 +102,53 @@ def test_fmp_diagnostics_fail_when_all_attempts_fail(monkeypatch) -> None:
     assert diagnostics["attempts"] == 2
     assert diagnostics["successes"] == 0
     assert diagnostics["failures"] == 2
+
+
+def test_fetch_profiles_and_quotes_uses_per_symbol_stable_requests(monkeypatch) -> None:
+    calls = []
+
+    def fake_get(url, params, timeout):
+        calls.append({"url": url, "params": dict(params), "timeout": timeout})
+        symbol = params["symbol"]
+        if url == "https://financialmodelingprep.com/stable/profile":
+            return FakeResponse(200, [{"symbol": symbol, "sector": "Technology"}])
+        if url == "https://financialmodelingprep.com/stable/quote":
+            return FakeResponse(200, [{"symbol": symbol, "price": 100}])
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr(collector.requests, "get", fake_get)
+
+    client = collector.FmpClient(DUMMY_FMP_VALUE)
+    profiles, quotes = collector.fetch_profiles_and_quotes(["AAPL", "MSFT"], client)
+
+    assert profiles == {
+        "AAPL": {"symbol": "AAPL", "sector": "Technology"},
+        "MSFT": {"symbol": "MSFT", "sector": "Technology"},
+    }
+    assert quotes == {
+        "AAPL": {"symbol": "AAPL", "price": 100},
+        "MSFT": {"symbol": "MSFT", "price": 100},
+    }
+    assert [call["params"]["symbol"] for call in calls] == ["AAPL", "AAPL", "MSFT", "MSFT"]
+    assert all("," not in call["params"]["symbol"] for call in calls)
+    assert client.diagnostics()["status"] == "ok"
+
+
+def test_fetch_profiles_and_quotes_marks_empty_responses_degraded(monkeypatch) -> None:
+    def fake_get(url, params, timeout):
+        return FakeResponse(200, [])
+
+    monkeypatch.setattr(collector.requests, "get", fake_get)
+
+    client = collector.FmpClient(DUMMY_FMP_VALUE)
+    profiles, quotes = collector.fetch_profiles_and_quotes(["AAPL"], client)
+
+    assert profiles == {}
+    assert quotes == {}
+    diagnostics = client.diagnostics()
+    assert diagnostics["status"] == "degraded"
+    assert diagnostics["missing"] == 2
+    assert diagnostics["missing_samples"] == [
+        {"source": "profile", "symbol": "AAPL", "reason": "empty_or_unmatched_response"},
+        {"source": "quote", "symbol": "AAPL", "reason": "empty_or_unmatched_response"},
+    ]

--- a/scripts/weekly_core_collect.py
+++ b/scripts/weekly_core_collect.py
@@ -16,7 +16,15 @@ import requests
 
 ALPACA_PAPER_BASE_URL = "https://paper-api.alpaca.markets"
 ALPACA_LIVE_BASE_URL = "https://api.alpaca.markets"
-FMP_BASE_URL = "https://financialmodelingprep.com/api/v3"
+FMP_V3_BASE_URL = "https://financialmodelingprep.com/api/v3"
+FMP_STABLE_BASE_URL = "https://financialmodelingprep.com/stable"
+FMP_SYMBOL_QUERY_ENDPOINTS = {
+    "balance-sheet-statement",
+    "cash-flow-statement",
+    "income-statement",
+    "profile",
+    "quote",
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,9 +45,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--alpaca-paper",
-        choices=["true", "false"],
         default=os.environ.get("ALPACA_PAPER", "true").lower(),
-        help="Use Alpaca paper endpoint when true. Defaults to ALPACA_PAPER or true.",
+        help=(
+            "Use Alpaca paper endpoint. Accepts true/false, yes/no, or 1/0. "
+            "Defaults to ALPACA_PAPER or true."
+        ),
     )
     parser.add_argument(
         "--fmp-sleep-seconds",
@@ -47,7 +57,21 @@ def parse_args() -> argparse.Namespace:
         default=0.08,
         help="Pause between per-symbol FMP request groups.",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    args.alpaca_paper = parse_bool(args.alpaca_paper, "ALPACA_PAPER/--alpaca-paper")
+    return args
+
+
+def parse_bool(value: str, name: str) -> bool:
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "f", "no", "n", "off"}:
+        return False
+    raise SystemExit(
+        f"Invalid {name}: {value!r}. Expected true/false, yes/no, or 1/0; refusing "
+        "to choose a live Alpaca endpoint implicitly."
+    )
 
 
 def require_env(name: str) -> str:
@@ -83,38 +107,140 @@ def alpaca_base_url(use_paper: bool) -> str:
     return ALPACA_PAPER_BASE_URL if use_paper else ALPACA_LIVE_BASE_URL
 
 
-def fmp_get(api_key: str | None, path: str, **params: Any) -> Any:
-    if not api_key:
+class FmpClient:
+    """Small stable-first FMP client for the weekly collector.
+
+    Callers pass the legacy v3 path-style endpoints used elsewhere in the repo.
+    The client tries the known /stable query-style equivalent first, falls back
+    to v3 for legacy keys, and records diagnostics instead of silently dropping
+    enrichment failures.
+    """
+
+    def __init__(self, api_key: str | None):
+        self.api_key = api_key
+        self.attempts = 0
+        self.successes = 0
+        self.failures: list[dict[str, Any]] = []
+
+    def get(self, path: str, **params: Any) -> Any:
+        if not self.api_key:
+            return None
+
+        attempts: list[tuple[str, str, dict[str, Any]]] = []
+        stable_spec = self._stable_spec(path, params)
+        if stable_spec:
+            attempts.append(("stable", stable_spec[0], stable_spec[1]))
+        attempts.append(("v3", f"{FMP_V3_BASE_URL}/{path}", dict(params)))
+
+        for source, url, req_params in attempts:
+            data = self._request(source, path, url, req_params)
+            if data is not None:
+                return self._normalize(path, data)
         return None
-    params["apikey"] = api_key
-    try:
-        response = requests.get(f"{FMP_BASE_URL}/{path}", params=params, timeout=30)
+
+    def diagnostics(self) -> dict[str, Any]:
+        if not self.api_key:
+            status = "disabled"
+        elif self.attempts == 0:
+            status = "skipped"
+        elif self.successes == 0:
+            status = "failed"
+        elif self.failures:
+            status = "degraded"
+        else:
+            status = "ok"
+
+        return {
+            "status": status,
+            "attempts": self.attempts,
+            "successes": self.successes,
+            "failures": len(self.failures),
+            "failure_samples": self.failures[:20],
+        }
+
+    @staticmethod
+    def _stable_spec(path: str, params: dict[str, Any]) -> tuple[str, dict[str, Any]] | None:
+        stable_params = dict(params)
+        if path.startswith("historical-price-full/stock_dividend/"):
+            stable_params["symbol"] = path.rsplit("/", 1)[-1]
+            return f"{FMP_STABLE_BASE_URL}/dividends", stable_params
+
+        endpoint, _, symbol = path.partition("/")
+        if symbol and endpoint in FMP_SYMBOL_QUERY_ENDPOINTS:
+            stable_params["symbol"] = symbol
+            return f"{FMP_STABLE_BASE_URL}/{endpoint}", stable_params
+
+        return None
+
+    @staticmethod
+    def _normalize(path: str, data: Any) -> Any:
+        if path.startswith("historical-price-full/stock_dividend/"):
+            return {"historical": data} if isinstance(data, list) else data
+
+        if path.startswith(("profile/", "quote/")) and isinstance(data, dict):
+            return [data]
+
+        if path.startswith("cash-flow-statement/") and isinstance(data, list):
+            for row in data:
+                if (
+                    isinstance(row, dict)
+                    and "dividendsPaid" not in row
+                    and "netDividendsPaid" in row
+                ):
+                    row["dividendsPaid"] = row["netDividendsPaid"]
+
+        return data
+
+    def _request(self, source: str, path: str, url: str, params: dict[str, Any]) -> Any:
+        self.attempts += 1
+        req_params = dict(params)
+        req_params["apikey"] = self.api_key
+        try:
+            response = requests.get(url, params=req_params, timeout=30)
+        except requests.RequestException as exc:
+            self.failures.append({"source": source, "path": path, "error": str(exc)})
+            return None
+
         if response.status_code != 200:
-            return {"_status": response.status_code, "_text": response.text[:200]}
-        return response.json()
-    except requests.RequestException as exc:
-        return {"_error": str(exc)}
+            self.failures.append(
+                {
+                    "source": source,
+                    "path": path,
+                    "status_code": response.status_code,
+                    "body_preview": response.text[:200],
+                }
+            )
+            return None
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            self.failures.append({"source": source, "path": path, "error": str(exc)})
+            return None
+
+        self.successes += 1
+        return data
 
 
 def chunks(values: list[str], size: int) -> list[list[str]]:
     return [values[i : i + size] for i in range(0, len(values), size)]
 
 
-def fetch_profiles_and_quotes(symbols: list[str], fmp_api_key: str | None) -> tuple[dict, dict]:
+def fetch_profiles_and_quotes(symbols: list[str], fmp_client: FmpClient) -> tuple[dict, dict]:
     profiles: dict[str, dict] = {}
     quotes: dict[str, dict] = {}
-    if not symbols or not fmp_api_key:
+    if not symbols or not fmp_client.api_key:
         return profiles, quotes
 
     for chunk in chunks(symbols, 50):
         symbol_csv = ",".join(chunk)
-        profile_data = fmp_get(fmp_api_key, f"profile/{symbol_csv}")
+        profile_data = fmp_client.get(f"profile/{symbol_csv}")
         if isinstance(profile_data, list):
             profiles.update(
                 {item.get("symbol"): item for item in profile_data if item.get("symbol")}
             )
 
-        quote_data = fmp_get(fmp_api_key, f"quote/{symbol_csv}")
+        quote_data = fmp_client.get(f"quote/{symbol_csv}")
         if isinstance(quote_data, list):
             quotes.update({item.get("symbol"): item for item in quote_data if item.get("symbol")})
 
@@ -126,7 +252,7 @@ def build_holding_rows(
     positions: list[dict],
     profiles: dict[str, dict],
     quotes: dict[str, dict],
-    fmp_api_key: str | None,
+    fmp_client: FmpClient,
     fmp_sleep_seconds: float,
 ) -> tuple[list[dict], list[dict]]:
     monitor_holdings = []
@@ -143,14 +269,14 @@ def build_holding_rows(
         cashflow = []
         income = []
         balance_sheet = []
-        if fmp_api_key:
-            dividend_data = fmp_get(fmp_api_key, f"historical-price-full/stock_dividend/{symbol}")
+        if fmp_client.api_key:
+            dividend_data = fmp_client.get(f"historical-price-full/stock_dividend/{symbol}")
             if isinstance(dividend_data, dict):
                 dividends = dividend_data.get("historical") or []
 
-            cashflow = fmp_get(fmp_api_key, f"cash-flow-statement/{symbol}", limit=4)
-            income = fmp_get(fmp_api_key, f"income-statement/{symbol}", limit=4)
-            balance_sheet = fmp_get(fmp_api_key, f"balance-sheet-statement/{symbol}", limit=4)
+            cashflow = fmp_client.get(f"cash-flow-statement/{symbol}", limit=4)
+            income = fmp_client.get(f"income-statement/{symbol}", limit=4)
+            balance_sheet = fmp_client.get(f"balance-sheet-statement/{symbol}", limit=4)
             time.sleep(fmp_sleep_seconds)
 
         positive_dividends = [
@@ -280,7 +406,7 @@ def build_holding_rows(
     return full_rows, monitor_holdings
 
 
-def build_summary(account: dict, holdings: list[dict], as_of: str) -> dict:
+def build_summary(account: dict, holdings: list[dict], as_of: str, fmp_status: dict) -> dict:
     sector_weights: dict[str, float] = defaultdict(float)
     for row in holdings:
         sector_weights[row["sector"]] += row["market_value"]
@@ -307,6 +433,7 @@ def build_summary(account: dict, holdings: list[dict], as_of: str) -> dict:
         },
         "positions_count": len(holdings),
         "symbols": [row["symbol"] for row in holdings],
+        "fmp_enrichment": fmp_status,
         "gross_long_exposure_pct_equity": long_market_value / equity * 100 if equity else None,
         "cash_pct_equity": to_float(account.get("cash")) / equity * 100 if equity else None,
         "sector_weights_gross_long": {
@@ -326,8 +453,7 @@ def main() -> None:
     args = parse_args()
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
-    use_paper = args.alpaca_paper == "true"
-    base_url = alpaca_base_url(use_paper)
+    base_url = alpaca_base_url(args.alpaca_paper)
     headers = alpaca_headers()
     account = get_json(f"{base_url}/v2/account", headers=headers)
     positions = get_json(f"{base_url}/v2/positions", headers=headers)
@@ -337,12 +463,13 @@ def main() -> None:
         raise SystemExit("Unexpected Alpaca positions response")
 
     symbols = [position["symbol"] for position in positions]
-    fmp_api_key = os.environ.get("FMP_API_KEY")
-    profiles, quotes = fetch_profiles_and_quotes(symbols, fmp_api_key)
+    fmp_client = FmpClient(os.environ.get("FMP_API_KEY"))
+    profiles, quotes = fetch_profiles_and_quotes(symbols, fmp_client)
     holdings, monitor_holdings = build_holding_rows(
-        account, positions, profiles, quotes, fmp_api_key, args.fmp_sleep_seconds
+        account, positions, profiles, quotes, fmp_client, args.fmp_sleep_seconds
     )
-    summary = build_summary(account, holdings, args.as_of)
+    fmp_status = fmp_client.diagnostics()
+    summary = build_summary(account, holdings, args.as_of, fmp_status)
 
     holdings_path = args.output_dir / f"core_portfolio_holdings_{args.as_of}.json"
     monitor_path = args.output_dir / f"kanchi_monitor_input_{args.as_of}.json"
@@ -363,10 +490,13 @@ def main() -> None:
                 "long_mv": account.get("long_market_value"),
                 "cash": account.get("cash"),
                 "sector_weights": summary["sector_weights_gross_long"],
+                "fmp_enrichment": fmp_status,
             },
             indent=2,
         )
     )
+    if fmp_status["status"] == "failed":
+        raise SystemExit("FMP enrichment failed; artifacts were written with fmp_enrichment=failed")
 
 
 if __name__ == "__main__":

--- a/scripts/weekly_core_collect.py
+++ b/scripts/weekly_core_collect.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Collect weekly core portfolio data for local review workflows."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import requests
+
+ALPACA_PAPER_BASE_URL = "https://paper-api.alpaca.markets"
+ALPACA_LIVE_BASE_URL = "https://api.alpaca.markets"
+FMP_BASE_URL = "https://financialmodelingprep.com/api/v3"
+
+
+def parse_args() -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(
+        description="Collect Alpaca holdings plus FMP enrichment for weekly core reviews."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=repo_root / "reports",
+        help="Directory for generated JSON artifacts. Defaults to reports/ in this repo.",
+    )
+    parser.add_argument(
+        "--as-of",
+        default=dt.datetime.now().astimezone().date().isoformat(),
+        help="Date string for output filenames. Defaults to today's local date.",
+    )
+    parser.add_argument(
+        "--alpaca-paper",
+        choices=["true", "false"],
+        default=os.environ.get("ALPACA_PAPER", "true").lower(),
+        help="Use Alpaca paper endpoint when true. Defaults to ALPACA_PAPER or true.",
+    )
+    parser.add_argument(
+        "--fmp-sleep-seconds",
+        type=float,
+        default=0.08,
+        help="Pause between per-symbol FMP request groups.",
+    )
+    return parser.parse_args()
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def to_float(value: Any, default: float = 0.0) -> float:
+    if value is None or value == "":
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def alpaca_headers() -> dict[str, str]:
+    return {
+        "APCA-API-KEY-ID": require_env("ALPACA_API_KEY"),
+        "APCA-API-SECRET-KEY": require_env("ALPACA_SECRET_KEY"),
+    }
+
+
+def get_json(url: str, **kwargs: Any) -> Any:
+    response = requests.get(url, timeout=30, **kwargs)
+    response.raise_for_status()
+    return response.json()
+
+
+def alpaca_base_url(use_paper: bool) -> str:
+    return ALPACA_PAPER_BASE_URL if use_paper else ALPACA_LIVE_BASE_URL
+
+
+def fmp_get(api_key: str | None, path: str, **params: Any) -> Any:
+    if not api_key:
+        return None
+    params["apikey"] = api_key
+    try:
+        response = requests.get(f"{FMP_BASE_URL}/{path}", params=params, timeout=30)
+        if response.status_code != 200:
+            return {"_status": response.status_code, "_text": response.text[:200]}
+        return response.json()
+    except requests.RequestException as exc:
+        return {"_error": str(exc)}
+
+
+def chunks(values: list[str], size: int) -> list[list[str]]:
+    return [values[i : i + size] for i in range(0, len(values), size)]
+
+
+def fetch_profiles_and_quotes(symbols: list[str], fmp_api_key: str | None) -> tuple[dict, dict]:
+    profiles: dict[str, dict] = {}
+    quotes: dict[str, dict] = {}
+    if not symbols or not fmp_api_key:
+        return profiles, quotes
+
+    for chunk in chunks(symbols, 50):
+        symbol_csv = ",".join(chunk)
+        profile_data = fmp_get(fmp_api_key, f"profile/{symbol_csv}")
+        if isinstance(profile_data, list):
+            profiles.update(
+                {item.get("symbol"): item for item in profile_data if item.get("symbol")}
+            )
+
+        quote_data = fmp_get(fmp_api_key, f"quote/{symbol_csv}")
+        if isinstance(quote_data, list):
+            quotes.update({item.get("symbol"): item for item in quote_data if item.get("symbol")})
+
+    return profiles, quotes
+
+
+def build_holding_rows(
+    account: dict,
+    positions: list[dict],
+    profiles: dict[str, dict],
+    quotes: dict[str, dict],
+    fmp_api_key: str | None,
+    fmp_sleep_seconds: float,
+) -> tuple[list[dict], list[dict]]:
+    monitor_holdings = []
+    full_rows = []
+    equity = to_float(account.get("equity"))
+    long_market_value = to_float(account.get("long_market_value"))
+
+    for position in positions:
+        symbol = position["symbol"]
+        profile = profiles.get(symbol, {}) or {}
+        quote = quotes.get(symbol, {}) or {}
+
+        dividends = []
+        cashflow = []
+        income = []
+        balance_sheet = []
+        if fmp_api_key:
+            dividend_data = fmp_get(fmp_api_key, f"historical-price-full/stock_dividend/{symbol}")
+            if isinstance(dividend_data, dict):
+                dividends = dividend_data.get("historical") or []
+
+            cashflow = fmp_get(fmp_api_key, f"cash-flow-statement/{symbol}", limit=4)
+            income = fmp_get(fmp_api_key, f"income-statement/{symbol}", limit=4)
+            balance_sheet = fmp_get(fmp_api_key, f"balance-sheet-statement/{symbol}", limit=4)
+            time.sleep(fmp_sleep_seconds)
+
+        positive_dividends = [
+            to_float(item.get("adjDividend") or item.get("dividend"))
+            for item in dividends
+            if to_float(item.get("adjDividend") or item.get("dividend")) > 0
+        ]
+        latest_dividend = positive_dividends[0] if positive_dividends else None
+        prior_dividend = positive_dividends[1] if len(positive_dividends) > 1 else None
+
+        coverage_ratios = []
+        if isinstance(cashflow, list):
+            for statement in cashflow[:4]:
+                free_cash_flow = to_float(statement.get("operatingCashFlow")) + to_float(
+                    statement.get("capitalExpenditure")
+                )
+                dividends_paid = abs(to_float(statement.get("dividendsPaid")))
+                if dividends_paid:
+                    coverage_ratios.append(
+                        dividends_paid / free_cash_flow if free_cash_flow else 999
+                    )
+
+        net_debt_history = []
+        if isinstance(balance_sheet, list):
+            for statement in balance_sheet[:4]:
+                net_debt_history.append(
+                    to_float(statement.get("totalDebt"))
+                    - to_float(statement.get("cashAndCashEquivalents"))
+                )
+
+        interest_coverage_history = []
+        revenues = []
+        if isinstance(income, list):
+            for statement in income[:4]:
+                interest_expense = abs(to_float(statement.get("interestExpense")))
+                ebit = to_float(statement.get("ebitda") or statement.get("operatingIncome"))
+                interest_coverage_history.append(
+                    ebit / interest_expense if interest_expense else None
+                )
+                if statement.get("revenue"):
+                    revenues.append(to_float(statement.get("revenue")))
+
+        revenue_cagr_3y = None
+        if len(revenues) >= 4 and revenues[-1] > 0:
+            revenue_cagr_3y = (revenues[0] / revenues[-1]) ** (1 / 3) - 1
+
+        instrument_type = "etf" if profile.get("isEtf") else "stock"
+        sector = profile.get("sector") or quote.get("sector") or "Unknown"
+        market_value = to_float(position.get("market_value"))
+
+        row = {
+            "symbol": symbol,
+            "qty": to_float(position.get("qty")),
+            "market_value": market_value,
+            "cost_basis": to_float(position.get("cost_basis")),
+            "unrealized_pl": to_float(position.get("unrealized_pl")),
+            "unrealized_plpc": to_float(position.get("unrealized_plpc")),
+            "current_price": to_float(position.get("current_price")),
+            "weight_gross_long": market_value / long_market_value if long_market_value else None,
+            "weight_equity": market_value / equity if equity else None,
+            "sector": sector,
+            "industry": profile.get("industry"),
+            "company": profile.get("companyName") or symbol,
+            "instrument_type": instrument_type,
+            "is_etf": bool(profile.get("isEtf")),
+            "beta": profile.get("beta") or quote.get("beta"),
+            "dividend_yield_profile": profile.get("lastDiv"),
+            "latest_regular_dividend": latest_dividend,
+            "prior_regular_dividend": prior_dividend,
+            "dividend_events_count": len(positive_dividends),
+            "coverage_ratio_history": coverage_ratios[:4],
+            "net_debt_history": net_debt_history[:4],
+            "interest_coverage_history": interest_coverage_history[:4],
+            "revenue_cagr_3y": revenue_cagr_3y,
+        }
+        full_rows.append(row)
+
+        if latest_dividend is not None or instrument_type == "etf":
+            dividend_growth_stalled = (
+                latest_dividend is not None
+                and prior_dividend is not None
+                and abs(latest_dividend - prior_dividend) < 1e-9
+            )
+            monitor_holdings.append(
+                {
+                    "ticker": symbol,
+                    "instrument_type": instrument_type,
+                    "dividend": {
+                        "latest_regular": latest_dividend,
+                        "prior_regular": prior_dividend,
+                        "is_missing": latest_dividend is None or prior_dividend is None,
+                        "flags": {
+                            "cut_flag": bool(
+                                latest_dividend is not None
+                                and prior_dividend is not None
+                                and latest_dividend < prior_dividend * 0.99
+                            ),
+                            "freeze_flag": dividend_growth_stalled,
+                            "special_dividend_flag": False,
+                            "variable_policy_flag": False,
+                        },
+                    },
+                    "cashflow": {
+                        "fcf": None,
+                        "ffo": None,
+                        "nii": None,
+                        "dividends_paid": None,
+                        "coverage_ratio_history": coverage_ratios[:4],
+                    },
+                    "balance_sheet": {
+                        "net_debt_history": net_debt_history[:4],
+                        "interest_coverage_history": interest_coverage_history[:4],
+                    },
+                    "capital_returns": {"buybacks": None, "dividends_paid": None, "fcf": None},
+                    "filings": {"recent_text": "", "latest_8k_text": "", "headlines": []},
+                    "operations": {
+                        "revenue_cagr_5y": revenue_cagr_3y * 100
+                        if revenue_cagr_3y is not None
+                        else None,
+                        "margin_trend": None,
+                        "guidance_trend": None,
+                        "dividend_growth_stalled": dividend_growth_stalled,
+                    },
+                }
+            )
+
+    return full_rows, monitor_holdings
+
+
+def build_summary(account: dict, holdings: list[dict], as_of: str) -> dict:
+    sector_weights: dict[str, float] = defaultdict(float)
+    for row in holdings:
+        sector_weights[row["sector"]] += row["market_value"]
+
+    equity = to_float(account.get("equity"))
+    long_market_value = to_float(account.get("long_market_value"))
+    return {
+        "as_of": as_of,
+        "account": {
+            key: account.get(key)
+            for key in [
+                "status",
+                "currency",
+                "equity",
+                "cash",
+                "buying_power",
+                "long_market_value",
+                "short_market_value",
+                "portfolio_value",
+                "balance_asof",
+                "multiplier",
+                "pattern_day_trader",
+            ]
+        },
+        "positions_count": len(holdings),
+        "symbols": [row["symbol"] for row in holdings],
+        "gross_long_exposure_pct_equity": long_market_value / equity * 100 if equity else None,
+        "cash_pct_equity": to_float(account.get("cash")) / equity * 100 if equity else None,
+        "sector_weights_gross_long": {
+            sector: value / long_market_value * 100 if long_market_value else None
+            for sector, value in sorted(sector_weights.items(), key=lambda item: -item[1])
+        },
+        "top_positions": sorted(holdings, key=lambda row: row["market_value"], reverse=True)[:10],
+        "holdings": holdings,
+    }
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    use_paper = args.alpaca_paper == "true"
+    base_url = alpaca_base_url(use_paper)
+    headers = alpaca_headers()
+    account = get_json(f"{base_url}/v2/account", headers=headers)
+    positions = get_json(f"{base_url}/v2/positions", headers=headers)
+    if not isinstance(account, dict):
+        raise SystemExit("Unexpected Alpaca account response")
+    if not isinstance(positions, list):
+        raise SystemExit("Unexpected Alpaca positions response")
+
+    symbols = [position["symbol"] for position in positions]
+    fmp_api_key = os.environ.get("FMP_API_KEY")
+    profiles, quotes = fetch_profiles_and_quotes(symbols, fmp_api_key)
+    holdings, monitor_holdings = build_holding_rows(
+        account, positions, profiles, quotes, fmp_api_key, args.fmp_sleep_seconds
+    )
+    summary = build_summary(account, holdings, args.as_of)
+
+    holdings_path = args.output_dir / f"core_portfolio_holdings_{args.as_of}.json"
+    monitor_path = args.output_dir / f"kanchi_monitor_input_{args.as_of}.json"
+    write_json(holdings_path, summary)
+    write_json(
+        monitor_path,
+        {"schema_version": 1, "as_of": args.as_of, "holdings": monitor_holdings},
+    )
+
+    print(
+        json.dumps(
+            {
+                "holdings_path": str(holdings_path),
+                "monitor_path": str(monitor_path),
+                "positions": len(holdings),
+                "symbols": symbols,
+                "equity": account.get("equity"),
+                "long_mv": account.get("long_market_value"),
+                "cash": account.get("cash"),
+                "sector_weights": summary["sector_weights_gross_long"],
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/weekly_core_collect.py
+++ b/scripts/weekly_core_collect.py
@@ -121,6 +121,7 @@ class FmpClient:
         self.attempts = 0
         self.successes = 0
         self.failures: list[dict[str, Any]] = []
+        self.missing: list[dict[str, Any]] = []
 
     def get(self, path: str, **params: Any) -> Any:
         if not self.api_key:
@@ -135,8 +136,21 @@ class FmpClient:
         for source, url, req_params in attempts:
             data = self._request(source, path, url, req_params)
             if data is not None:
-                return self._normalize(path, data)
+                normalized = self._normalize(path, data)
+                if self._should_fallback_on_empty_stable(source, path, normalized):
+                    self.failures.append(
+                        {
+                            "source": source,
+                            "path": path,
+                            "reason": "empty_stable_response",
+                        }
+                    )
+                    continue
+                return normalized
         return None
+
+    def record_missing(self, source: str, symbol: str, reason: str) -> None:
+        self.missing.append({"source": source, "symbol": symbol, "reason": reason})
 
     def diagnostics(self) -> dict[str, Any]:
         if not self.api_key:
@@ -145,7 +159,7 @@ class FmpClient:
             status = "skipped"
         elif self.successes == 0:
             status = "failed"
-        elif self.failures:
+        elif self.failures or self.missing:
             status = "degraded"
         else:
             status = "ok"
@@ -155,7 +169,9 @@ class FmpClient:
             "attempts": self.attempts,
             "successes": self.successes,
             "failures": len(self.failures),
+            "missing": len(self.missing),
             "failure_samples": self.failures[:20],
+            "missing_samples": self.missing[:20],
         }
 
     @staticmethod
@@ -191,6 +207,10 @@ class FmpClient:
 
         return data
 
+    @staticmethod
+    def _should_fallback_on_empty_stable(source: str, path: str, data: Any) -> bool:
+        return source == "stable" and path.startswith(("profile/", "quote/")) and data == []
+
     def _request(self, source: str, path: str, url: str, params: dict[str, Any]) -> Any:
         self.attempts += 1
         req_params = dict(params)
@@ -222,8 +242,15 @@ class FmpClient:
         return data
 
 
-def chunks(values: list[str], size: int) -> list[list[str]]:
-    return [values[i : i + size] for i in range(0, len(values), size)]
+def find_symbol_record(data: Any, symbol: str) -> dict | None:
+    records = data if isinstance(data, list) else [data] if isinstance(data, dict) else []
+    symbol_upper = symbol.upper()
+    for record in records:
+        if isinstance(record, dict) and str(record.get("symbol", "")).upper() == symbol_upper:
+            return record
+    if len(records) == 1 and isinstance(records[0], dict) and not records[0].get("symbol"):
+        return records[0]
+    return None
 
 
 def fetch_profiles_and_quotes(symbols: list[str], fmp_client: FmpClient) -> tuple[dict, dict]:
@@ -232,17 +259,18 @@ def fetch_profiles_and_quotes(symbols: list[str], fmp_client: FmpClient) -> tupl
     if not symbols or not fmp_client.api_key:
         return profiles, quotes
 
-    for chunk in chunks(symbols, 50):
-        symbol_csv = ",".join(chunk)
-        profile_data = fmp_client.get(f"profile/{symbol_csv}")
-        if isinstance(profile_data, list):
-            profiles.update(
-                {item.get("symbol"): item for item in profile_data if item.get("symbol")}
-            )
+    for symbol in symbols:
+        profile = find_symbol_record(fmp_client.get(f"profile/{symbol}"), symbol)
+        if profile:
+            profiles[symbol] = profile
+        else:
+            fmp_client.record_missing("profile", symbol, "empty_or_unmatched_response")
 
-        quote_data = fmp_client.get(f"quote/{symbol_csv}")
-        if isinstance(quote_data, list):
-            quotes.update({item.get("symbol"): item for item in quote_data if item.get("symbol")})
+        quote = find_symbol_record(fmp_client.get(f"quote/{symbol}"), symbol)
+        if quote:
+            quotes[symbol] = quote
+        else:
+            fmp_client.record_missing("quote", symbol, "empty_or_unmatched_response")
 
     return profiles, quotes
 

--- a/skills/dividend-growth-pullback-screener/SKILL.md
+++ b/skills/dividend-growth-pullback-screener/SKILL.md
@@ -134,7 +134,7 @@ For each qualified stock, the report includes:
 
 ## Output
 
-The script saves two files to the current working directory (or `--output-dir` if specified):
+The script saves two files to its configured output location. In current packaged versions the CLI may not accept `--output-dir`; if that flag is unavailable, run the script from the desired working directory or move the generated files after execution. Some builds write to the repository `logs/` directory even when invoked from another directory, so verify the printed paths before reading artifacts.
 
 | File | Description |
 |---|---|

--- a/skills/economic-calendar-fetcher/SKILL.md
+++ b/skills/economic-calendar-fetcher/SKILL.md
@@ -133,11 +133,29 @@ python3 skills/economic-calendar-fetcher/scripts/get_economic_calendar.py \
 - `--format`: Output format (json or text) - default: json
 - `--output`: Output file path (optional, default: stdout)
 
-**Handle errors:**
+**Handle errors and empty results:**
 - Invalid API key → Ask user to verify key
 - Rate limit exceeded (429) → Suggest waiting or upgrading FMP tier
 - Network errors → Check your connection and re-run the script
 - Invalid date format → Provide correct format example
+- **Unexpected empty list for a plausible current/future range:** Do not declare the calendar empty yet. Verify the same range against the primary v3 endpoint directly, then locally filter rows by parsed `date` because FMP may return adjacent-date rows. This applies even when the helper script itself returned `[]` (not only when a stable endpoint was used).
+
+Direct v3 fallback probe:
+```bash
+python3 - <<'PY'
+import os, json, urllib.parse, urllib.request, datetime
+start = datetime.date.fromisoformat("YYYY-MM-DD")
+end = datetime.date.fromisoformat("YYYY-MM-DD")
+url = "https://financialmodelingprep.com/api/v3/economic_calendar?" + urllib.parse.urlencode({
+    "from": start.isoformat(), "to": end.isoformat(), "apikey": os.environ["FMP_API_KEY"]
+})
+with urllib.request.urlopen(url, timeout=30) as r:
+    data = json.loads(r.read())
+filtered = [e for e in data if start <= datetime.date.fromisoformat(e["date"][:10]) <= end]
+filtered.sort(key=lambda e: e.get("date", ""))
+print(json.dumps(filtered, indent=2))
+PY
+```
 
 ### Step 4: Parse and Filter Events
 
@@ -341,7 +359,9 @@ If user requested specific filters, note at top:
   - Best practices for caching and efficiency
 
 **API Details:**
-- Endpoint: `https://financialmodelingprep.com/api/v3/economic_calendar`
+- Primary endpoint: `https://financialmodelingprep.com/api/v3/economic_calendar`
+- Stable endpoint caveat: if a helper script or docs use `https://financialmodelingprep.com/stable/economics-calendar` and it returns `404` or `[]` for an otherwise valid date range, fall back to the v3 endpoint above before declaring the calendar empty.
+- Date-range caveat: v3 responses can include rows just outside the requested `from`/`to` window; after fetching, filter events locally by parsed `date` so only the requested date range is reported.
 - Authentication: API key required (free tier: 250 requests/day)
 - Max date range: 90 days per request
 - Response format: JSON array of event objects
@@ -364,4 +384,5 @@ If user requested specific filters, note at top:
 - API key errors: Clear user guidance for obtaining free key
 - Rate limits (429): Suggest waiting or upgrading FMP tier; re-run the script after the wait
 - Network failures: Check connection and re-run; no automatic retry or cache in the script
+- Stable endpoint returns `404` or an empty list for a valid range: retry the same range through `https://financialmodelingprep.com/api/v3/economic_calendar`, then locally filter returned events to the requested dates before reporting.
 - Invalid dates: Validation with helpful error messages

--- a/skills/exposure-coach/SKILL.md
+++ b/skills/exposure-coach/SKILL.md
@@ -60,6 +60,8 @@ python3 skills/exposure-coach/scripts/calculate_exposure.py \
 
 The script accepts partial inputs; missing files reduce confidence but do not block execution.
 
+**Verification pitfall:** After each run, inspect the generated JSON fields `inputs_provided` and `inputs_missing`. If a file you passed on the CLI still appears in `inputs_missing` (for example a theme-detector JSON that the exposure engine did not recognize), report the affected dimension as degraded and keep confidence capped; do not assume the supplied input was incorporated just because the CLI argument was present.
+
 ### Step 3: Interpret the Market Posture Summary
 
 Review the generated posture report containing:

--- a/skills/kanchi-dividend-review-monitor/SKILL.md
+++ b/skills/kanchi-dividend-review-monitor/SKILL.md
@@ -42,6 +42,10 @@ Always create `WARN` or `REVIEW` evidence for human confirmation first.
 
 Use `references/trigger-matrix.md` for trigger thresholds and actions.
 
+### Flat-dividend cadence caveat
+
+When T6 is driven only by `freeze_flag` / latest regular dividend equal to prior regular dividend, treat it as a `WARN` for cadence confirmation, not as proof of dividend deterioration. Many quarterly dividend payers repeat the same dividend for several quarters between annual raise cycles. In reports, phrase this as “confirm next dividend-growth cadence / pause optional adds until checked” and avoid implying a cut or broken thesis unless T1/T2/T3/T4/T5 evidence also supports escalation.
+
 ## Monitoring Cadence
 
 - Daily:

--- a/skills/market-breadth-analyzer/SKILL.md
+++ b/skills/market-breadth-analyzer/SKILL.md
@@ -60,7 +60,7 @@ python3 skills/market-breadth-analyzer/scripts/market_breadth_analyzer.py \
   --output-dir reports/<routine-or-date>
 ```
 
-For a simple ad-hoc run, omit `--output-dir` or use an existing directory.
+For a simple ad-hoc run, omit `--output-dir` or use an existing directory. In scheduled cron runs from the repository root, prefer a repo-relative output directory such as `reports/after-close-YYYY-MM-DD` rather than an absolute path. If an absolute nested `--output-dir` unexpectedly fails at the history-writing step despite the directory existing, rerun once with the equivalent repo-relative path before treating the breadth analysis as unavailable.
 
 The script will:
 1. Fetch detail CSV (~2,500 rows, 2016-present) and summary CSV (8 metrics)

--- a/skills/pead-screener/SKILL.md
+++ b/skills/pead-screener/SKILL.md
@@ -53,6 +53,8 @@ python3 skills/pead-screener/scripts/screen_pead.py \
   --output-dir reports/
 ```
 
+**Scheduled US-equity routine pitfall:** Prefer Mode B for pre-market / US-equity cron briefs after running `earnings-trade-analyzer`. Mode A can pull the global FMP earnings calendar, spend the API budget on non-US symbols, and return weak/non-actionable foreign listings before reaching the intended US watchlist. If Mode A is used anyway and the script reports budget trimming or non-US symbols, mark PEAD output as degraded and treat it as manual-review only rather than a clean candidate source.
+
 ### Step 2: Review Results
 
 1. Read the generated JSON and Markdown reports

--- a/skills/portfolio-manager/SKILL.md
+++ b/skills/portfolio-manager/SKILL.md
@@ -44,22 +44,29 @@ If Alpaca MCP Server is not connected, inform the user and provide setup instruc
 
 ## Workflow
 
-### Step 1: Fetch Portfolio Data via Alpaca MCP
+### Step 1: Fetch Portfolio Data via Alpaca MCP or REST fallback
 
-Use Alpaca MCP Server tools to gather current portfolio information:
+Use Alpaca MCP Server tools to gather current portfolio information when available. In scheduled Hermes jobs, MCP tools may not be exposed even when Alpaca credentials are present; in that case, use the Alpaca REST API directly with `ALPACA_API_KEY`, `ALPACA_SECRET_KEY`, and `ALPACA_PAPER`.
 
 **1.1 Get Account Information:**
 ```
-Use mcp__alpaca__get_account_info to fetch:
+Preferred: use mcp__alpaca__get_account_info to fetch:
 - Account equity (total portfolio value)
 - Cash balance
 - Buying power
 - Account status
+
+Fallback REST endpoints:
+- paper: https://paper-api.alpaca.markets/v2/account
+- live:  https://api.alpaca.markets/v2/account
+Headers:
+- APCA-API-KEY-ID=$ALPACA_API_KEY
+- APCA-API-SECRET-KEY=$ALPACA_SECRET_KEY
 ```
 
 **1.2 Get Current Positions:**
 ```
-Use mcp__alpaca__get_positions to fetch all holdings:
+Preferred: use mcp__alpaca__get_positions to fetch all holdings:
 - Symbol ticker
 - Quantity held
 - Average entry price (cost basis)
@@ -67,15 +74,27 @@ Use mcp__alpaca__get_positions to fetch all holdings:
 - Current market value
 - Unrealized P&L ($ and %)
 - Position size as % of portfolio
+
+Fallback REST endpoints:
+- paper: https://paper-api.alpaca.markets/v2/positions
+- live:  https://api.alpaca.markets/v2/positions
 ```
 
 **1.3 Get Portfolio History (Optional):**
 ```
-Use mcp__alpaca__get_portfolio_history for performance analysis:
+Preferred: use mcp__alpaca__get_portfolio_history for performance analysis:
 - Historical equity values
 - Time-weighted return calculation
 - Drawdown analysis
+
+Fallback REST endpoint:
+- /v2/account/portfolio/history
 ```
+
+**Scheduled-job fallback discipline:**
+- Clearly label the source as `Alpaca REST fallback` rather than MCP.
+- Use `ALPACA_PAPER=true` to choose paper endpoint; otherwise use live endpoint.
+- Still validate that long market value plus cash approximately reconciles to equity, and highlight margin/leverage if `long_market_value > equity`.
 
 **Data Validation:**
 - Verify all positions have valid ticker symbols

--- a/skills/theme-detector/SKILL.md
+++ b/skills/theme-detector/SKILL.md
@@ -53,10 +53,23 @@ This skill detects and ranks trending market themes by analyzing cross-sector mo
 ## Prerequisites
 
 **Required:**
-- Python 3.7+ with core dependencies:
+- Python 3.10+ with core dependencies. The scripts use modern type-hint syntax such as `dict | None`, so Python 3.9 and older can fail at import time even when dependencies are installed.
   ```bash
   pip install requests beautifulsoup4 lxml pandas numpy yfinance
   ```
+
+**Cron / mixed-Python fallback:** If the active `python3` is older than 3.10, or a newer Hermes venv lacks the data-science dependencies, run the detector through `uv` with an explicit modern interpreter and temporary dependencies instead of editing the environment mid-cron:
+```bash
+uv run --python 3.12 \
+  --with requests --with beautifulsoup4 --with lxml \
+  --with pandas --with numpy --with yfinance \
+  --with finvizfinance --with PyYAML \
+  python skills/theme-detector/scripts/theme_detector.py \
+  --finviz-api-key "$FINVIZ_API_KEY" \
+  --fmp-api-key "$FMP_API_KEY" \
+  --output-dir reports/
+```
+Use this as a setup workaround, not as evidence that the detector is broken; still report FINVIZ/FMP/API-data caveats separately.
 
 **Optional API Keys:**
 


### PR DESCRIPTION
## Summary

- Add scripts/weekly_core_collect.py to collect Alpaca account/positions, enrich holdings with FMP data, and emit weekly core portfolio plus Kanchi monitor JSON artifacts.
- Document scheduled workflow fallbacks and verification pitfalls for economic calendar, exposure coach, market breadth, PEAD, portfolio manager, and theme detector skills.
- Clarify dividend workflow caveats for generated output paths and flat-dividend cadence review handling.

## Validation

- Commit hooks passed for each split commit.
- Pre-push hook passed, including strict metadata validation and all skill tests.
- git diff --check origin/main...HEAD
- uv run ruff check scripts/weekly_core_collect.py
- python3 -m compileall scripts/weekly_core_collect.py
- python3 scripts/weekly_core_collect.py --help