### PR TITLE
[codex] Document earnings degraded fallback

### DIFF
--- a/skills/earnings-trade-analyzer/SKILL.md
+++ b/skills/earnings-trade-analyzer/SKILL.md
@@ -45,13 +45,13 @@ python3 skills/earnings-trade-analyzer/scripts/analyze_earnings_trades.py \
 
 #### Degraded endpoint fallback for scheduled reviews
 
-If the analyzer reports a 404 or an implausible empty earnings calendar during a scheduled after-close/pre-market run, do not report "no earnings reactions" immediately. Verify with FMP's documented calendar endpoint and clearly label the result as an ungraded fallback:
+If the analyzer reports a 404 or an implausible empty earnings calendar during a scheduled after-close/pre-market run, do not report "no earnings reactions" immediately. Verify the same range through the stable endpoint used by the compatibility shim and clearly label the result as an ungraded fallback:
 
 ```bash
-curl "https://financialmodelingprep.com/api/v3/earning_calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&apikey=$FMP_API_KEY"
+curl "https://financialmodelingprep.com/stable/earning_calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&apikey=$FMP_API_KEY"
 ```
 
-Then optionally enrich returned US tickers with batched `/api/v3/quote/<symbols>` data to rank by same-day `changesPercentage`, market cap, and liquidity. Present these as **preliminary / ungraded reactions** because the 5-factor scorer did not run; do not assign A/B/C/D grades from the fallback alone.
+Then optionally enrich returned US tickers through the analyzer's stable-first FMP client or per-symbol `/stable/quote?symbol=<ticker>` calls to rank by same-day `changesPercentage`, market cap, and liquidity. Use legacy `/api/v3` quote calls only as a legacy-key fallback after stable has failed. Present these as **preliminary / ungraded reactions** because the 5-factor scorer did not run; do not assign A/B/C/D grades from the fallback alone.
 
 ### Step 2: Review Results
 

--- a/skills/earnings-trade-analyzer/SKILL.md
+++ b/skills/earnings-trade-analyzer/SKILL.md
@@ -43,6 +43,16 @@ python3 skills/earnings-trade-analyzer/scripts/analyze_earnings_trades.py \
   --output-dir reports/
 ```
 
+#### Degraded endpoint fallback for scheduled reviews
+
+If the analyzer reports a 404 or an implausible empty earnings calendar during a scheduled after-close/pre-market run, do not report "no earnings reactions" immediately. Verify with FMP's documented calendar endpoint and clearly label the result as an ungraded fallback:
+
+```bash
+curl "https://financialmodelingprep.com/api/v3/earning_calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&apikey=$FMP_API_KEY"
+```
+
+Then optionally enrich returned US tickers with batched `/api/v3/quote/<symbols>` data to rank by same-day `changesPercentage`, market cap, and liquidity. Present these as **preliminary / ungraded reactions** because the 5-factor scorer did not run; do not assign A/B/C/D grades from the fallback alone.
+
 ### Step 2: Review Results
 
 1. Read the generated JSON and Markdown reports


### PR DESCRIPTION
## Summary

- Add scheduled-run guidance for degraded earnings calendar endpoint behavior in earnings-trade-analyzer.
- Tell operators to verify implausible empty calendar output through FMP's documented earning_calendar endpoint before reporting no earnings reactions.
- Clarify that fallback-ranked reactions are preliminary and must not receive A/B/C/D grades when the 5-factor scorer did not run.

## Why

Scheduled after-close or pre-market reviews can encounter endpoint 404s or implausibly empty calendars. This documents the manual fallback boundary so reports do not silently convert endpoint degradation into a false no reactions conclusion.

## Validation

- Commit hooks passed.
- Pre-push hook passed, including strict metadata validation and all skill tests.
- git diff --check

## Notes

This is documentation-only. No live Alpaca/FMP collection was run.