### PR TITLE
Improve uptrend-analyzer skill (score 81 -> 98)

### DIFF
--- a/skills/uptrend-analyzer/SKILL.md
+++ b/skills/uptrend-analyzer/SKILL.md
@@ -27,6 +27,12 @@ Unlike the Market Top Detector (API-based risk scorer), this skill uses free CSV
 - ブレドス分析に基づくエクスポージャーガイダンスが欲しい
 - Montyのアップトレンドダッシュボードについて質問
 
+## Prerequisites
+
+- **Python 3.8+** with `pandas` and `requests` libraries
+- **Internet connection** to fetch CSV data from GitHub (no API key required)
+- No paid API subscriptions needed
+
 ## Difference from Market Top Detector
 
 | Aspect | Uptrend Analyzer | Market Top Detector |

--- a/skills/uptrend-analyzer/SKILL.md
+++ b/skills/uptrend-analyzer/SKILL.md
@@ -29,7 +29,7 @@ Unlike the Market Top Detector (API-based risk scorer), this skill uses free CSV
 
 ## Prerequisites
 
-- **Python 3.8+** with `pandas` and `requests` libraries
+- **Python 3.9+** with the `requests` library (CSV parsing uses the stdlib `csv`/`io` modules)
 - **Internet connection** to fetch CSV data from GitHub (no API key required)
 - No paid API subscriptions needed
 


### PR DESCRIPTION
## Summary
- Skill: `uptrend-analyzer`
- Score: 81 -> 98

## Improvements
- Missing section: `## Prerequisites`. -> Add `## Prerequisites` to improve operator guidance.

Generated by skill self-improvement loop.