### PR TITLE
Fix pre-existing Prerequisites drift in 7 skills

### DIFF
--- a/skills/canslim-screener/SKILL.md
+++ b/skills/canslim-screener/SKILL.md
@@ -81,7 +81,7 @@ override with `--rs-benchmark SPY/QQQ/IWM/...`.
   - Set via environment variable: `export FMP_API_KEY=your_key_here`
 
 **Python Dependencies:**
-- Python 3.7+
+- Python 3.9+
 - `requests` (FMP API calls)
 - `beautifulsoup4` (Finviz web scraping)
 - `lxml` (HTML parsing)
@@ -132,7 +132,7 @@ echo $FMP_API_KEY
 
 **Requirements:**
 - **FMP API key** (free tier: 250 calls/day, sufficient for 40 stocks)
-- **Python 3.7+** with required libraries:
+- **Python 3.9+** with required libraries:
   - `requests` (FMP API calls)
   - `beautifulsoup4` (Finviz web scraping)
   - `lxml` (HTML parsing)

--- a/skills/dividend-growth-pullback-screener/SKILL.md
+++ b/skills/dividend-growth-pullback-screener/SKILL.md
@@ -30,7 +30,7 @@ Use this skill when:
 
 - **FMP API key** (required): Set `FMP_API_KEY` environment variable or pass `--fmp-api-key`. Free tier (250 calls/day) is sufficient for FMP-only mode (≤40 stocks). [Sign up](https://site.financialmodelingprep.com/developer/docs).
 - **FINVIZ Elite API key** (optional, recommended): Set `FINVIZ_API_KEY` environment variable or pass `--finviz-api-key`. Reduces execution time from 10–15 min to 2–3 min. [Sign up](https://elite.finviz.com/).
-- Python 3.8+ with `requests` and `pandas` libraries installed.
+- Python 3.9+ with the `requests` library installed.
 
 ## Screening Workflow
 

--- a/skills/ftd-detector/SKILL.md
+++ b/skills/ftd-detector/SKILL.md
@@ -123,7 +123,7 @@ NO_SIGNAL → CORRECTION → RALLY_ATTEMPT → FTD_WINDOW → FTD_CONFIRMED
 ## Prerequisites
 
 - **FMP API Key:** Required. Set `FMP_API_KEY` environment variable or pass via `--api-key` flag.
-- **Python 3.8+:** With `requests` library installed.
+- **Python 3.9+:** With `requests` library installed.
 - **API Budget:** 4 calls per execution (well within FMP free tier of 250/day).
 
 ## Output Files

--- a/skills/institutional-flow-tracker/SKILL.md
+++ b/skills/institutional-flow-tracker/SKILL.md
@@ -14,7 +14,7 @@ This skill tracks institutional investor activity through 13F SEC filings to ide
 ## Prerequisites
 
 - **FMP API Key:** Set `FMP_API_KEY` environment variable or pass `--api-key` to scripts
-- **Python 3.8+:** Required for running analysis scripts
+- **Python 3.9+:** Required for running analysis scripts
 - **Dependencies:** `pip install requests` (scripts handle missing dependencies gracefully)
 
 ## When to Use This Skill

--- a/skills/market-breadth-analyzer/SKILL.md
+++ b/skills/market-breadth-analyzer/SKILL.md
@@ -30,7 +30,7 @@ Quantify market breadth health using a data-driven 6-component scoring system (0
 
 ## Prerequisites
 
-- **Python 3.8+** with `requests` library (for fetching CSV data)
+- **Python 3.9+** with `requests` library (for fetching CSV data)
 - **Internet access** to reach GitHub Pages URLs
 - **No API keys required** - uses freely available public CSV data
 

--- a/skills/options-strategy-advisor/SKILL.md
+++ b/skills/options-strategy-advisor/SKILL.md
@@ -24,7 +24,7 @@ This skill provides comprehensive options strategy analysis and education using 
 ## Prerequisites
 
 **Required:**
-- Python 3.8+ with `numpy`, `scipy`, `requests`
+- Python 3.9+ with `numpy`, `scipy`, `requests`
 
 **Optional:**
 - FMP API key (for real-time stock prices and historical volatility)
@@ -892,7 +892,7 @@ else:
 - **Theoretical pricing**: Black-Scholes approximation
 - **User IV input**: Optional, defaults to HV
 - **No real-time data required**: FMP Free tier sufficient
-- **Dependencies**: Python 3.8+, numpy, scipy, pandas
+- **Dependencies**: Python 3.9+, numpy, scipy, requests
 
 ## Common Use Cases
 
@@ -986,5 +986,5 @@ Workflow:
 
 **Version**: 1.0
 **Last Updated**: 2025-11-08
-**Dependencies**: Python 3.8+, numpy, scipy, pandas, requests
+**Dependencies**: Python 3.9+, numpy, scipy, requests
 **API**: FMP API (Free tier sufficient)

--- a/skills/sector-analyst/SKILL.md
+++ b/skills/sector-analyst/SKILL.md
@@ -28,7 +28,7 @@ Example user requests:
 
 ## Prerequisites
 
-- **Python 3.8+** with `requests` library (for CSV fetching)
+- **Python 3.9+**; no third-party libraries required (CSV fetched via stdlib `urllib`)
 - **No API keys required** — data is fetched from a public GitHub repository
 - **Optional**: Sector performance chart images for supplementary analysis
 


### PR DESCRIPTION
## Summary

Cleans up the 7 pre-existing Prerequisites/dependency inaccuracies surfaced by the new code-faithfulness detector (#165) — the same class as #164. Each fix was verified against the skill's **actual imports**, not assumed.

## Fixes

**Python floor → `3.9+`** (repo `requires-python`; docs claimed 3.7/3.8):
`canslim-screener`, `dividend-growth-pullback-screener`, `ftd-detector`, `institutional-flow-tracker`, `market-breadth-analyzer`, `options-strategy-advisor`, `sector-analyst`.

**Removed unused libraries:**
- `dividend-growth-pullback-screener` — dropped `pandas` (only `requests` is imported)
- `sector-analyst` — dropped `requests` (CSV is fetched via stdlib `urllib`)
- `options-strategy-advisor` — dropped `pandas` from two footer dependency lines

**Kept (verified real deps):**
- `canslim-screener` keeps `beautifulsoup4` + `lxml`. lxml is the BeautifulSoup parser backend (`BeautifulSoup(html, "lxml")`) — a real runtime dependency even though it is referenced by name rather than `import`ed. Only the version was wrong.

## Verification

After the fixes, `check_prerequisites_faithfulness` reports **0 violations across all 56 skills**.

## Notes

- Docs-only; no script behavior changes. Pre-commit (incl. `skill-docs-drift`) and the full test suite pass.
- Recognizing canslim's lxml as faithful relies on the detector enhancement in #165 (string-literal references count as used). The doc fixes here are independent and correct on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
