### PR TITLE
fix(parabolic-short): hyphenated /stable endpoints + mktCap alias (Fixes #162)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,13 @@ jobs:
           --cov-report=term-missing
           --cov-append
 
+      - name: Test parabolic-short-trade-planner
+        run: >
+          python -m pytest skills/parabolic-short-trade-planner/scripts/tests/ -v
+          --cov=skills/parabolic-short-trade-planner/scripts
+          --cov-report=term-missing
+          --cov-append
+
       - name: Test sector-analyst
         run: >
           python -m pytest skills/sector-analyst/scripts/tests/ -v

--- a/skills/parabolic-short-trade-planner/scripts/_fmp_compat.py
+++ b/skills/parabolic-short-trade-planner/scripts/_fmp_compat.py
@@ -40,6 +40,17 @@ _PATH_WITH_SYMBOL = {
     "discounted-cash-flow": "/discounted-cash-flow",
 }
 
+# v3 path → /stable path for endpoints that carry NO path symbol and whose
+# /stable name differs from the v3 name. Explicit because the underscore
+# (v3-style) /stable name 404s for these; the hyphenated name is the live one
+# (verified 2026-06: /stable/sp500_constituent and /stable/earning_calendar
+# both 404, the hyphenated variants both 200). These override the
+# underscore-preserving best-effort fallthrough below.
+_PATH_RENAME_NO_SYMBOL = {
+    "sp500_constituent": "/sp500-constituent",
+    "earning_calendar": "/earnings-calendar",
+}
+
 
 def v3_to_stable(url: str, params: dict | None = None) -> tuple[str, dict]:
     """Rewrite a legacy FMP v3 URL to its ``/stable`` equivalent.
@@ -81,6 +92,11 @@ def v3_to_stable(url: str, params: dict | None = None) -> tuple[str, dict]:
             return _STABLE + stable_path, params
         if after == v3_path:
             return _STABLE + stable_path, params
+
+    # Explicit hyphenated renames for symbol-less endpoints whose underscore
+    # /stable form 404s (must come before the underscore-preserving fallthrough).
+    if after in _PATH_RENAME_NO_SYMBOL:
+        return _STABLE + _PATH_RENAME_NO_SYMBOL[after], params
 
     # Best-effort 1:1 swap; preserve underscore names (free-tier friendly).
     return _STABLE + "/" + after, params

--- a/skills/parabolic-short-trade-planner/scripts/fmp_client.py
+++ b/skills/parabolic-short-trade-planner/scripts/fmp_client.py
@@ -353,6 +353,11 @@ class FMPClient:
         data = self._rate_limited_get(url, params)
         if isinstance(data, list) and data:
             profile = data[0]
+            # /stable/profile returns ``marketCap``; v3 returned ``mktCap``.
+            # Re-alias so consumers (e.g. screen_parabolic.py market-cap bounds)
+            # keep working against the legacy key.
+            if "mktCap" not in profile and "marketCap" in profile:
+                profile["mktCap"] = profile["marketCap"]
             self.cache[cache_key] = profile
             return profile
         return None

--- a/skills/parabolic-short-trade-planner/scripts/tests/conftest.py
+++ b/skills/parabolic-short-trade-planner/scripts/tests/conftest.py
@@ -23,9 +23,10 @@ for _p in (str(CALCULATORS_DIR), str(SCRIPTS_DIR)):
 
 # When the full repo test suite runs, other skills (pead-screener, vcp-screener,
 # market-top-detector, ...) may have already imported their own ``calculators``
-# package and ``fmp_client`` module under those exact names. Drop those entries
-# from sys.modules so this skill's imports below resolve to its own files.
-_NAMESPACES_TO_RESET = ("calculators", "fmp_client", "scorer", "report_generator")
+# package and ``fmp_client`` / ``_fmp_compat`` modules under those exact names.
+# Drop those entries from sys.modules so this skill's imports below resolve to
+# its own files.
+_NAMESPACES_TO_RESET = ("calculators", "fmp_client", "_fmp_compat", "scorer", "report_generator")
 for _key in [
     k
     for k in list(sys.modules)

--- a/skills/parabolic-short-trade-planner/scripts/tests/test_fmp_client_stable.py
+++ b/skills/parabolic-short-trade-planner/scripts/tests/test_fmp_client_stable.py
@@ -1,0 +1,115 @@
+"""Regression tests for the FMP ``/stable`` endpoint migration (Issue #162).
+
+The v3→/stable sweep routed three ``fmp_client.py`` methods through
+``_fmp_compat.v3_to_stable()``, which passes unknown endpoint names through
+verbatim. Two endpoints were renamed between v3 and /stable, so the rewritten
+URLs 404; a third method dropped the ``mktCap`` alias its consumer still reads.
+These tests pin the corrected behaviour:
+
+- ``/stable/sp500-constituent`` (not ``sp500_constituent``)
+- ``/stable/earnings-calendar`` (not ``earning_calendar``)
+- ``get_company_profile`` re-aliases ``marketCap`` → ``mktCap``
+
+Offline: the network boundary (``_rate_limited_get``) is mocked.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import _fmp_compat  # noqa: E402
+from fmp_client import FMPClient  # noqa: E402
+
+_V3 = "https://financialmodelingprep.com/api/v3"
+
+
+def _call_url_params(mock: MagicMock) -> tuple[str, dict | None]:
+    """Extract (url, params) from a _rate_limited_get mock call, tolerating
+    both positional and keyword ``params`` call styles."""
+    call = mock.call_args
+    url = call.args[0]
+    if len(call.args) > 1:
+        params = call.args[1]
+    else:
+        params = call.kwargs.get("params")
+    return url, params
+
+
+# --- v3_to_stable URL mapping (pure function) ---------------------------------
+
+
+def test_v3_to_stable_sp500_constituent_uses_hyphen() -> None:
+    url, params = _fmp_compat.v3_to_stable(f"{_V3}/sp500_constituent")
+    assert url == "https://financialmodelingprep.com/stable/sp500-constituent"
+    assert "sp500_constituent" not in url
+    assert params == {}
+
+
+def test_v3_to_stable_earning_calendar_uses_hyphen_and_preserves_params() -> None:
+    url, params = _fmp_compat.v3_to_stable(
+        f"{_V3}/earning_calendar", {"from": "2026-05-20", "to": "2026-06-15"}
+    )
+    assert url == "https://financialmodelingprep.com/stable/earnings-calendar"
+    assert "earning_calendar" not in url
+    assert params == {"from": "2026-05-20", "to": "2026-06-15"}
+
+
+# --- Client methods build the corrected URLs ----------------------------------
+
+
+def test_get_sp500_constituents_requests_hyphenated_url() -> None:
+    client = FMPClient(api_key="test-key")
+    client._rate_limited_get = MagicMock(return_value=[{"symbol": "AAPL"}])
+
+    client.get_sp500_constituents()
+
+    url, _ = _call_url_params(client._rate_limited_get)
+    assert url == "https://financialmodelingprep.com/stable/sp500-constituent"
+
+
+def test_get_earnings_calendar_requests_hyphenated_url_with_dates() -> None:
+    client = FMPClient(api_key="test-key")
+    client._rate_limited_get = MagicMock(return_value=[{"symbol": "AAPL"}])
+
+    client.get_earnings_calendar("2026-05-20", "2026-06-15")
+
+    url, params = _call_url_params(client._rate_limited_get)
+    assert url == "https://financialmodelingprep.com/stable/earnings-calendar"
+    assert params == {"from": "2026-05-20", "to": "2026-06-15"}
+
+
+# --- Profile alias ------------------------------------------------------------
+
+
+def test_get_company_profile_aliases_market_cap() -> None:
+    client = FMPClient(api_key="test-key")
+    # /stable/profile returns ``marketCap`` (no ``mktCap``).
+    client._rate_limited_get = MagicMock(
+        return_value=[{"symbol": "AAPL", "marketCap": 4_000_000_000_000}]
+    )
+
+    profile = client.get_company_profile("AAPL")
+
+    assert profile is not None
+    assert profile["mktCap"] == 4_000_000_000_000
+    # The original key remains intact.
+    assert profile["marketCap"] == 4_000_000_000_000
+
+
+def test_get_company_profile_keeps_existing_mktcap() -> None:
+    client = FMPClient(api_key="test-key")
+    # If a row already carries ``mktCap`` it must not be overwritten.
+    client._rate_limited_get = MagicMock(
+        return_value=[{"symbol": "AAPL", "mktCap": 123, "marketCap": 456}]
+    )
+
+    profile = client.get_company_profile("AAPL")
+
+    assert profile is not None
+    assert profile["mktCap"] == 123


### PR DESCRIPTION
## Summary

The FMP `/api/v3` → `/stable` migration sweep (`0f7f534` PR #139, `e14ba71`) routed three `skills/parabolic-short-trade-planner/scripts/fmp_client.py` methods through `_fmp_compat.v3_to_stable()`. That shim passes endpoint names it doesn't recognize through **verbatim**, and two endpoints were renamed between v3 and `/stable`. A third method dropped a field alias its consumer still reads. Result: three silent regressions, all verified live (2026-06).

This is option 1 from #162 — targeted endpoint mapping + alias restoration.

## Regressions fixed

| # | Method | Before | After |
|---|--------|--------|-------|
| 1 | `get_sp500_constituents()` | `/stable/sp500_constituent` → **404** (empty universe) | `/stable/sp500-constituent` → 503 rows |
| 2 | `get_earnings_calendar()` | `/stable/earning_calendar` → **404** (earnings rules never fire) | `/stable/earnings-calendar` → 200 |
| 3 | `get_company_profile()` | raw `/stable/profile` row had `marketCap`, no `mktCap`; `screen_parabolic.py:247` read `None` → market-cap bounds dead | re-aliases `marketCap` → `mktCap` |

## Changes

- **`_fmp_compat.py`** — new `_PATH_RENAME_NO_SYMBOL` table mapping the two symbol-less endpoints to their hyphenated `/stable` names, applied before the underscore-preserving fallthrough. `economic_calendar` is intentionally untouched (different skill).
- **`fmp_client.py`** — `get_company_profile()` re-adds the `mktCap` alias (does not overwrite an existing `mktCap`).
- **`tests/test_fmp_client_stable.py`** *(new)* — 6 offline tests: URL mapping for both endpoints (+param preservation), client methods build the hyphenated URLs (mocked network), and the `mktCap` alias.
- **`tests/conftest.py`** — add `_fmp_compat` to `_NAMESPACES_TO_RESET` so the full-repo suite can't resolve another skill's top-level `_fmp_compat.py` from the `sys.modules` cache.
- **`.github/workflows/ci.yml`** — the `test` job omitted parabolic-short, so these regression tests would never have gated; added a step mirroring the existing pattern.

## Verification

- `pytest skills/parabolic-short-trade-planner/scripts/tests/` → **265 passed** (259 prior + 6 new).
- Pinned `ruff==0.9.6` `check` + `format --check` → pass; `codespell` → pass.
- Live sanity against the real key: 503 constituents, 3,259 earnings rows, `mktCap` populated.

## Out of scope

- v3 fallback for free-tier keys (#162 option 2; `/stable/sp500-constituent` is 402 on lower tiers — current key returns 200).
- `economic_calendar` underscore→hyphen (separate skill).
- `.skill` bundle regeneration (historically a separate chore PR).

Fixes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)