### PR TITLE
feat: add personal VCP toolkit (detector, monitor, KOSPI screener)

### DIFF
--- a/personal_tools/.gitignore
+++ b/personal_tools/.gitignore
@@ -1,0 +1,12 @@
+# Runtime caches and generated reports
+.cache/
+reports/
+monitor_reports/
+
+# Personal trading plans (contain account size, position details)
+plans/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo

--- a/personal_tools/daily_monitor.py
+++ b/personal_tools/daily_monitor.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""
+Daily Trade Setup Monitor & Alarm
+Checks watchlist tickers against trigger conditions, posts alerts.
+
+Examples:
+    python3 daily_monitor.py --config oci_plan.json
+    python3 daily_monitor.py --ticker 010060.KS --entry 260000 --entry 220000 \
+        --stop 195000 --target 320000 --target 395000 --target 440000
+    python3 daily_monitor.py --ticker AAPL --entry 180 --stop 170 --target 200
+
+Exit codes:
+    0 = OK
+    1 = WARN-level alerts fired
+    2 = CRITICAL alerts fired (stop hit / setup broken)
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from statistics import mean
+
+
+def load_yfinance(ticker, period):
+    import yfinance as yf
+    import math
+    df = yf.download(ticker, period=period, interval="1d", progress=False, auto_adjust=False)
+    if df.empty:
+        return []
+    bars = []
+    for idx, row in df.iterrows():
+        def f(col):
+            v = row[col]
+            v = v.iloc[0] if hasattr(v, "iloc") else v
+            return float(v)
+        try:
+            o, h, l, c = f("Open"), f("High"), f("Low"), f("Close")
+            v = int(f("Volume"))
+        except (ValueError, TypeError):
+            continue
+        if any(math.isnan(x) for x in (o, h, l, c)):
+            continue
+        bars.append({
+            "date": idx.strftime("%Y-%m-%d"),
+            "open": o, "high": h, "low": l, "close": c, "volume": v,
+        })
+    return bars
+
+
+def trend_template(bars):
+    if len(bars) < 200:
+        return None
+    closes = [b["close"] for b in bars]
+    ma50  = mean(closes[-50:])
+    ma150 = mean(closes[-150:])
+    ma200 = mean(closes[-200:])
+    ma200_30d = mean(closes[-230:-30]) if len(closes) >= 230 else ma200
+    close = closes[-1]
+    window_52w = bars[-252:] if len(bars) >= 252 else bars
+    high_52w = max(b["high"] for b in window_52w)
+    low_52w  = min(b["low"]  for b in window_52w)
+
+    checks = {
+        "close>MA150,200":   close > ma150 and close > ma200,
+        "MA150>MA200":       ma150 > ma200,
+        "MA200 rising":      ma200 > ma200_30d,
+        "MA50>MA150,200":    ma50 > ma150 and ma50 > ma200,
+        "close>MA50":        close > ma50,
+        "52wLow+30%":        close >= low_52w * 1.30,
+        "52wHigh-25%":       close >= high_52w * 0.75,
+    }
+    return {
+        "passed": sum(checks.values()), "total": 7, "checks": checks,
+        "ma50": ma50, "ma150": ma150, "ma200": ma200,
+        "high_52w": high_52w, "low_52w": low_52w,
+    }
+
+
+def count_distribution_days(bars, lookback=25, threshold=-0.2):
+    count, days = 0, []
+    start = max(1, len(bars) - lookback)
+    for i in range(start, len(bars)):
+        chg = (bars[i]["close"] - bars[i-1]["close"]) / bars[i-1]["close"] * 100
+        if chg < threshold and bars[i]["volume"] > bars[i-1]["volume"]:
+            count += 1
+            days.append({"date": bars[i]["date"], "chg_pct": round(chg, 2)})
+    return count, days
+
+
+def evaluate_triggers(bars, plan):
+    if len(bars) < 2:
+        return []
+    current = bars[-1]
+    prev = bars[-2]
+    alerts = []
+
+    for entry in plan.get("entries", []):
+        if current["low"] <= entry["price"] <= current["high"]:
+            alerts.append({
+                "type": "ENTRY_HIT", "level": entry["price"],
+                "label": entry.get("label", ""), "severity": "INFO",
+                "msg": f"📍 진입가 ₩{entry['price']:,.0f} 도달 ({entry.get('label','')})",
+            })
+
+    stop = plan.get("stop_loss")
+    if stop:
+        if current["close"] <= stop:
+            alerts.append({
+                "type": "STOP_HIT_CLOSE", "level": stop, "severity": "CRITICAL",
+                "msg": f"🆘 손절선 ₩{stop:,.0f} 종가 이탈 — 즉시 청산",
+            })
+        elif current["low"] <= stop:
+            alerts.append({
+                "type": "STOP_TOUCHED", "level": stop, "severity": "WARN",
+                "msg": f"⚠️ 손절선 ₩{stop:,.0f} 일중 터치 (종가는 회복)",
+            })
+
+    for tgt in plan.get("targets", []):
+        if current["high"] >= tgt["price"] > prev["high"]:
+            alerts.append({
+                "type": "TARGET_HIT", "level": tgt["price"],
+                "label": tgt.get("label", ""), "severity": "INFO",
+                "msg": f"🎯 목표가 ₩{tgt['price']:,.0f} 도달 ({tgt.get('label','')})",
+            })
+
+    chg_pct = (current["close"] - prev["close"]) / prev["close"] * 100
+    if chg_pct <= -5:
+        alerts.append({
+            "type": "BIG_DOWN", "level": None, "severity": "WARN",
+            "msg": f"🔴 큰 하락 {chg_pct:+.2f}%",
+        })
+
+    vol_50d = mean(b["volume"] for b in bars[-51:-1]) if len(bars) >= 51 else current["volume"]
+    rvol = current["volume"] / vol_50d if vol_50d else 0
+    if rvol >= 2.0 and chg_pct < -0.5:
+        alerts.append({
+            "type": "DISTRIBUTION_DAY", "level": None, "severity": "WARN",
+            "msg": f"⚠️ 분배일 가능성 (RVOL {rvol:.1f}x, {chg_pct:+.2f}%)",
+        })
+
+    pivot = plan.get("pivot")
+    if pivot and current["close"] > pivot and prev["close"] <= pivot:
+        if rvol >= 1.5:
+            alerts.append({
+                "type": "BREAKOUT_CONFIRMED", "level": pivot, "severity": "INFO",
+                "msg": f"🚀 피봇 ₩{pivot:,.0f} 돌파 + RVOL {rvol:.1f}x — 진입 검토",
+            })
+        else:
+            alerts.append({
+                "type": "BREAKOUT_LOW_VOL", "level": pivot, "severity": "WARN",
+                "msg": f"🟡 피봇 돌파했지만 RVOL {rvol:.1f}x (1.5 미달)",
+            })
+
+    return alerts
+
+
+def build_plan(args):
+    if args.config:
+        with open(args.config) as f:
+            plan = json.load(f)
+        plan.setdefault("ticker", args.ticker)
+        return plan
+    return {
+        "ticker": args.ticker,
+        "entries": [{"price": p, "label": f"Entry{i+1}"} for i, p in enumerate(args.entry or [])],
+        "stop_loss": args.stop,
+        "targets": [{"price": p, "label": f"T{i+1}"} for i, p in enumerate(args.target or [])],
+        "pivot": args.pivot,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(description="Daily Trade Setup Monitor")
+    p.add_argument("--ticker", required=True, help="Yahoo Finance ticker")
+    p.add_argument("--config", help="Plan JSON config (overrides CLI flags)")
+    p.add_argument("--entry",  type=float, action="append", help="Entry price (repeatable)")
+    p.add_argument("--stop",   type=float, help="Stop-loss price")
+    p.add_argument("--target", type=float, action="append", help="Target price (repeatable)")
+    p.add_argument("--pivot",  type=float, help="Pivot breakout level")
+    p.add_argument("--period", default="1y")
+    p.add_argument("--output-dir", default="./monitor_reports")
+    p.add_argument("--quiet", action="store_true", help="Only print alerts")
+    args = p.parse_args()
+
+    plan = build_plan(args)
+
+    print(f"📡 {args.ticker} fetching...", file=sys.stderr)
+    bars = load_yfinance(args.ticker, args.period)
+    if len(bars) < 50:
+        print(f"ERROR: insufficient bars ({len(bars)})", file=sys.stderr)
+        sys.exit(3)
+
+    current = bars[-1]
+    prev = bars[-2]
+    chg_pct = (current["close"] - prev["close"]) / prev["close"] * 100
+    tt = trend_template(bars)
+    d_count, d_days = count_distribution_days(bars, 25)
+    alerts = evaluate_triggers(bars, plan)
+
+    if not args.quiet:
+        print(f"\n{'='*72}")
+        print(f"📊 Daily Monitor — {args.ticker}  {current['date']}")
+        print(f"{'='*72}")
+        print(f"Close:  {current['close']:>10,.0f}  ({chg_pct:+.2f}%)")
+        print(f"High:   {current['high']:>10,.0f}")
+        print(f"Low:    {current['low']:>10,.0f}")
+        print(f"Volume: {current['volume']:>10,}")
+
+        if tt:
+            print(f"\n--- Trend Template: {tt['passed']}/7 ---")
+            for k, v in tt["checks"].items():
+                print(f"  {'✅' if v else '❌'} {k}")
+            print(f"  MA50: {tt['ma50']:,.0f}  MA200: {tt['ma200']:,.0f}  52wH: {tt['high_52w']:,.0f}")
+        else:
+            print(f"\n--- Trend Template: insufficient bars (< 200), use --period 2y+ ---")
+
+        print(f"\n--- Distribution Days (25d): {d_count} ---")
+        for d in d_days[-5:]:
+            print(f"  {d['date']}: {d['chg_pct']:+.2f}%")
+        if d_count >= 5:
+            print(f"  ⚠️ {d_count} D-Days → 시장/종목 압박")
+
+        print(f"\n--- Plan ---")
+        for e in plan.get("entries", []):
+            print(f"  📍 Entry:  {e['price']:>10,.0f} ({e.get('label','')})")
+        if plan.get("stop_loss"):
+            print(f"  🛡️ Stop:   {plan['stop_loss']:>10,.0f}")
+        if plan.get("pivot"):
+            print(f"  🚀 Pivot:  {plan['pivot']:>10,.0f}")
+        for t in plan.get("targets", []):
+            print(f"  🎯 Target: {t['price']:>10,.0f} ({t.get('label','')})")
+
+    print(f"\n--- 🚨 ALERTS ({len(alerts)}) ---")
+    if not alerts:
+        print("  (no triggers fired today)")
+    for a in alerts:
+        icon = {"CRITICAL": "🔴", "WARN": "🟡", "INFO": "🟢"}.get(a["severity"], "  ")
+        print(f"  {icon} [{a['severity']}] {a['msg']}")
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / f"monitor_{args.ticker.replace('.','_')}_{current['date']}.json"
+    with open(out_file, "w") as f:
+        json.dump({
+            "ticker": args.ticker,
+            "as_of": current["date"],
+            "current": current,
+            "change_pct": round(chg_pct, 2),
+            "trend_template": tt,
+            "distribution_days": {"count": d_count, "recent": d_days[-10:]},
+            "plan": plan,
+            "alerts": alerts,
+        }, f, indent=2, default=str)
+    print(f"\n📁 {out_file}", file=sys.stderr)
+
+    if any(a["severity"] == "CRITICAL" for a in alerts): sys.exit(2)
+    if any(a["severity"] == "WARN" for a in alerts):     sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/personal_tools/kospi_breakout_screener.py
+++ b/personal_tools/kospi_breakout_screener.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""
+KOSPI Breakout Screener — VCP Top 20 Candidate Scanner
+
+Scans the KOSPI universe (FinanceDataReader) for Minervini VCP setups,
+ranks candidates by composite score (Trend Template + VCP + Liquidity + RS),
+and produces JSON + Markdown reports.
+
+Examples:
+    # Default: scan KOSPI stocks with Marcap >= 1조원, save Top 20
+    python3 kospi_breakout_screener.py
+
+    # Custom thresholds + larger universe + parallelism
+    python3 kospi_breakout_screener.py \
+        --min-marcap-bn 500 --top 30 --workers 12 --period 2y
+
+    # KOSDAQ instead
+    python3 kospi_breakout_screener.py --market KOSDAQ --min-marcap-bn 300
+
+    # Use cache from prior run (skip OHLCV fetch)
+    python3 kospi_breakout_screener.py --use-cache
+"""
+
+import argparse
+import json
+import math
+import pickle
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta
+from pathlib import Path
+from statistics import mean
+
+CACHE_DIR = Path(__file__).parent / ".cache"
+REPORTS_DIR = Path(__file__).parent / "reports"
+
+
+def load_universe(market="KOSPI", min_marcap_bn=1000, max_tickers=None):
+    """Fetch the ticker list and filter by market cap (in 억원, 100M KRW)."""
+    import FinanceDataReader as fdr
+    df = fdr.StockListing(market)
+    df = df[df["Marcap"].notna() & (df["Marcap"] > 0)]
+    df = df.sort_values("Marcap", ascending=False)
+    cutoff = min_marcap_bn * 100_000_000  # 억원 → 원
+    df = df[df["Marcap"] >= cutoff]
+    if max_tickers:
+        df = df.head(max_tickers)
+    universe = []
+    for _, row in df.iterrows():
+        universe.append({
+            "code": str(row["Code"]).zfill(6),
+            "name": row["Name"],
+            "marcap_bn_krw": int(row["Marcap"] / 100_000_000),
+            "marcap_t_krw": round(row["Marcap"] / 1_000_000_000_000, 2),
+        })
+    return universe
+
+
+def fetch_ohlcv(code, period_days=500, cache_date=None):
+    """Fetch OHLCV via FDR, with optional disk cache keyed by date."""
+    if cache_date:
+        cf = CACHE_DIR / cache_date / f"{code}.pkl"
+        if cf.exists():
+            with open(cf, "rb") as f:
+                return pickle.load(f)
+    import FinanceDataReader as fdr
+    end = datetime.now()
+    start = end - timedelta(days=period_days * 1.5)  # extra to cover weekends
+    df = fdr.DataReader(code, start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d"))
+    bars = []
+    for idx, row in df.iterrows():
+        try:
+            o, h, l, c = float(row["Open"]), float(row["High"]), float(row["Low"]), float(row["Close"])
+            v = int(row["Volume"])
+        except (ValueError, TypeError, KeyError):
+            continue
+        if any(math.isnan(x) for x in (o, h, l, c)) or v < 0:
+            continue
+        if c <= 0 or h < l:
+            continue
+        bars.append({"date": idx.strftime("%Y-%m-%d"),
+                     "open": o, "high": h, "low": l, "close": c, "volume": v})
+    if cache_date:
+        cf = CACHE_DIR / cache_date / f"{code}.pkl"
+        cf.parent.mkdir(parents=True, exist_ok=True)
+        with open(cf, "wb") as f:
+            pickle.dump(bars, f)
+    return bars
+
+
+def find_swings(bars, window=5):
+    swings = []
+    for i in range(window, len(bars) - window):
+        is_peak = all(bars[i]["high"] >= bars[i+k]["high"] for k in range(-window, window+1) if k != 0)
+        is_trough = all(bars[i]["low"] <= bars[i+k]["low"] for k in range(-window, window+1) if k != 0)
+        if is_peak:
+            swings.append({"idx": i, "date": bars[i]["date"], "price": bars[i]["high"], "type": "PEAK"})
+        elif is_trough:
+            swings.append({"idx": i, "date": bars[i]["date"], "price": bars[i]["low"], "type": "TROUGH"})
+    return swings
+
+
+def detect_contractions(bars, swings, lookback_days):
+    if not swings:
+        return []
+    cutoff = len(bars) - lookback_days
+    recent = [s for s in swings if s["idx"] >= cutoff]
+    contractions = []
+    last_peak = None
+    for s in recent:
+        if s["type"] == "PEAK":
+            if last_peak is None or s["price"] > last_peak["price"]:
+                last_peak = s
+        elif s["type"] == "TROUGH" and last_peak is not None and s["idx"] > last_peak["idx"]:
+            depth_pct = (s["price"] - last_peak["price"]) / last_peak["price"] * 100
+            contractions.append({
+                "n": len(contractions) + 1,
+                "high_date":  last_peak["date"], "high_price": last_peak["price"],
+                "low_date":   s["date"],         "low_price":  s["price"],
+                "depth_pct":  round(depth_pct, 2),
+                "duration_days": s["idx"] - last_peak["idx"],
+            })
+            last_peak = None
+    return contractions
+
+
+def evaluate_vcp(contractions, bars):
+    if len(contractions) < 2:
+        return {"valid": False, "score": 0, "rating_band": "developing",
+                "tightening": False, "volume_dryup": False,
+                "last_contraction_depth_pct": None, "num_contractions": len(contractions)}
+    depths = [abs(c["depth_pct"]) for c in contractions]
+    tightening = all(depths[i] <= depths[i-1] for i in range(1, len(depths)))
+    last_depth = depths[-1]
+
+    last_c = contractions[-1]
+    bars_in_last = [b for b in bars if last_c["high_date"] <= b["date"] <= last_c["low_date"]]
+    vol_50d_avg = mean(b["volume"] for b in bars[-50:]) if len(bars) >= 50 else 1
+    vol_in_last = mean(b["volume"] for b in bars_in_last) if bars_in_last else 0
+    volume_dryup = vol_in_last < vol_50d_avg * 0.6 if vol_50d_avg else False
+
+    score = 0
+    if len(contractions) >= 3: score += 25
+    elif len(contractions) >= 2: score += 15
+    if tightening: score += 25
+    if last_depth <= 7: score += 25
+    elif last_depth <= 12: score += 15
+    elif last_depth <= 18: score += 5
+    if volume_dryup: score += 25
+
+    if score >= 90:   rating_band = "textbook"
+    elif score >= 80: rating_band = "strong"
+    elif score >= 70: rating_band = "good"
+    elif score >= 60: rating_band = "developing"
+    else:             rating_band = "weak"
+
+    valid = len(contractions) >= 2 and tightening and last_depth <= 15 and depths[0] <= 35
+    return {"valid": valid, "score": score, "rating_band": rating_band,
+            "tightening": tightening, "volume_dryup": volume_dryup,
+            "last_contraction_depth_pct": -last_depth,
+            "num_contractions": len(contractions)}
+
+
+def trend_template(bars):
+    if len(bars) < 200:
+        return None
+    closes = [b["close"] for b in bars]
+    ma50  = mean(closes[-50:])
+    ma150 = mean(closes[-150:])
+    ma200 = mean(closes[-200:])
+    ma200_30d = mean(closes[-230:-30]) if len(closes) >= 230 else ma200
+    close = closes[-1]
+    window_52w = bars[-252:] if len(bars) >= 252 else bars
+    high_52w = max(b["high"] for b in window_52w)
+    low_52w  = min(b["low"]  for b in window_52w)
+
+    checks = [
+        close > ma150 and close > ma200,
+        ma150 > ma200,
+        ma200 > ma200_30d,
+        ma50 > ma150 and ma50 > ma200,
+        close > ma50,
+        close >= low_52w * 1.30,
+        close >= high_52w * 0.75,
+    ]
+    return {"passed": sum(checks), "total": 7, "checks": checks,
+            "ma50": ma50, "ma150": ma150, "ma200": ma200,
+            "high_52w": high_52w, "low_52w": low_52w,
+            "from_52w_high_pct": (close / high_52w - 1) * 100,
+            "from_52w_low_pct":  (close / low_52w  - 1) * 100,
+            "ma200_slope_30d_pct": (ma200 - ma200_30d) / ma200_30d * 100}
+
+
+def compute_relative_strength(bars, period_days=126):
+    """6-month price return as a simple RS proxy."""
+    if len(bars) < period_days + 1:
+        return None
+    return (bars[-1]["close"] / bars[-period_days]["close"] - 1) * 100
+
+
+def liquidity_score(bars):
+    if len(bars) < 50:
+        return 0
+    avg_amount = mean(b["close"] * b["volume"] for b in bars[-50:])
+    if avg_amount >= 100_000_000_000: return 25  # >= 1000억
+    if avg_amount >=  50_000_000_000: return 20  # >= 500억
+    if avg_amount >=  20_000_000_000: return 15  # >= 200억
+    if avg_amount >=  10_000_000_000: return 10  # >= 100억
+    if avg_amount >=   5_000_000_000: return 5
+    return 0
+
+
+def analyze(ticker_info, bars, lookback_days=120):
+    code = ticker_info["code"]
+    name = ticker_info["name"]
+    if len(bars) < 200:
+        return {"code": code, "name": name, "error": "insufficient_bars", "bars": len(bars)}
+
+    tt = trend_template(bars)
+    swings = find_swings(bars, 5)
+    contractions = detect_contractions(bars, swings, lookback_days)
+    vcp = evaluate_vcp(contractions, bars)
+    rs_126 = compute_relative_strength(bars, 126)
+    rs_63  = compute_relative_strength(bars, 63)
+    liq = liquidity_score(bars)
+
+    pivot = max((c["high_price"] for c in contractions), default=None)
+    last_low = contractions[-1]["low_price"] if contractions else None
+    risk_pct = None
+    if pivot and last_low:
+        worst_entry = pivot * 1.02
+        stop = last_low * 0.99
+        risk_pct = (worst_entry - stop) / worst_entry * 100
+
+    # Composite ranking score (0-100)
+    tt_score = tt["passed"] / 7 * 30
+    vcp_score = vcp["score"] / 100 * 35
+    liq_norm = liq / 25 * 15
+    rs_score = 0
+    if rs_126 is not None:
+        rs_score = max(0, min(rs_126 / 2, 20))  # 40% return = max score
+
+    composite = round(tt_score + vcp_score + liq_norm + rs_score, 1)
+
+    # Hard filters for Minervini-style breakout consideration
+    tt_pass = tt["passed"] >= 6
+    risk_ok = risk_pct is not None and risk_pct <= 12
+    vcp_ok  = vcp["score"] >= 50
+    actionable = tt_pass and risk_ok and vcp_ok
+
+    return {
+        "code": code,
+        "name": name,
+        "marcap_bn_krw": ticker_info.get("marcap_bn_krw"),
+        "marcap_t_krw":  ticker_info.get("marcap_t_krw"),
+        "as_of": bars[-1]["date"],
+        "close": bars[-1]["close"],
+        "tt_passed": tt["passed"],
+        "tt_from_high_pct":  round(tt["from_52w_high_pct"], 2),
+        "tt_from_low_pct":   round(tt["from_52w_low_pct"], 2),
+        "vcp_score": vcp["score"],
+        "vcp_rating": vcp["rating_band"],
+        "vcp_valid": vcp["valid"],
+        "num_contractions": vcp["num_contractions"],
+        "tightening": vcp["tightening"],
+        "volume_dryup": vcp["volume_dryup"],
+        "rs_126d_pct": round(rs_126, 2) if rs_126 is not None else None,
+        "rs_63d_pct":  round(rs_63, 2)  if rs_63  is not None else None,
+        "liquidity_score": liq,
+        "composite_score": composite,
+        "pivot": pivot,
+        "last_contraction_low": last_low,
+        "risk_pct": round(risk_pct, 2) if risk_pct is not None else None,
+        "actionable": actionable,
+    }
+
+
+def scan_one(ticker_info, period_days, lookback_days, cache_date):
+    try:
+        bars = fetch_ohlcv(ticker_info["code"], period_days, cache_date)
+        if len(bars) < 50:
+            return {"code": ticker_info["code"], "name": ticker_info["name"], "error": "no_data"}
+        return analyze(ticker_info, bars, lookback_days)
+    except Exception as e:
+        return {"code": ticker_info["code"], "name": ticker_info["name"], "error": str(e)[:80]}
+
+
+def render_markdown(top, all_results, args, scan_meta):
+    lines = []
+    lines.append(f"# 📊 {args.market} Breakout Screener — VCP Top {args.top}\n")
+    lines.append(f"**Scan Date:** {scan_meta['scan_date']}  ")
+    lines.append(f"**Universe:** {scan_meta['universe_size']} 종목 ({args.market}, "
+                 f"Marcap ≥ {args.min_marcap_bn:,}억원)  ")
+    lines.append(f"**Analyzed:** {scan_meta['analyzed']} ({scan_meta['errors']} errors)  ")
+    lines.append(f"**Duration:** {scan_meta['duration_sec']}초\n")
+
+    actionable = [r for r in top if r.get("actionable")]
+    lines.append(f"## 🎯 Actionable Breakout Candidates ({len(actionable)})\n")
+    if not actionable:
+        lines.append("_None today — market environment may not favor breakout setups._\n")
+    else:
+        lines.append("| # | Code | Name | Close | Mcap (조) | TT | VCP | Rating | Contr | RS 6M | Pivot | Stop | Risk% | Score |")
+        lines.append("|---|------|------|------:|----------:|---:|----:|--------|------:|------:|------:|-----:|------:|------:|")
+        for i, r in enumerate(actionable[:args.top], 1):
+            lines.append(
+                f"| {i} | {r['code']} | {r['name']} | {r['close']:,.0f} | "
+                f"{r.get('marcap_t_krw','-')} | {r['tt_passed']}/7 | {r['vcp_score']} | "
+                f"{r['vcp_rating']} | {r['num_contractions']} | "
+                f"{r['rs_126d_pct']:+.1f}% | {r['pivot']:,.0f} | "
+                f"{r['last_contraction_low']:,.0f} | {r['risk_pct']:.1f}% | "
+                f"**{r['composite_score']}** |"
+            )
+
+    watchlist = [r for r in top if not r.get("actionable") and not r.get("error")
+                 and r["tt_passed"] >= 5]
+    lines.append(f"\n## 👁️ Watchlist — Developing Setups ({len(watchlist)})\n")
+    if watchlist:
+        lines.append("| # | Code | Name | TT | VCP | Rating | RS 6M | From-High | Risk% | Score |")
+        lines.append("|---|------|------|---:|----:|--------|------:|----------:|------:|------:|")
+        for i, r in enumerate(watchlist[:args.top], 1):
+            risk = f"{r['risk_pct']:.1f}%" if r['risk_pct'] is not None else "-"
+            lines.append(
+                f"| {i} | {r['code']} | {r['name']} | {r['tt_passed']}/7 | "
+                f"{r['vcp_score']} | {r['vcp_rating']} | {r['rs_126d_pct']:+.1f}% | "
+                f"{r['tt_from_high_pct']:+.1f}% | {risk} | {r['composite_score']} |"
+            )
+
+    lines.append("\n## 📋 Filter Criteria\n")
+    lines.append(f"- **Trend Template**: ≥ 6/7 passed")
+    lines.append(f"- **VCP Score**: ≥ 50")
+    lines.append(f"- **Risk (worst-entry → stop)**: ≤ 12%")
+    lines.append(f"- **Composite Score**: `tt(30) + vcp(35) + liquidity(15) + rs(20)`\n")
+
+    lines.append("## 🔄 Next Steps\n")
+    lines.append("1. 상위 후보별로 **TradingView**에서 차트 확인 (`KRX:종목코드`)")
+    lines.append("2. 정통 진입 검토 시: `vcp_detector.py --ticker <code>.KS` 단일 정밀 분석")
+    lines.append("3. 진입 결정 시: `plans/<code>.json` 작성 + `daily_monitor.py` 등록")
+    return "\n".join(lines)
+
+
+def main():
+    p = argparse.ArgumentParser(description="KOSPI Breakout Screener — VCP Top Candidates")
+    p.add_argument("--market", default="KOSPI", choices=["KOSPI", "KOSDAQ", "KRX"])
+    p.add_argument("--min-marcap-bn", type=int, default=1000, help="Min market cap (억원). Default 1000억=1조")
+    p.add_argument("--max-tickers", type=int, default=None, help="Limit universe size (debug)")
+    p.add_argument("--period-days", type=int, default=500)
+    p.add_argument("--lookback-days", type=int, default=120)
+    p.add_argument("--workers", type=int, default=8)
+    p.add_argument("--top", type=int, default=20)
+    p.add_argument("--output-dir", default=str(REPORTS_DIR))
+    p.add_argument("--use-cache", action="store_true", help="Reuse today's cache")
+    p.add_argument("--no-cache", action="store_true", help="Skip cache write")
+    args = p.parse_args()
+
+    start_time = time.time()
+    cache_date = datetime.now().strftime("%Y-%m-%d") if not args.no_cache else None
+    if not args.use_cache and cache_date:
+        # Invalidate by re-fetching; cache hits only if same day file exists
+        pass
+
+    print(f"📡 Loading {args.market} universe (Marcap ≥ {args.min_marcap_bn:,}억원)...",
+          file=sys.stderr)
+    universe = load_universe(args.market, args.min_marcap_bn, args.max_tickers)
+    print(f"   Universe: {len(universe)} tickers", file=sys.stderr)
+    if not universe:
+        print("ERROR: empty universe", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"🔍 Scanning with {args.workers} workers...", file=sys.stderr)
+    results = []
+    completed = 0
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        futures = {ex.submit(scan_one, t, args.period_days, args.lookback_days, cache_date): t
+                   for t in universe}
+        for fut in as_completed(futures):
+            r = fut.result()
+            results.append(r)
+            completed += 1
+            if completed % 25 == 0 or completed == len(universe):
+                print(f"   [{completed}/{len(universe)}] processed", file=sys.stderr)
+
+    errors  = [r for r in results if r.get("error")]
+    success = [r for r in results if not r.get("error")]
+    success.sort(key=lambda r: r.get("composite_score", 0), reverse=True)
+    top = success[:max(args.top * 3, 60)]
+    duration = round(time.time() - start_time, 1)
+
+    scan_meta = {
+        "scan_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "market": args.market,
+        "universe_size": len(universe),
+        "analyzed": len(success),
+        "errors": len(errors),
+        "duration_sec": duration,
+    }
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    date_tag = datetime.now().strftime("%Y-%m-%d")
+    json_path = out_dir / f"breakout_screener_{args.market}_{date_tag}.json"
+    md_path   = out_dir / f"breakout_screener_{args.market}_{date_tag}.md"
+
+    with open(json_path, "w") as f:
+        json.dump({"meta": scan_meta, "top": success[:args.top * 3],
+                   "all_results_count": len(results)}, f, indent=2, default=str)
+
+    md = render_markdown(top, success, args, scan_meta)
+    with open(md_path, "w") as f:
+        f.write(md)
+
+    actionable = [r for r in success if r.get("actionable")]
+    print(f"\n{'='*72}")
+    print(f"✅ Scan complete: {len(success)} analyzed, {len(actionable)} actionable")
+    print(f"   Duration: {duration}s, Errors: {len(errors)}")
+    print(f"📁 JSON: {json_path}")
+    print(f"📁 MD:   {md_path}")
+    if actionable:
+        print(f"\n🎯 Top {min(5, len(actionable))} Actionable:")
+        for r in actionable[:5]:
+            print(f"   [{r['composite_score']:5.1f}] {r['code']} {r['name']:12s} "
+                  f"TT={r['tt_passed']}/7 VCP={r['vcp_score']:3d} "
+                  f"Pivot={r['pivot']:,.0f} Risk={r['risk_pct']:.1f}%")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/personal_tools/vcp_detector.py
+++ b/personal_tools/vcp_detector.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+VCP Contraction Auto-Detector
+Detects Mark Minervini VCP patterns and Minervini Gate status from OHLCV data.
+
+Examples:
+    python3 vcp_detector.py --ticker 010060.KS --period 2y
+    python3 vcp_detector.py --json /tmp/oci_holdings_daily.json
+    python3 vcp_detector.py --csv data.csv --output report.json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from statistics import mean
+
+
+def load_yfinance(ticker, period):
+    import yfinance as yf
+    df = yf.download(ticker, period=period, interval="1d", progress=False, auto_adjust=False)
+    if df.empty:
+        return []
+    bars = []
+    for idx, row in df.iterrows():
+        bars.append({
+            "date": idx.strftime("%Y-%m-%d"),
+            "open": float(row["Open"].iloc[0] if hasattr(row["Open"], "iloc") else row["Open"]),
+            "high": float(row["High"].iloc[0] if hasattr(row["High"], "iloc") else row["High"]),
+            "low":  float(row["Low"].iloc[0]  if hasattr(row["Low"], "iloc")  else row["Low"]),
+            "close":float(row["Close"].iloc[0]if hasattr(row["Close"], "iloc")else row["Close"]),
+            "volume": int(row["Volume"].iloc[0] if hasattr(row["Volume"], "iloc") else row["Volume"]),
+        })
+    return bars
+
+
+def load_csv(path):
+    import csv
+    bars = []
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            bars.append({
+                "date": row.get("Date") or row.get("date"),
+                "open": float(row.get("Open") or row.get("open")),
+                "high": float(row.get("High") or row.get("high")),
+                "low":  float(row.get("Low")  or row.get("low")),
+                "close":float(row.get("Close")or row.get("close")),
+                "volume": int(float(row.get("Volume") or row.get("volume") or 0)),
+            })
+    bars.sort(key=lambda b: b["date"])
+    return bars
+
+
+def load_json(path):
+    with open(path) as f:
+        bars = json.load(f)
+    bars.sort(key=lambda b: b["date"])
+    return bars
+
+
+def find_swings(bars, window=5):
+    swings = []
+    for i in range(window, len(bars) - window):
+        is_peak = all(bars[i]["high"] >= bars[i+k]["high"] for k in range(-window, window+1) if k != 0)
+        is_trough = all(bars[i]["low"] <= bars[i+k]["low"] for k in range(-window, window+1) if k != 0)
+        if is_peak:
+            swings.append({"idx": i, "date": bars[i]["date"], "price": bars[i]["high"], "type": "PEAK"})
+        elif is_trough:
+            swings.append({"idx": i, "date": bars[i]["date"], "price": bars[i]["low"], "type": "TROUGH"})
+    return swings
+
+
+def detect_contractions(bars, swings, lookback_days):
+    if not swings:
+        return []
+    cutoff = len(bars) - lookback_days
+    recent = [s for s in swings if s["idx"] >= cutoff]
+
+    contractions = []
+    last_peak = None
+    for s in recent:
+        if s["type"] == "PEAK":
+            if last_peak is None or s["price"] > last_peak["price"]:
+                last_peak = s
+        elif s["type"] == "TROUGH" and last_peak is not None and s["idx"] > last_peak["idx"]:
+            depth_pct = (s["price"] - last_peak["price"]) / last_peak["price"] * 100
+            contractions.append({
+                "n": len(contractions) + 1,
+                "high_date":  last_peak["date"],
+                "high_price": last_peak["price"],
+                "low_date":   s["date"],
+                "low_price":  s["price"],
+                "depth_pct":  round(depth_pct, 2),
+                "duration_days": s["idx"] - last_peak["idx"],
+            })
+            last_peak = None
+    return contractions
+
+
+def evaluate_vcp(contractions, bars):
+    if len(contractions) < 2:
+        return {"valid": False, "score": 0, "rating_band": "developing",
+                "reason": "Need >= 2 contractions"}
+
+    depths = [abs(c["depth_pct"]) for c in contractions]
+    tightening = all(depths[i] <= depths[i-1] for i in range(1, len(depths)))
+    last_depth = depths[-1]
+
+    last_c = contractions[-1]
+    bars_in_last = [b for b in bars if last_c["high_date"] <= b["date"] <= last_c["low_date"]]
+    vol_50d_avg = mean(b["volume"] for b in bars[-50:]) if len(bars) >= 50 else 1
+    vol_in_last = mean(b["volume"] for b in bars_in_last) if bars_in_last else 0
+    volume_dryup = vol_in_last < vol_50d_avg * 0.6 if vol_50d_avg else False
+
+    score = 0
+    if len(contractions) >= 3: score += 25
+    elif len(contractions) >= 2: score += 15
+    if tightening: score += 25
+    if last_depth <= 7: score += 25
+    elif last_depth <= 12: score += 15
+    elif last_depth <= 18: score += 5
+    if volume_dryup: score += 25
+
+    if score >= 90:   rating_band = "textbook"
+    elif score >= 80: rating_band = "strong"
+    elif score >= 70: rating_band = "good"
+    elif score >= 60: rating_band = "developing"
+    else:             rating_band = "weak"
+
+    valid = (
+        len(contractions) >= 2 and
+        tightening and
+        last_depth <= 15 and
+        depths[0] <= 35
+    )
+
+    return {
+        "valid": valid,
+        "score": score,
+        "rating_band": rating_band,
+        "tightening": tightening,
+        "volume_dryup": volume_dryup,
+        "last_contraction_depth_pct": -last_depth,
+        "num_contractions": len(contractions),
+    }
+
+
+def trend_template(bars):
+    if len(bars) < 200:
+        return None
+    closes = [b["close"] for b in bars]
+
+    def ma(arr, n, i):
+        return mean(arr[i+1-n:i+1])
+
+    i = len(bars) - 1
+    ma50  = ma(closes, 50,  i)
+    ma150 = ma(closes, 150, i)
+    ma200 = ma(closes, 200, i)
+    ma200_30d = ma(closes, 200, i - 30) if i >= 229 else ma200
+
+    window_52w = bars[-252:] if len(bars) >= 252 else bars
+    high_52w = max(b["high"] for b in window_52w)
+    low_52w  = min(b["low"]  for b in window_52w)
+    close = closes[i]
+
+    checks = {
+        "1_close_above_150_200":    close > ma150 and close > ma200,
+        "2_ma150_above_200":        ma150 > ma200,
+        "3_ma200_rising_30d":       (ma200 - ma200_30d) / ma200_30d > 0,
+        "4_ma50_above_150_200":     ma50 > ma150 and ma50 > ma200,
+        "5_close_above_ma50":       close > ma50,
+        "6_close_30pct_above_low":  close >= low_52w * 1.30,
+        "7_close_within_25pct_high":close >= high_52w * 0.75,
+    }
+    return {
+        "passed": sum(checks.values()),
+        "total": 7,
+        "checks": checks,
+        "ma50":   round(ma50, 0),
+        "ma150":  round(ma150, 0),
+        "ma200":  round(ma200, 0),
+        "high_52w": high_52w,
+        "low_52w":  low_52w,
+        "from_52w_high_pct": round((close / high_52w - 1) * 100, 2),
+        "from_52w_low_pct":  round((close / low_52w  - 1) * 100, 2),
+        "ma200_slope_30d_pct": round((ma200 - ma200_30d) / ma200_30d * 100, 2),
+    }
+
+
+def compute_atr(bars, period=14):
+    if len(bars) < period + 1:
+        return None
+    trs = []
+    for i in range(1, len(bars)):
+        tr = max(
+            bars[i]["high"] - bars[i]["low"],
+            abs(bars[i]["high"] - bars[i-1]["close"]),
+            abs(bars[i]["low"]  - bars[i-1]["close"]),
+        )
+        trs.append(tr)
+    return mean(trs[-period:])
+
+
+def main():
+    p = argparse.ArgumentParser(description="VCP Contraction Auto-Detector")
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--ticker", help="Yahoo Finance ticker (e.g. 010060.KS, AAPL)")
+    src.add_argument("--csv",    help="CSV path with Date,Open,High,Low,Close,Volume")
+    src.add_argument("--json",   help="JSON path (list of bar dicts)")
+    p.add_argument("--period", default="2y")
+    p.add_argument("--lookback-days", type=int, default=120)
+    p.add_argument("--swing-window",  type=int, default=5)
+    p.add_argument("--output", help="Save JSON report path")
+    args = p.parse_args()
+
+    if args.ticker:   bars = load_yfinance(args.ticker, args.period)
+    elif args.csv:    bars = load_csv(args.csv)
+    else:             bars = load_json(args.json)
+
+    if len(bars) < 50:
+        print(f"ERROR: insufficient bars ({len(bars)})", file=sys.stderr)
+        sys.exit(1)
+
+    swings = find_swings(bars, args.swing_window)
+    contractions = detect_contractions(bars, swings, args.lookback_days)
+    vcp = evaluate_vcp(contractions, bars)
+    tt  = trend_template(bars)
+    atr = compute_atr(bars, 14)
+
+    pivot = max((c["high_price"] for c in contractions), default=None)
+    last_low = contractions[-1]["low_price"] if contractions else None
+
+    tt_pass = tt and tt["passed"] == 7
+    vcp_pass = vcp["valid"] and vcp["rating_band"] in ("good", "strong", "textbook")
+    verdict = "PASS" if (tt_pass and vcp_pass) else "REJECT"
+
+    src_label = args.ticker or args.csv or args.json
+    report = {
+        "schema_version": "1.0",
+        "as_of": bars[-1]["date"],
+        "source": src_label,
+        "current_price": bars[-1]["close"],
+        "atr_14": round(atr, 0) if atr else None,
+        "atr_pct": round(atr / bars[-1]["close"] * 100, 2) if atr else None,
+        "bars_analyzed": len(bars),
+        "trend_template": tt,
+        "swings_recent": swings[-12:],
+        "contractions": contractions,
+        "vcp_assessment": vcp,
+        "pivot_price": pivot,
+        "last_contraction_low": last_low,
+        "minervini_gate": {
+            "trend_template_passed": tt_pass,
+            "vcp_valid": vcp["valid"],
+            "rating_band": vcp["rating_band"],
+            "verdict": verdict,
+        },
+    }
+
+    # Console report
+    print(f"\n{'='*70}")
+    print(f"📊 VCP Detector — {src_label}")
+    print(f"{'='*70}")
+    print(f"As of: {report['as_of']}  Close: {report['current_price']:,.0f}  Bars: {len(bars)}")
+    print(f"ATR(14): {report['atr_14']:,.0f}  ({report['atr_pct']}%)" if atr else "")
+
+    if tt:
+        print(f"\n--- Trend Template: {tt['passed']}/7 ---")
+        for k, v in tt["checks"].items():
+            print(f"  {'✅' if v else '❌'} {k}")
+        print(f"  MA50: {tt['ma50']:,.0f}  MA150: {tt['ma150']:,.0f}  MA200: {tt['ma200']:,.0f}")
+        print(f"  52w: {tt['low_52w']:,.0f}~{tt['high_52w']:,.0f}  "
+              f"from-high: {tt['from_52w_high_pct']:+.1f}%  from-low: {tt['from_52w_low_pct']:+.1f}%")
+
+    print(f"\n--- Contractions ({len(contractions)}) ---")
+    for c in contractions:
+        print(f"  #{c['n']}: {c['high_date']} {c['high_price']:>9,.0f} → "
+              f"{c['low_date']} {c['low_price']:>9,.0f}  "
+              f"({c['depth_pct']:+.1f}%, {c['duration_days']}d)")
+
+    print(f"\n--- VCP Assessment ---")
+    print(f"  Valid:        {vcp['valid']}")
+    print(f"  Score:        {vcp.get('score', 0)}/100")
+    print(f"  Rating Band:  {vcp['rating_band']}")
+    print(f"  Tightening:   {vcp.get('tightening')}")
+    print(f"  Volume Dryup: {vcp.get('volume_dryup')}")
+
+    print(f"\n--- Minervini Gate: {verdict} ---")
+    if pivot:    print(f"  Pivot:              {pivot:,.0f}")
+    if last_low: print(f"  Last Contraction:   {last_low:,.0f}")
+    if pivot and last_low:
+        worst_entry = pivot * 1.02
+        stop = last_low * 0.99
+        risk_pct = (worst_entry - stop) / worst_entry * 100
+        print(f"  Worst Entry (+2%):  {worst_entry:,.0f}")
+        print(f"  Stop (-1% buf):     {stop:,.0f}")
+        print(f"  Risk %:             {risk_pct:.2f}%  {'✅ Pass' if risk_pct <= 8 else '❌ > 8%'}")
+
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2, default=str)
+        print(f"\n📁 Saved: {args.output}")
+
+    sys.exit(0 if verdict == "PASS" else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds three standalone Python utilities under `personal_tools/` that implement Mark Minervini's VCP breakout workflow for Korean (KOSPI/KOSDAQ) and US equities. Runnable independently of the canonical `skills/` directory.

- **`vcp_detector.py`** — single-ticker VCP + Trend Template + Minervini Gate evaluation. Reads OHLCV from yfinance / CSV / JSON, outputs a JSON report with pivot, last-contraction-low, worst-entry, stop, risk%, and a PASS/REJECT verdict.
- **`daily_monitor.py`** — per-plan trigger alarm (entry / stop / target / pivot breakout / distribution day) with JSON history and exit-code severity (0 OK / 1 WARN / 2 CRITICAL / 3 data error). Plan defined via CLI flags or JSON config.
- **`kospi_breakout_screener.py`** — nightly KOSPI/KOSDAQ universe scan using FinanceDataReader. Parallel OHLCV fetch with disk cache, ranks candidates by composite score `tt(30) + vcp(35) + liquidity(15) + rs(20)`, writes Top-N JSON + Markdown reports. Verified end-to-end on KOSPI universe (Marcap ≥ 1조원, 651 tickers, ~41 min wall time on 12 workers).

`.gitignore` excludes runtime artifacts (caches, generated reports) and personal trading plans, so account size and position details cannot enter the public repo.

## Why

The canonical `skills/vcp-screener/` targets the S&P 500 via the FMP API. These utilities cover three gaps for users primarily trading KRX-listed equities:

1. **KRX universe coverage** without an FMP subscription — FinanceDataReader is free.
2. **Minervini Gate evaluation on arbitrary OHLCV** (HTML/CSV exports from Yahoo, manual JSON), so users can vet a setup without a paid pipeline.
3. **Per-plan daily monitoring** that turns a static trade plan into a deterministic alarm — closes the loop between screening and execution.

## Test plan

- [ ] `vcp_detector.py --json <local OHLCV>` returns Trend Template + VCP rating + Gate verdict
- [ ] `vcp_detector.py --ticker AAPL --period 2y` works on US tickers via yfinance
- [ ] `daily_monitor.py --ticker 010060.KS --entry … --stop … --target …` produces alerts and writes a JSON history entry
- [ ] `kospi_breakout_screener.py --max-tickers 30 --top 10` completes a small-universe smoke test
- [ ] Full `kospi_breakout_screener.py --top 20` run produces ranked Watchlist (verified locally — 583 analyzed / 68 errors / 60 Watchlist entries on 2026-06-17)
- [ ] `.gitignore` correctly excludes `reports/`, `monitor_reports/`, `.cache/`, `plans/`

## Notes for reviewers

- Scripts are intentionally outside `skills/` because they do not follow the SKILL.md / progressive-loading convention. If you'd prefer they be repackaged as a `skills/kospi-vcp-toolkit/` with the full SKILL.md + references/ + tests, happy to do that in a follow-up.
- No new required dependencies for `skills/` consumers. The screener depends on `finance-datareader` (free, PyPI) and `yfinance`; both are imported lazily inside script entry points so absence does not break unrelated tooling.
- No FMP / FINVIZ / Alpaca keys touched; this PR adds no entries to the API Requirements Matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)