### PR TITLE
ci(skill-packages): check drift for changed packaged skills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -298,6 +300,23 @@ jobs:
 
       - name: FMP client drift check
         run: python3 scripts/generate_fmp_client.py --check
+
+      - name: Changed skill package drift check
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+            if [[ "$BASE" =~ ^0+$ ]]; then
+              BASE="${HEAD}^"
+            fi
+          fi
+          mapfile -t changed < <(git diff --name-only "$BASE...$HEAD")
+          python3 scripts/check_package_drift_for_changed_skills.py "${changed[@]}"
 
       - name: FMP skill package drift check
         run: python3 scripts/package_skills.py --check --skill pead-screener --skill earnings-trade-analyzer --skill ibd-distribution-day-monitor --skill vcp-screener --skill parabolic-short-trade-planner --skill ftd-detector --skill canslim-screener --skill macro-regime-detector --skill market-top-detector

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,6 +143,15 @@ repos:
         files: '^(scripts/fmp_client/.*|scripts/generate_fmp_client\.py|skills/(pead-screener|earnings-trade-analyzer|ibd-distribution-day-monitor|vcp-screener|parabolic-short-trade-planner|ftd-detector|canslim-screener|macro-regime-detector|market-top-detector)/scripts/(fmp_client|_fmp_compat)\.py)$'
         pass_filenames: false
 
+      - id: changed-package-drift
+        name: Changed packaged skill drift check
+        entry: python3 scripts/check_package_drift_for_changed_skills.py
+        language: system
+        # Check only packaged skills touched by this commit, so unrelated stale
+        # archives do not block focused PRs.
+        files: '^(skills/[^/]+/.*|skill-packages/[^/]+\.skill)$'
+        pass_filenames: true
+
       - id: fmp-package-drift
         name: FMP skill package drift check (re-package after vendored client changes)
         entry: python3 scripts/package_skills.py --check --skill pead-screener --skill earnings-trade-analyzer --skill ibd-distribution-day-monitor --skill vcp-screener --skill parabolic-short-trade-planner --skill ftd-detector --skill canslim-screener --skill macro-regime-detector --skill market-top-detector

--- a/scripts/check_package_drift_for_changed_skills.py
+++ b/scripts/check_package_drift_for_changed_skills.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Check package drift only for packaged skills touched by changed files."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+from package_skills import DEFAULT_OUTPUT_DIR, DEFAULT_SKILLS_DIR, PROJECT_ROOT, check_skill
+from package_skills import should_include as package_should_include
+
+
+def _relative_changed_path(raw_path: str, project_root: Path) -> Path | None:
+    path = Path(raw_path)
+    if path.is_absolute():
+        try:
+            path = path.resolve().relative_to(project_root.resolve())
+        except ValueError:
+            return None
+    if not path.parts:
+        return None
+    return Path(*path.parts)
+
+
+def _changed_source_skill(relative_path: Path) -> str | None:
+    parts = relative_path.parts
+    if len(parts) < 3 or parts[0] != "skills":
+        return None
+
+    skill = parts[1]
+    skill_relative_path = Path(*parts[2:])
+
+    if not package_should_include(skill_relative_path):
+        return None
+    return skill
+
+
+def _changed_archive_skill(relative_path: Path) -> str | None:
+    parts = relative_path.parts
+    if len(parts) != 2 or parts[0] != "skill-packages":
+        return None
+    archive = Path(parts[1])
+    if archive.suffix != ".skill":
+        return None
+    return archive.stem
+
+
+def packaged_skills_for_changed_paths(
+    changed_paths: Iterable[str],
+    *,
+    skills_dir: Path = DEFAULT_SKILLS_DIR,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    project_root: Path = PROJECT_ROOT,
+) -> list[str]:
+    """Return packaged skill names affected by changed repository paths."""
+    skills_dir = skills_dir.resolve()
+    output_dir = output_dir.resolve()
+    project_root = project_root.resolve()
+
+    candidate_skills: set[str] = set()
+    for raw_path in changed_paths:
+        relative_path = _relative_changed_path(raw_path, project_root)
+        if relative_path is None:
+            continue
+
+        skill = _changed_source_skill(relative_path) or _changed_archive_skill(relative_path)
+        if skill is None:
+            continue
+
+        archive_path = output_dir / f"{skill}.skill"
+        if archive_path.is_file() and (skills_dir / skill / "SKILL.md").is_file():
+            candidate_skills.add(skill)
+
+    return sorted(candidate_skills)
+
+
+def check_changed_package_drift(
+    changed_paths: Iterable[str],
+    *,
+    skills_dir: Path = DEFAULT_SKILLS_DIR,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    project_root: Path = PROJECT_ROOT,
+) -> int:
+    """Check changed packaged skills and return a process-style exit code."""
+    skill_names = packaged_skills_for_changed_paths(
+        changed_paths,
+        skills_dir=skills_dir,
+        output_dir=output_dir,
+        project_root=project_root,
+    )
+    if not skill_names:
+        return 0
+
+    drift = False
+    for skill_name in skill_names:
+        skill_dir = skills_dir / skill_name
+        archive_path = output_dir / f"{skill_name}.skill"
+        display_archive = f"skill-packages/{archive_path.name}"
+        if check_skill(skill_dir, output_dir):
+            print(f"OK: {display_archive} matches source")
+        else:
+            print(
+                f"DRIFT: {display_archive} is stale; "
+                f"re-run python3 scripts/package_skills.py --skill {skill_name}"
+            )
+            drift = True
+
+    return 1 if drift else 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    changed_paths = sys.argv[1:] if argv is None else list(argv)
+    return check_changed_package_drift(changed_paths)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_package_drift_for_changed_skills.py
+++ b/scripts/tests/test_check_package_drift_for_changed_skills.py
@@ -1,0 +1,164 @@
+"""Tests for scripts/check_package_drift_for_changed_skills.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from check_package_drift_for_changed_skills import (
+    check_changed_package_drift,  # noqa: E402
+    packaged_skills_for_changed_paths,  # noqa: E402
+)
+from package_skills import package_skill  # noqa: E402
+
+
+def _make_skill(project_root: Path, skill_name: str, *, package: bool = True) -> Path:
+    skill_dir = project_root / "skills" / skill_name
+    (skill_dir / "scripts" / "tests").mkdir(parents=True)
+    (skill_dir / "references").mkdir()
+    (skill_dir / "schemas").mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {skill_name}\ndescription: Demo skill.\n---\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "scripts" / "run.py").write_text("print('ok')\n", encoding="utf-8")
+    (skill_dir / "scripts" / "tests" / "test_run.py").write_text(
+        "def test_run(): pass\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "references" / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    (skill_dir / "schemas" / "input.schema.json").write_text("{}\n", encoding="utf-8")
+    if package:
+        package_skill(skill_dir, project_root / "skill-packages")
+    return skill_dir
+
+
+def _check(project_root: Path, changed_paths: list[str]) -> int:
+    return check_changed_package_drift(
+        changed_paths,
+        skills_dir=project_root / "skills",
+        output_dir=project_root / "skill-packages",
+        project_root=project_root,
+    )
+
+
+def test_no_args_passes(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert _check(tmp_path, []) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_skill_source_change_fails_when_archive_is_stale(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skill_dir = _make_skill(tmp_path, "demo")
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Changed.\n---\n",
+        encoding="utf-8",
+    )
+
+    assert _check(tmp_path, ["skills/demo/SKILL.md"]) == 1
+    assert capsys.readouterr().out == (
+        "DRIFT: skill-packages/demo.skill is stale; "
+        "re-run python3 scripts/package_skills.py --skill demo\n"
+    )
+
+
+def test_skill_source_change_passes_when_archive_is_synced(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _make_skill(tmp_path, "demo")
+
+    assert _check(tmp_path, ["skills/demo/SKILL.md"]) == 0
+    assert capsys.readouterr().out == "OK: skill-packages/demo.skill matches source\n"
+
+
+def test_package_excluded_script_tests_only_change_is_ignored(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skill_dir = _make_skill(tmp_path, "demo")
+    (skill_dir / "scripts" / "run.py").write_text("print('stale')\n", encoding="utf-8")
+
+    assert _check(tmp_path, ["skills/demo/scripts/tests/test_run.py"]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_archive_change_targets_matching_skill(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skill_dir = _make_skill(tmp_path, "demo")
+    (skill_dir / "references" / "guide.md").write_text("# Changed\n", encoding="utf-8")
+
+    assert _check(tmp_path, ["skill-packages/demo.skill"]) == 1
+    assert capsys.readouterr().out == (
+        "DRIFT: skill-packages/demo.skill is stale; "
+        "re-run python3 scripts/package_skills.py --skill demo\n"
+    )
+
+
+def test_packaged_schema_change_fails_when_archive_is_stale(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skill_dir = _make_skill(tmp_path, "demo")
+    (skill_dir / "schemas" / "input.schema.json").write_text(
+        '{"changed": true}\n',
+        encoding="utf-8",
+    )
+
+    assert _check(tmp_path, ["skills/demo/schemas/input.schema.json"]) == 1
+    assert capsys.readouterr().out == (
+        "DRIFT: skill-packages/demo.skill is stale; "
+        "re-run python3 scripts/package_skills.py --skill demo\n"
+    )
+
+
+def test_unpacked_skill_source_change_is_ignored(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _make_skill(tmp_path, "demo", package=False)
+
+    assert _check(tmp_path, ["skills/demo/SKILL.md"]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_multiple_skill_changes_check_only_packaged_changed_skills(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    changed_skill = _make_skill(tmp_path, "changed")
+    unchanged_skill = _make_skill(tmp_path, "unchanged")
+    _make_skill(tmp_path, "unpacked", package=False)
+    (changed_skill / "SKILL.md").write_text(
+        "---\nname: changed\ndescription: Changed.\n---\n",
+        encoding="utf-8",
+    )
+    (unchanged_skill / "SKILL.md").write_text(
+        "---\nname: unchanged\ndescription: Also stale, but not changed.\n---\n",
+        encoding="utf-8",
+    )
+
+    assert packaged_skills_for_changed_paths(
+        [
+            "skills/changed/SKILL.md",
+            "skills/unpacked/SKILL.md",
+            "skills/changed/scripts/tests/test_run.py",
+        ],
+        skills_dir=tmp_path / "skills",
+        output_dir=tmp_path / "skill-packages",
+        project_root=tmp_path,
+    ) == ["changed"]
+    assert _check(tmp_path, ["skills/changed/SKILL.md", "skills/unpacked/SKILL.md"]) == 1
+    assert capsys.readouterr().out == (
+        "DRIFT: skill-packages/changed.skill is stale; "
+        "re-run python3 scripts/package_skills.py --skill changed\n"
+    )


### PR DESCRIPTION
## Summary

Closes #178.

Adds a focused package-drift gate for packaged skills touched by a change. The new script derives candidate skills from changed file paths, checks only skills that already have a committed `.skill` archive, and compares source vs archive using the existing logical `check_skill()` implementation from `scripts/package_skills.py`.

## Key changes

- Add `scripts/check_package_drift_for_changed_skills.py`.
- Add a `changed-package-drift` pre-commit hook with filename passing enabled.
- Add a CI metadata step that passes PR/push changed files without shell word-splitting.
- Keep the existing FMP package drift gate unchanged.

## Drift coverage

- Covers packaged skill source files under `skills/<skill>/...`, including `SKILL.md`, `references/`, `scripts/`, `schemas/`, `assets/`, and other package-included paths.
- Delegates package exclusion behavior to `package_skills.should_include()`, so tests, `__pycache__`, `.pyc`, `.pyo`, and `.DS_Store` are ignored consistently with archive generation.
- Ignores changed skills that do not have `skill-packages/<skill>.skill`, avoiding unrelated no-archive failures.

## Validation

- [x] `python3 -m pytest scripts/tests/test_package_skills.py scripts/tests/test_check_package_drift_for_changed_skills.py -q` -> 11 passed
- [x] `python3.9 -m pytest scripts/tests/test_package_skills.py scripts/tests/test_check_package_drift_for_changed_skills.py -q` -> 11 passed
- [x] `ruff check scripts/check_package_drift_for_changed_skills.py scripts/tests/test_package_skills.py scripts/tests/test_check_package_drift_for_changed_skills.py`
- [x] `ruff format --check scripts/check_package_drift_for_changed_skills.py scripts/tests/test_package_skills.py scripts/tests/test_check_package_drift_for_changed_skills.py`
- [x] `git diff --check --cached`
- [x] `git diff --check`
- [x] `python3 scripts/check_package_drift_for_changed_skills.py skills/trader-memory-core/schemas/thesis.schema.json skills/trader-memory-core/assets/postmortem_template.md`
- [x] pre-push hooks passed during branch push

🤖 Generated with Codex