### PR TITLE
fix(skill-generation): unblock daily PR creation (Closes #180)

### DIFF
--- a/scripts/run_skill_generation_pipeline.py
+++ b/scripts/run_skill_generation_pipeline.py
@@ -649,15 +649,26 @@ def _get_staged_files(project_root: Path, skill_name: str) -> list[str]:
     return [f.strip() for f in result.stdout.strip().splitlines() if f.strip()]
 
 
+# pre-commit result line: "<hook name>....<dots>....<status>" with the status
+# (Passed/Failed/Skipped) immediately after a run of >=4 dots.
+_RESULT_LINE_RE = re.compile(r"^(?P<name>.+?)\.{4,}(?P<status>Passed|Failed|Skipped)\b")
+
+
 def _extract_failed_hooks(output: str) -> str:
-    """Extract hook names that show 'Failed' from pre-commit output."""
+    """Extract hook names that show 'Failed' from pre-commit output.
+
+    pre-commit result lines look like ``<hook name>....<dots>....<status>`` where
+    status is Passed/Failed/Skipped immediately after the dot run. Anchoring on
+    that shape preserves multi-word hook names (e.g. "Detect absolute paths with
+    usernames") and ignores hook *output* lines that merely contain the word
+    "Failed" (e.g. "... 0 Failed"), which the old word-splitting heuristic
+    mis-captured (the "folder, only)" garbage seen in logs).
+    """
     failed = []
     for line in output.splitlines():
-        # pre-commit output format: "hook-name...Failed" or "hook-name...Passed"
-        if "Failed" in line:
-            hook_name = line.split("...")[0].strip().split()[-1] if "..." in line else ""
-            if hook_name:
-                failed.append(hook_name)
+        match = _RESULT_LINE_RE.match(line)
+        if match and match.group("status") == "Failed":
+            failed.append(match.group("name").strip())
     return ", ".join(failed) if failed else ""
 
 
@@ -1058,24 +1069,19 @@ def _rollback_skill(project_root: Path, skill_name: str, branch_name: str) -> No
         capture_output=True,
         check=False,
     )
-    # Restore modified tracked files
-    restore = subprocess.run(
-        ["git", "checkout", "--"] + rollback_paths,
-        cwd=project_root,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    # Fallback: git restore for files that git checkout missed
-    if restore.returncode != 0:
-        logger.info("git checkout restore failed; trying git restore fallback.")
+    # Restore modified tracked files ONE PATH AT A TIME. A batched
+    # "git checkout -- <all paths>" aborts on the first invalid pathspec (e.g. a
+    # brand-new untracked skill dir with no tracked version), leaving the other
+    # tracked paths — notably docs/{en,ja}/skills/index.md — dirty and blocking
+    # the next day's clean-tree gate. Per-path restore is independent.
+    for path in rollback_paths:
         subprocess.run(
-            ["git", "restore", "--"] + rollback_paths,
+            ["git", "checkout", "--", path],
             cwd=project_root,
             capture_output=True,
             check=False,
         )
-    # Remove untracked files/dirs under the skill and generated docs
+    # Remove untracked files/dirs (the new skill + its generated doc pages)
     for clean_path in [
         f"skills/{skill_name}/",
         f"docs/en/skills/{skill_name}.md",
@@ -1087,22 +1093,39 @@ def _rollback_skill(project_root: Path, skill_name: str, branch_name: str) -> No
             capture_output=True,
             check=False,
         )
-    # Verify pyproject.toml is clean
+    # Assert a clean tree across ALL rollback paths; force-restore tracked files
+    # and force-clean untracked ones that survived, and log leftovers by name so
+    # a stuck rollback is diagnosable rather than silently dirtying the tree.
     verify = subprocess.run(
-        ["git", "diff", "--name-only", "--", "pyproject.toml"],
+        ["git", "status", "--porcelain", "--"] + rollback_paths,
         cwd=project_root,
         capture_output=True,
         text=True,
         check=False,
     )
-    if verify.stdout.strip():
-        logger.warning("pyproject.toml still dirty after rollback; forcing restore.")
-        subprocess.run(
-            ["git", "restore", "pyproject.toml"],
-            cwd=project_root,
-            capture_output=True,
-            check=False,
+    leftover = [ln for ln in verify.stdout.splitlines() if ln.strip()]
+    if leftover:
+        logger.warning(
+            "Rollback left %d dirty path(s); forcing cleanup: %s",
+            len(leftover),
+            ", ".join(ln[3:] for ln in leftover),
         )
+        for ln in leftover:
+            status, path = ln[:2], ln[3:].strip().strip('"')
+            if "?" in status:
+                subprocess.run(
+                    ["git", "clean", "-fd", "--", path],
+                    cwd=project_root,
+                    capture_output=True,
+                    check=False,
+                )
+            else:
+                subprocess.run(
+                    ["git", "restore", "--", path],
+                    cwd=project_root,
+                    capture_output=True,
+                    check=False,
+                )
     # Return to main
     subprocess.run(
         ["git", "checkout", "main"],
@@ -1133,10 +1156,14 @@ def create_skill_pr(
     if not shutil.which("gh"):
         logger.error("gh CLI not found; cannot create PR.")
         return None
-    # Auto-fix lint issues
+    # Auto-fix lint issues. --unsafe-fixes is required for rules ruff flags but
+    # won't safe-fix (e.g. UP007 Optional[X] -> X | None); without it these
+    # survive every pre-commit attempt and the skill never opens a PR. ruff only
+    # flags such rules when applying them is runtime-safe, and the result is
+    # re-verified by pre-commit + human PR review + CI.
     if shutil.which("ruff"):
         subprocess.run(
-            ["ruff", "check", "--fix", f"skills/{skill_name}/"],
+            ["ruff", "check", "--fix", "--unsafe-fixes", f"skills/{skill_name}/"],
             cwd=project_root,
             capture_output=True,
             check=False,
@@ -1237,7 +1264,7 @@ def create_skill_pr(
                     "pre-commit still failing after %d attempts. Failed hooks: %s. Output: %s",
                     max_precommit_attempts,
                     failed_hooks,
-                    pc_output.strip()[:500],
+                    pc_output.strip()[:2000],
                 )
                 return None
             restage = subprocess.run(

--- a/scripts/tests/test_skill_generation_pipeline.py
+++ b/scripts/tests/test_skill_generation_pipeline.py
@@ -1109,6 +1109,28 @@ def test_extract_failed_hooks(pipeline_module):
     assert "codespell" not in result
 
 
+def test_extract_failed_hooks_multiword_name(pipeline_module):
+    """Multi-word hook names are captured in full (not truncated to last word)."""
+    output = "Detect absolute paths with usernames.................................Failed\n"
+    result = pipeline_module._extract_failed_hooks(output)
+    assert result == "Detect absolute paths with usernames"
+
+
+def test_extract_failed_hooks_ignores_output_lines(pipeline_module):
+    """Hook *output* lines that merely contain 'Failed' are not mistaken for hooks.
+
+    Regression for the garbled "folder, only)" hook names seen in the logs: the
+    status must sit immediately after the dot run, so prose containing 'Failed'
+    elsewhere is ignored.
+    """
+    output = (
+        "ruff.................................................................Failed\n"
+        "  some check ran........ 2 files scanned, 0 Failed in folder, only staged\n"
+    )
+    result = pipeline_module._extract_failed_hooks(output)
+    assert result == "ruff"
+
+
 # -- Daily flow: existing PR sets pr_open --
 
 
@@ -1318,3 +1340,61 @@ def test_register_testpaths_empty_tests_dir(pipeline_module, tmp_path: Path):
     result = pipeline_module.register_testpaths(tmp_path, "empty-tests")
 
     assert result is False
+
+
+def test_create_skill_pr_uses_unsafe_fixes(pipeline_module, tmp_path: Path):
+    """Auto-fix must pass --unsafe-fixes so rules like UP007 are actually fixed."""
+    call_log = []
+
+    def fake_run(cmd, **kwargs):
+        cmd_str = " ".join(str(c) for c in cmd)
+        call_log.append(cmd_str)
+        if "diff" in cmd_str and "--cached" in cmd_str:
+            return CompletedProcess(cmd, 0, "skills/x/SKILL.md\n", "")
+        if "gh" in cmd_str and "pr" in cmd_str and "create" in cmd_str:
+            return CompletedProcess(cmd, 0, "https://github.com/test/pr/9", "")
+        return CompletedProcess(cmd, 0, "", "")
+
+    # ruff + gh present; pre-commit absent so the verify loop is skipped.
+    def fake_which(name):
+        return None if name == "pre-commit" else f"/usr/bin/{name}"
+
+    with (
+        patch.object(pipeline_module.subprocess, "run", fake_run),
+        patch.object(pipeline_module.shutil, "which", fake_which),
+    ):
+        pipeline_module.create_skill_pr(
+            tmp_path, "x", {"id": "x", "title": "X"}, {"auto_review": {"score": 90}}, "feat/x"
+        )
+
+    assert any("ruff check --fix --unsafe-fixes" in c for c in call_log)
+
+
+def test_rollback_restores_tracked_despite_untracked_pathspec(pipeline_module, tmp_path: Path):
+    """A failed checkout of the untracked skill dir must not block other restores.
+
+    Asserts the new per-path behavior: tracked paths (e.g. index.md) are still
+    restored individually, and the final clean-tree assertion force-cleans any
+    leftover (here index.md reported still dirty -> git restore issued).
+    """
+    call_log = []
+
+    def fake_run(cmd, **kwargs):
+        cmd_str = " ".join(str(c) for c in cmd)
+        call_log.append(cmd_str)
+        # The brand-new untracked skill dir has no tracked version -> checkout fails.
+        if cmd[:3] == ["git", "checkout", "--"] and cmd[-1] == "skills/x/":
+            return CompletedProcess(cmd, 1, "", "error: pathspec 'skills/x/' did not match")
+        # Clean-tree assertion: report index.md still dirty to exercise force-cleanup.
+        if "status" in cmd_str and "--porcelain" in cmd_str:
+            return CompletedProcess(cmd, 0, " M docs/en/skills/index.md\n", "")
+        return CompletedProcess(cmd, 0, "", "")
+
+    with patch.object(pipeline_module.subprocess, "run", fake_run):
+        pipeline_module._rollback_skill(tmp_path, "x", "feat/x")
+
+    # Per-path restore reached index.md even though skills/x/ checkout failed first.
+    assert "git checkout -- docs/en/skills/index.md" in call_log
+    # Final clean-tree assertion ran and force-restored the leftover tracked file.
+    assert any("status --porcelain" in c for c in call_log)
+    assert "git restore -- docs/en/skills/index.md" in call_log


### PR DESCRIPTION
Closes #180

## Summary

Fixes #180: the daily `skill-generation` job (`com.trade-analysis.skill-generation-daily`, 07:00) reached pre-commit but failed 3× and opened **no PR**, and a fragile rollback could leave the tree dirty and block the next day's clean-tree gate. Three fixes in `scripts/run_skill_generation_pipeline.py`.

Investigated against `origin/main`. Note: the existing `create_skill_pr` already ran `ruff check --fix` + `ruff format` before pre-commit — the gap was that `--fix` alone doesn't apply rules ruff flags as unsafe-to-autofix.

## Changes

1. **Auto-fix with `--unsafe-fixes`** (`create_skill_pr`). `ruff check --fix` (safe-only) does **not** fix rules like **UP007** (`Optional[X]` → `X | None`); these survived every pre-commit attempt and lost the PR. ruff only flags such rules when applying them is runtime-safe (e.g. `from __future__ import annotations` present), and the result is re-verified by pre-commit + human review + CI. (Confirmed the same UP007/`--unsafe-fixes` behavior during the recent Stockbee skill onboarding.) codespell is **not** auto-written (would corrupt identifiers) — genuine codespell failures still fail by design, now with accurate logs.
2. **Robust `_extract_failed_hooks` + bigger log cap.** Replaced the word-splitting heuristic with a regex anchored on the pre-commit result-line shape (`<name>` + `.{4,}` dots + status). This preserves multi-word hook names (e.g. *Detect absolute paths with usernames*) and ignores prose lines that merely contain "Failed" — the source of the garbled `folder, only)` hook names in the logs. Raised the final-failure output cap `500 → 2000` so the actual ruff rule is visible (the log was truncated right at `ruff........`, hiding the cause).
3. **Deterministic `_rollback_skill`.** Restore tracked paths **one at a time** — a single invalid pathspec (the brand-new untracked skill dir) previously aborted the whole batched `git checkout`, stranding `docs/{en,ja}/skills/index.md` dirty and tripping the next day's `_is_safe_dirty_tree` gate. Then assert a clean tree across **all** rollback paths and force-restore (tracked) / force-clean (untracked) + log any leftovers by name.

## Tests (`scripts/tests/test_skill_generation_pipeline.py`, +4 → 66 passed)

- `_extract_failed_hooks`: multi-word hook name captured in full; output line containing "Failed" is ignored.
- `create_skill_pr` issues `ruff check --fix --unsafe-fixes`.
- `_rollback_skill`: a failed `git checkout -- skills/x/` does not prevent per-path restore of `docs/en/skills/index.md`, and the final `git status --porcelain` cleanup force-restores a reported leftover.

## Verification (all green)

- `pytest scripts/tests/test_skill_generation_pipeline.py` → **66 passed**
- `ruff check` / `ruff format --check` / `codespell` → clean
- `--mode daily --dry-run` smoke (selection only — dry-run returns before the fixed paths)
- pre-commit on changed files; diff scoped to the script + its tests (2 files)

## Scope note

This fixes (a) non-auto-fixable ruff PR loss, (b) rollback residue blocking the next day, (c) garbled/truncated failure logs. The 2026-06-20 failure also involved codespell; if a given day's "no PR" is codespell-driven, the improved logs will surface the exact word for an `ignore-words-list` / generator follow-up — that case is intentionally not auto-fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
