### PR TITLE
[codex] Harden skill package drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,22 +351,8 @@ jobs:
       - name: FMP client drift check
         run: python3 scripts/generate_fmp_client.py --check
 
-      - name: Changed skill package drift check
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD="${{ github.event.pull_request.head.sha }}"
-          else
-            BASE="${{ github.event.before }}"
-            HEAD="${{ github.sha }}"
-            if [[ "$BASE" =~ ^0+$ ]]; then
-              BASE="${HEAD}^"
-            fi
-          fi
-          mapfile -t changed < <(git diff --name-only "$BASE...$HEAD")
-          python3 scripts/check_package_drift_for_changed_skills.py "${changed[@]}"
+      - name: Packaged skill drift check
+        run: python3 scripts/check_package_drift_for_changed_skills.py
 
       - name: FMP skill package drift check
         run: python3 scripts/package_skills.py --check --skill pead-screener --skill earnings-trade-analyzer --skill ibd-distribution-day-monitor --skill vcp-screener --skill parabolic-short-trade-planner --skill ftd-detector --skill canslim-screener --skill macro-regime-detector --skill market-top-detector

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -144,13 +144,14 @@ repos:
         pass_filenames: false
 
       - id: changed-package-drift
-        name: Changed packaged skill drift check
+        name: Packaged skill drift check
         entry: python3 scripts/check_package_drift_for_changed_skills.py
         language: system
-        # Check only packaged skills touched by this commit, so unrelated stale
-        # archives do not block focused PRs.
-        files: '^(skills/[^/]+/.*|skill-packages/[^/]+\.skill)$'
-        pass_filenames: true
+        # Keep the historical id for hook continuity, but run the checker in
+        # no-argument mode so missing or stale packages cannot be skipped when
+        # the hook is invoked without filenames.
+        files: '^(skills/[^/]+/.*|skill-packages/[^/]+\.skill|scripts/(check_package_drift_for_changed_skills|package_skills)\.py)$'
+        pass_filenames: false
 
       - id: fmp-package-drift
         name: FMP skill package drift check (re-package after vendored client changes)

--- a/scripts/check_package_drift_for_changed_skills.py
+++ b/scripts/check_package_drift_for_changed_skills.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check package drift only for packaged skills touched by changed files."""
+"""Check .skill package drift for changed paths or the full skill set."""
 
 from __future__ import annotations
 
@@ -7,7 +7,13 @@ import sys
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
-from package_skills import DEFAULT_OUTPUT_DIR, DEFAULT_SKILLS_DIR, PROJECT_ROOT, check_skill
+from package_skills import (
+    DEFAULT_OUTPUT_DIR,
+    DEFAULT_SKILLS_DIR,
+    PROJECT_ROOT,
+    check_skill,
+    discover_skill_dirs,
+)
 from package_skills import should_include as package_should_include
 
 
@@ -68,30 +74,18 @@ def packaged_skills_for_changed_paths(
         if skill is None:
             continue
 
-        archive_path = output_dir / f"{skill}.skill"
-        if archive_path.is_file() and (skills_dir / skill / "SKILL.md").is_file():
+        if (skills_dir / skill / "SKILL.md").is_file():
             candidate_skills.add(skill)
 
     return sorted(candidate_skills)
 
 
-def check_changed_package_drift(
-    changed_paths: Iterable[str],
+def _check_skill_names(
+    skill_names: Iterable[str],
     *,
     skills_dir: Path = DEFAULT_SKILLS_DIR,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
-    project_root: Path = PROJECT_ROOT,
 ) -> int:
-    """Check changed packaged skills and return a process-style exit code."""
-    skill_names = packaged_skills_for_changed_paths(
-        changed_paths,
-        skills_dir=skills_dir,
-        output_dir=output_dir,
-        project_root=project_root,
-    )
-    if not skill_names:
-        return 0
-
     drift = False
     for skill_name in skill_names:
         skill_dir = skills_dir / skill_name
@@ -107,6 +101,36 @@ def check_changed_package_drift(
             drift = True
 
     return 1 if drift else 0
+
+
+def check_changed_package_drift(
+    changed_paths: Iterable[str],
+    *,
+    skills_dir: Path = DEFAULT_SKILLS_DIR,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    project_root: Path = PROJECT_ROOT,
+) -> int:
+    """Check package drift and return a process-style exit code.
+
+    Filename mode stays scoped to packageable changed skills. No-argument mode
+    validates every source skill so CI/pre-commit wiring cannot skip missing
+    archives when invoked without file arguments.
+    """
+    changed_path_list = list(changed_paths)
+    if changed_path_list:
+        skill_names = packaged_skills_for_changed_paths(
+            changed_path_list,
+            skills_dir=skills_dir,
+            output_dir=output_dir,
+            project_root=project_root,
+        )
+    else:
+        skill_names = [skill_dir.name for skill_dir in discover_skill_dirs(skills_dir)]
+
+    if not skill_names:
+        return 0
+
+    return _check_skill_names(skill_names, skills_dir=skills_dir, output_dir=output_dir)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/tests/test_check_package_drift_for_changed_skills.py
+++ b/scripts/tests/test_check_package_drift_for_changed_skills.py
@@ -10,6 +10,7 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import check_package_drift_for_changed_skills as checker  # noqa: E402
 from check_package_drift_for_changed_skills import (
     check_changed_package_drift,  # noqa: E402
     packaged_skills_for_changed_paths,  # noqa: E402
@@ -47,9 +48,44 @@ def _check(project_root: Path, changed_paths: list[str]) -> int:
     )
 
 
-def test_no_args_passes(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_no_args_checks_all_skills_and_passes_when_archives_match(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _make_skill(tmp_path, "demo")
+
     assert _check(tmp_path, []) == 0
-    assert capsys.readouterr().out == ""
+    assert capsys.readouterr().out == "OK: skill-packages/demo.skill matches source\n"
+
+
+def test_no_args_fails_when_archive_is_stale(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skill_dir = _make_skill(tmp_path, "demo")
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: Changed.\n---\n",
+        encoding="utf-8",
+    )
+
+    assert _check(tmp_path, []) == 1
+    assert capsys.readouterr().out == (
+        "DRIFT: skill-packages/demo.skill is stale; "
+        "re-run python3 scripts/package_skills.py --skill demo\n"
+    )
+
+
+def test_no_args_fails_when_archive_is_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _make_skill(tmp_path, "demo", package=False)
+
+    assert _check(tmp_path, []) == 1
+    assert capsys.readouterr().out == (
+        "DRIFT: skill-packages/demo.skill is stale; "
+        "re-run python3 scripts/package_skills.py --skill demo\n"
+    )
 
 
 def test_skill_source_change_fails_when_archive_is_stale(
@@ -121,17 +157,20 @@ def test_packaged_schema_change_fails_when_archive_is_stale(
     )
 
 
-def test_unpacked_skill_source_change_is_ignored(
+def test_skill_source_change_fails_when_archive_is_missing(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     _make_skill(tmp_path, "demo", package=False)
 
-    assert _check(tmp_path, ["skills/demo/SKILL.md"]) == 0
-    assert capsys.readouterr().out == ""
+    assert _check(tmp_path, ["skills/demo/SKILL.md"]) == 1
+    assert capsys.readouterr().out == (
+        "DRIFT: skill-packages/demo.skill is stale; "
+        "re-run python3 scripts/package_skills.py --skill demo\n"
+    )
 
 
-def test_multiple_skill_changes_check_only_packaged_changed_skills(
+def test_multiple_skill_changes_check_only_changed_skills_and_missing_archives(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -156,9 +195,26 @@ def test_multiple_skill_changes_check_only_packaged_changed_skills(
         skills_dir=tmp_path / "skills",
         output_dir=tmp_path / "skill-packages",
         project_root=tmp_path,
-    ) == ["changed"]
+    ) == ["changed", "unpacked"]
     assert _check(tmp_path, ["skills/changed/SKILL.md", "skills/unpacked/SKILL.md"]) == 1
     assert capsys.readouterr().out == (
         "DRIFT: skill-packages/changed.skill is stale; "
         "re-run python3 scripts/package_skills.py --skill changed\n"
+        "DRIFT: skill-packages/unpacked.skill is stale; "
+        "re-run python3 scripts/package_skills.py --skill unpacked\n"
     )
+
+
+def test_main_empty_argv_invokes_no_arg_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_paths: list[str] = []
+
+    def fake_check(changed_paths: list[str]) -> int:
+        captured_paths.extend(changed_paths)
+        return 7
+
+    monkeypatch.setattr(checker, "check_changed_package_drift", fake_check)
+
+    assert checker.main([]) == 7
+    assert captured_paths == []


### PR DESCRIPTION
## Summary

- Harden `scripts/check_package_drift_for_changed_skills.py` so no-argument mode validates the full skill package set.
- Stop skipping changed source skills whose `.skill` archive is missing; missing archives now fail through the same package drift path.
- Wire pre-commit and CI to run the full package drift gate, and add stale/missing package regression tests.

## Issue Handling

Closes #212.

Current package inventory on this branch:

- Indexed skills: 64
- `.skill` packages: 64
- Missing packages: none
- Extra packages: none

The gate checks logical archive equivalence rather than filesystem mtimes, which is stable across Git checkouts and still detects stale or missing Web App packages.

## Review Loops

- Plan review: 2 rounds. Round 1 found missing-archive, CI wiring, and hook trigger gaps; round 2 had no blockers.
- Implementation review: 1 round. No PR-blocking findings.

## Validation

- `python3.9 -m pytest scripts/tests/test_check_package_drift_for_changed_skills.py scripts/tests/test_package_skills.py -q`
- `ruff check scripts/check_package_drift_for_changed_skills.py scripts/tests/test_check_package_drift_for_changed_skills.py scripts/tests/test_package_skills.py`
- `ruff format --check scripts/check_package_drift_for_changed_skills.py scripts/tests/test_check_package_drift_for_changed_skills.py scripts/tests/test_package_skills.py`
- `python3 scripts/check_package_drift_for_changed_skills.py`
- `pre-commit run changed-package-drift --all-files`
- `python3 scripts/package_skills.py --check`
- `python3 scripts/generate_catalog_from_index.py --check`
- `python3 scripts/generate_skill_docs.py --check`
- `python3 scripts/validate_skills_index.py --strict-metadata --strict-workflows`
- `python3 scripts/validate_skillsets.py`
- `python3 scripts/generate_workflow_docs.py --check`
- `python3 scripts/generate_skillset_docs.py --check`
- `python3 skills/trading-skills-navigator/scripts/build_snapshot.py --check`
- `pre-commit run --all-files`
- `git diff --check`
- `bash scripts/run_all_tests.sh`

Note: the first sandboxed `bash scripts/run_all_tests.sh` attempt failed on `/Users/takueisaotome/.cache/uv/sdists-v9/.git` permissions. The same command passed when rerun with the required local cache access: `56/56 passed, 3 skipped` (`theme-detector`, `canslim-screener`, `pair-trade-screener` are known skips in the script).
