### PR TITLE
Generate the CI skill test matrix dynamically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,249 +31,75 @@ jobs:
       - name: Codespell
         run: codespell --toml pyproject.toml skills/ scripts/
 
-  test:
-    name: Test
+  discover-tests:
+    name: Discover test matrix
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"
+      - name: Discover and validate test coverage
+        id: discover
+        run: echo "matrix=$(python3 scripts/ci_test_matrix.py matrix)" >> "$GITHUB_OUTPUT"
 
-      - name: Install dependencies
+  test:
+    name: Test (${{ matrix.id }})
+    needs: discover-tests
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allowed_failure }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover-tests.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Install project dependencies
         run: pip install -e ".[dev]"
-
-      # Run each skill's tests in isolation to avoid module name collisions
-      # (each skill has its own scorer.py, calculators/, helpers.py).
-      # Order: alphabetical by skill name.
-      - name: Test backtest-expert
+      - name: Install policy dependencies
+        run: python scripts/ci_test_matrix.py install "${{ matrix.id }}"
+      - name: Run isolated tests
         run: >
-          python -m pytest skills/backtest-expert/scripts/tests/ -v
-          --cov=skills/backtest-expert/scripts
-          --cov-report=term-missing
-
-      - name: Test data-quality-checker
-        run: >
-          python -m pytest skills/data-quality-checker/scripts/tests/ -v
-          --cov=skills/data-quality-checker/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test drawdown-circuit-breaker
-        run: >
-          python -m pytest skills/drawdown-circuit-breaker/scripts/tests/ -v
-          --cov=skills/drawdown-circuit-breaker/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test dual-axis-skill-reviewer
-        run: >
-          python -m pytest skills/dual-axis-skill-reviewer/scripts/tests/ -v
-          --cov=skills/dual-axis-skill-reviewer/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test ftd-detector
-        run: >
-          python -m pytest skills/ftd-detector/scripts/tests/ -v
-          --cov=skills/ftd-detector/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test institutional-flow-tracker
-        run: >
-          python -m pytest skills/institutional-flow-tracker/scripts/tests/ -v
-          --cov=skills/institutional-flow-tracker/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test macro-regime-detector
-        run: >
-          python -m pytest skills/macro-regime-detector/scripts/tests/ -v
-          --cov=skills/macro-regime-detector/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test market-breadth-analyzer
-        run: >
-          python -m pytest skills/market-breadth-analyzer/scripts/tests/ -v
-          --cov=skills/market-breadth-analyzer/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test market-top-detector
-        run: >
-          python -m pytest skills/market-top-detector/scripts/tests/ -v
-          --cov=skills/market-top-detector/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Install canslim-screener FMP test deps
-        run: pip install beautifulsoup4 lxml
-
-      - name: Test canslim-screener FMP client contracts
-        run: >
-          python -m pytest
-          skills/canslim-screener/scripts/tests/test_fmp_fallback.py
-          skills/canslim-screener/scripts/tests/test_fmp_stable_migration.py
-          skills/canslim-screener/scripts/tests/test_institutional_fallback.py
-          -v
-          --cov=skills/canslim-screener/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test parabolic-short-trade-planner
-        run: >
-          python -m pytest skills/parabolic-short-trade-planner/scripts/tests/ -v
-          --cov=skills/parabolic-short-trade-planner/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test sector-analyst
-        run: >
-          python -m pytest skills/sector-analyst/scripts/tests/ -v
-          --cov=skills/sector-analyst/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test stanley-druckenmiller-investment
-        run: >
-          python -m pytest skills/stanley-druckenmiller-investment/scripts/tests/ -v
-          --cov=skills/stanley-druckenmiller-investment/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test stockbee-20pct-study
-        run: >
-          python -m pytest skills/stockbee-20pct-study/scripts/tests/ -v
-          --cov=skills/stockbee-20pct-study/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test stockbee-exhaustion-hammer-screener
-        run: >
-          python -m pytest skills/stockbee-exhaustion-hammer-screener/scripts/tests/ -v
-          --cov=skills/stockbee-exhaustion-hammer-screener/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test stockbee-momentum-burst-screener
-        run: >
-          python -m pytest skills/stockbee-momentum-burst-screener/scripts/tests/ -v
-          --cov=skills/stockbee-momentum-burst-screener/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test stockbee-episodic-pivot-analyzer
-        run: >
-          python -m pytest skills/stockbee-episodic-pivot-analyzer/scripts/tests/ -v
-          --cov=skills/stockbee-episodic-pivot-analyzer/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test stockbee-setup-fluency-trainer
-        run: >
-          python -m pytest skills/stockbee-setup-fluency-trainer/scripts/tests/ -v
-          --cov=skills/stockbee-setup-fluency-trainer/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test uptrend-analyzer
-        run: >
-          python -m pytest skills/uptrend-analyzer/scripts/tests/ -v
-          --cov=skills/uptrend-analyzer/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test vcp-screener
-        run: >
-          python -m pytest skills/vcp-screener/scripts/tests/ -v
-          --cov=skills/vcp-screener/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test position-sizer
-        run: >
-          python -m pytest skills/position-sizer/scripts/tests/ -v
-          --cov=skills/position-sizer/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test pre-trade-discipline-gate
-        run: >
-          python -m pytest skills/pre-trade-discipline-gate/scripts/tests/ -v
-          --cov=skills/pre-trade-discipline-gate/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test edge-strategy-reviewer
-        run: >
-          python -m pytest skills/edge-strategy-reviewer/scripts/tests/ -v
-          --cov=skills/edge-strategy-reviewer/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test edge-pipeline-orchestrator
-        run: >
-          python -m pytest skills/edge-pipeline-orchestrator/scripts/tests/ -v
-          --cov=skills/edge-pipeline-orchestrator/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test skill-designer
-        run: >
-          python -m pytest skills/skill-designer/scripts/tests/ -v
-          --cov=skills/skill-designer/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test skill-idea-miner
-        run: >
-          python -m pytest skills/skill-idea-miner/scripts/tests/ -v
-          --cov=skills/skill-idea-miner/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test trading-skills-navigator
-        run: >
-          python -m pytest skills/trading-skills-navigator/scripts/tests/ -v
-          --cov=skills/trading-skills-navigator/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Test repo-level scripts
-        run: >
-          python -m pytest scripts/tests/ -v
-          --cov=scripts
-          --cov-report=term-missing
-          --cov-append
-
-      # Known failures: theme-detector (27 pre-existing), canslim-screener (requires bs4).
-      # Run with continue-on-error so they don't block the pipeline.
-      - name: Install theme-detector extra deps
-        run: pip install pandas numpy
-
-      - name: Test theme-detector (known failures)
-        continue-on-error: true
-        run: >
-          python -m pytest skills/theme-detector/scripts/tests/ -v
-          --cov=skills/theme-detector/scripts
-          --cov-report=term-missing
-          --cov-append
-
-      - name: Coverage summary
+          python scripts/ci_test_matrix.py run "${{ matrix.id }}"
+          --coverage-dir coverage-data
+      - name: Upload coverage row
         if: always()
-        run: python -m coverage report
-
-      - name: Upload coverage report
-        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
-          path: htmlcov/
-          retention-days: 7
+          name: coverage-${{ matrix.id }}
+          path: coverage-data/
+          if-no-files-found: warn
+          retention-days: 1
+
+  coverage:
+    name: Coverage
+    needs: [discover-tests, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Install project dependencies
+        run: pip install -e ".[dev]"
+      - name: Download coverage rows
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts
+      - name: Validate and combine coverage
+        run: >
+          python scripts/ci_test_matrix.py aggregate
+          --artifacts coverage-artifacts
+          --output combined-coverage
 
   metadata:
     name: Metadata + Workflow checks

--- a/scripts/ci_test_matrix.py
+++ b/scripts/ci_test_matrix.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Discover and run skill tests without hand-maintained CI test steps."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+@dataclass(frozen=True)
+class TestEntry:
+    __test__ = False
+
+    id: str
+    test_paths: tuple[str, ...]
+    coverage_target: str
+    requirements: tuple[str, ...] = ()
+    allowed_failure: bool = False
+    excluded: bool = False
+    reason: str | None = None
+
+
+# Only existing exceptions belong here. Newly discovered skills use the default policy.
+POLICY = {
+    "canslim-screener": {
+        "test_paths": (
+            "skills/canslim-screener/scripts/tests/test_fmp_fallback.py",
+            "skills/canslim-screener/scripts/tests/test_fmp_stable_migration.py",
+            "skills/canslim-screener/scripts/tests/test_institutional_fallback.py",
+        ),
+        "requirements": ("beautifulsoup4", "lxml"),
+        "reason": "Preserve the existing CI FMP contract subset and optional dependencies.",
+    },
+    "pair-trade-screener": {
+        "excluded": True,
+        "reason": "Known optional statsmodels dependency; preserved as a covered exclusion.",
+    },
+    "theme-detector": {
+        "requirements": ("pandas", "numpy"),
+        "allowed_failure": True,
+        "reason": "Preserve the existing non-blocking known-failure CI contract.",
+    },
+}
+
+
+class MatrixError(ValueError):
+    """Raised when discovered tests and policy do not form a closed matrix."""
+
+
+def _has_tests(path: Path) -> bool:
+    return path.is_dir() and any(path.glob("test_*.py"))
+
+
+def discover(root: Path = ROOT) -> dict[str, TestEntry]:
+    """Return canonical direct-layout test entries from the filesystem."""
+    entries: dict[str, TestEntry] = {}
+    skills_dir = root / "skills"
+    if skills_dir.is_dir():
+        for skill_dir in sorted(path for path in skills_dir.iterdir() if path.is_dir()):
+            paths = []
+            for relative in (Path("scripts/tests"), Path("tests")):
+                candidate = skill_dir / relative
+                if _has_tests(candidate):
+                    paths.append(candidate.relative_to(root).as_posix())
+            if paths:
+                skill_id = skill_dir.name
+                entries[skill_id] = TestEntry(
+                    id=skill_id,
+                    test_paths=tuple(paths),
+                    coverage_target=f"skills/{skill_id}/scripts",
+                )
+
+    repo_tests = root / "scripts/tests"
+    if _has_tests(repo_tests):
+        entries["repo-scripts"] = TestEntry(
+            id="repo-scripts",
+            test_paths=("scripts/tests",),
+            coverage_target="scripts",
+        )
+    return entries
+
+
+def build_entries(
+    root: Path = ROOT, policy: dict[str, dict[str, object]] | None = None
+) -> dict[str, TestEntry]:
+    """Apply the explicit policy and fail if any discovered entry is uncovered."""
+    discovered = discover(root)
+    policy = POLICY if policy is None else policy
+    unknown = sorted(set(policy) - set(discovered))
+    if unknown:
+        raise MatrixError(f"policy references undiscovered test ids: {', '.join(unknown)}")
+
+    result: dict[str, TestEntry] = {}
+    for entry_id, base in discovered.items():
+        if not ID_RE.fullmatch(entry_id):
+            raise MatrixError(f"unsafe test id: {entry_id!r}")
+        override = policy.get(entry_id, {})
+        allowed_keys = {"test_paths", "requirements", "allowed_failure", "excluded", "reason"}
+        extra = set(override) - allowed_keys
+        if extra:
+            raise MatrixError(f"unknown policy keys for {entry_id}: {sorted(extra)}")
+        entry = replace(
+            base,
+            test_paths=tuple(override.get("test_paths", base.test_paths)),
+            requirements=tuple(override.get("requirements", ())),
+            allowed_failure=bool(override.get("allowed_failure", False)),
+            excluded=bool(override.get("excluded", False)),
+            reason=override.get("reason") if isinstance(override.get("reason"), str) else None,
+        )
+        if (
+            entry.allowed_failure or entry.excluded or entry.test_paths != base.test_paths
+        ) and not entry.reason:
+            raise MatrixError(f"exception policy for {entry_id} requires a reason")
+        if entry.allowed_failure and entry.excluded:
+            raise MatrixError(f"{entry_id} cannot be both allowed_failure and excluded")
+        if not entry.test_paths:
+            raise MatrixError(f"{entry_id} has no covered test paths")
+        for rel_path in entry.test_paths:
+            path = root / rel_path
+            if not path.exists() or root not in path.resolve().parents:
+                raise MatrixError(f"invalid test path for {entry_id}: {rel_path}")
+        for requirement in entry.requirements:
+            if not requirement or requirement.startswith("-") or re.search(r"\s", requirement):
+                raise MatrixError(f"unsafe requirement for {entry_id}: {requirement!r}")
+        result[entry_id] = entry
+
+    if not result:
+        raise MatrixError("no test suites discovered")
+    if set(result) != set(discovered):
+        missing = sorted(set(discovered) - set(result))
+        raise MatrixError(f"discovered tests are not covered: {', '.join(missing)}")
+    if not any(not entry.excluded for entry in result.values()):
+        raise MatrixError("matrix has no runnable test suites")
+    return result
+
+
+def matrix(entries: dict[str, TestEntry]) -> dict[str, list[dict[str, object]]]:
+    rows = [
+        {"id": entry.id, "allowed_failure": entry.allowed_failure}
+        for entry in entries.values()
+        if not entry.excluded
+    ]
+    return {"include": rows}
+
+
+def install(entry: TestEntry) -> None:
+    if entry.requirements:
+        uv = shutil.which("uv")
+        command = (
+            [uv, "pip", "install", "--python", sys.executable, "--", *entry.requirements]
+            if uv
+            else [sys.executable, "-m", "pip", "install", "--", *entry.requirements]
+        )
+        subprocess.run(command, check=True)
+
+
+def run(entry: TestEntry, root: Path, coverage_dir: Path | None) -> int:
+    command = [sys.executable, "-m", "pytest", *entry.test_paths, "--tb=short", "-q"]
+    manifest = None
+    if coverage_dir is not None:
+        coverage_dir.mkdir(parents=True, exist_ok=True)
+        coverage_file = coverage_dir / f"coverage.{entry.id}"
+        manifest = coverage_dir / f"manifest.{entry.id}.json"
+        env = {**os.environ, "COVERAGE_FILE": str(coverage_file)}
+        command.extend([f"--cov={entry.coverage_target}", "--cov-report=", "--cov-fail-under=0"])
+    else:
+        env = None
+
+    completed = subprocess.run(command, cwd=root, env=env, check=False)
+    if manifest is not None:
+        coverage_file = coverage_dir / f"coverage.{entry.id}"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "id": entry.id,
+                    "allowed_failure": entry.allowed_failure,
+                    "test_exit": completed.returncode,
+                    "coverage_created": coverage_file.is_file(),
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return completed.returncode
+
+
+def aggregate(entries: dict[str, TestEntry], artifacts: Path, output: Path) -> int:
+    expected = {entry.id: entry for entry in entries.values() if not entry.excluded}
+    manifests: dict[str, dict[str, object]] = {}
+    for path in artifacts.rglob("manifest.*.json"):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        entry_id = payload.get("id")
+        if not isinstance(entry_id, str) or entry_id in manifests:
+            raise MatrixError(f"invalid or duplicate manifest: {path}")
+        if path.name != f"manifest.{entry_id}.json":
+            raise MatrixError(f"manifest filename/id mismatch: {path}")
+        manifests[entry_id] = payload
+
+    unexpected = sorted(set(manifests) - set(expected))
+    if unexpected:
+        raise MatrixError(f"unexpected manifests: {', '.join(unexpected)}")
+
+    coverage_paths = []
+    blocking_errors = []
+    for entry_id, entry in expected.items():
+        payload = manifests.get(entry_id)
+        matching_coverage = list(artifacts.rglob(f"coverage.{entry_id}"))
+        if len(matching_coverage) > 1:
+            raise MatrixError(f"duplicate coverage data for {entry_id}")
+        coverage_path = matching_coverage[0] if matching_coverage else None
+        if payload is not None:
+            required = {"id", "allowed_failure", "test_exit", "coverage_created"}
+            if set(payload) != required:
+                raise MatrixError(f"invalid manifest fields for {entry_id}")
+            if not isinstance(payload["allowed_failure"], bool) or not isinstance(
+                payload["coverage_created"], bool
+            ):
+                raise MatrixError(f"invalid manifest booleans for {entry_id}")
+            if not isinstance(payload["test_exit"], int) or isinstance(payload["test_exit"], bool):
+                raise MatrixError(f"invalid test exit for {entry_id}")
+            if payload["allowed_failure"] != entry.allowed_failure:
+                raise MatrixError(f"allowed-failure mismatch for {entry_id}")
+            if payload["coverage_created"] != (coverage_path is not None):
+                raise MatrixError(f"coverage manifest mismatch for {entry_id}")
+            if payload["test_exit"] != 0 and not entry.allowed_failure:
+                blocking_errors.append(f"{entry_id} (tests failed)")
+                continue
+
+        missing = payload is None or coverage_path is None
+        if missing and entry.allowed_failure:
+            print(f"WARNING: allowed-failure row {entry_id} produced no coverage", file=sys.stderr)
+            continue
+        if missing:
+            blocking_errors.append(entry_id)
+            continue
+        coverage_paths.append(coverage_path)
+    if blocking_errors:
+        raise MatrixError(
+            f"blocking rows missing manifests or coverage: {', '.join(blocking_errors)}"
+        )
+    if not coverage_paths:
+        raise MatrixError("no coverage data available to combine")
+
+    output.mkdir(parents=True, exist_ok=True)
+    env = {**os.environ, "COVERAGE_FILE": str(output / "coverage")}
+    subprocess.run(
+        [sys.executable, "-m", "coverage", "combine", *map(str, coverage_paths)],
+        cwd=ROOT,
+        env=env,
+        check=True,
+    )
+    return subprocess.run(
+        [sys.executable, "-m", "coverage", "report", "--fail-under=40"],
+        cwd=ROOT,
+        env=env,
+        check=False,
+    ).returncode
+
+
+def _entry(entries: dict[str, TestEntry], entry_id: str) -> TestEntry:
+    try:
+        entry = entries[entry_id]
+    except KeyError as exc:
+        raise MatrixError(f"unknown test id: {entry_id}") from exc
+    if entry.excluded:
+        raise MatrixError(f"test id is a covered exclusion: {entry_id} ({entry.reason})")
+    return entry
+
+
+def _print_local_summary(entries: Iterable[TestEntry]) -> None:
+    excluded = [entry for entry in entries if entry.excluded]
+    if excluded:
+        print("Covered exclusions:")
+        for entry in excluded:
+            print(f"  {entry.id}: {entry.reason}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("matrix")
+    subparsers.add_parser("list")
+    allowed_parser = subparsers.add_parser("allowed-failure")
+    allowed_parser.add_argument("id")
+    install_parser = subparsers.add_parser("install")
+    install_parser.add_argument("id")
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("id")
+    run_parser.add_argument("--coverage-dir", type=Path)
+    aggregate_parser = subparsers.add_parser("aggregate")
+    aggregate_parser.add_argument("--artifacts", type=Path, required=True)
+    aggregate_parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        entries = build_entries()
+        if args.command == "matrix":
+            print(json.dumps(matrix(entries), separators=(",", ":")))
+        elif args.command == "list":
+            for entry in entries.values():
+                if not entry.excluded:
+                    print(entry.id)
+            _print_local_summary(entries.values())
+        elif args.command == "allowed-failure":
+            return 0 if _entry(entries, args.id).allowed_failure else 1
+        elif args.command == "install":
+            install(_entry(entries, args.id))
+        elif args.command == "run":
+            return run(_entry(entries, args.id), ROOT, args.coverage_dir)
+        elif args.command == "aggregate":
+            return aggregate(entries, args.artifacts, args.output)
+    except (MatrixError, OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -1,86 +1,31 @@
 #!/usr/bin/env bash
-# Run all skill-level tests, one pytest invocation per skill.
-# NOTE: With importmode = "importlib" in pyproject.toml, a single
-#   `uv run python -m pytest` also works for bulk execution.
-#   This script is kept for backward compatibility and for isolating
-#   known-failing skills (KNOWN_SKIP).
-#
-# Uses `uv run --extra dev` to ensure pytest and dev dependencies are available
-# regardless of the caller's virtualenv state.
-#
-# Exit with non-zero if any non-skipped skill's tests fail.
+# Run the same dynamically discovered test rows used by GitHub Actions.
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-
-# Skills with known pre-existing test failures.
-# These are excluded from the gate so that the pre-push hook is usable.
-# Remove a skill from this list once its failures are fixed.
-KNOWN_SKIP=(
-    "theme-detector"      # 27 pre-existing failures
-    "canslim-screener"    # requires bs4 (optional dep, not in dev extras)
-    "pair-trade-screener" # requires statsmodels (optional dep, not in dev extras)
-)
-
 FAILED=0
 TOTAL=0
-SKIPPED=0
 FAILED_SKILLS=()
-
-is_skipped() {
-    local skill="$1"
-    for s in "${KNOWN_SKIP[@]}"; do
-        [ "$s" = "$skill" ] && return 0
-    done
-    return 1
-}
-
-# --- Skill tests: skills/*/scripts/tests/ and skills/*/tests/ ---
-for test_dir in "$REPO_ROOT"/skills/*/scripts/tests/ "$REPO_ROOT"/skills/*/tests/; do
-    # Skip if directory doesn't exist or has no test files
-    [ -d "$test_dir" ] || continue
-    ls "$test_dir"/test_*.py >/dev/null 2>&1 || continue
-
-    skill_name=$(echo "$test_dir" | sed "s|$REPO_ROOT/skills/||" | cut -d/ -f1)
-
-    if is_skipped "$skill_name"; then
-        SKIPPED=$((SKIPPED + 1))
-        echo "--- $skill_name (SKIPPED — known failures) ---"
-        echo ""
-        continue
-    fi
-
+TEST_OUTPUT=$(uv run --extra dev python scripts/ci_test_matrix.py list)
+TEST_IDS=$(printf '%s\n' "$TEST_OUTPUT" | sed '/^Covered exclusions:/,$d')
+while IFS= read -r test_id; do
+    [ -n "$test_id" ] || continue
     TOTAL=$((TOTAL + 1))
-
-    echo "--- $skill_name ($test_dir) ---"
-    if uv run --extra dev pytest "$test_dir" --tb=short -q 2>&1; then
-        :
-    else
-        FAILED=$((FAILED + 1))
-        FAILED_SKILLS+=("$skill_name")
+    echo "--- $test_id ---"
+    if ! uv run --extra dev python scripts/ci_test_matrix.py install "$test_id" ||
+       ! uv run --extra dev python scripts/ci_test_matrix.py run "$test_id"; then
+        if uv run --extra dev python scripts/ci_test_matrix.py allowed-failure "$test_id"; then
+            echo "KNOWN FAILURE: $test_id is non-blocking"
+        else
+            FAILED=$((FAILED + 1))
+            FAILED_SKILLS+=("$test_id")
+        fi
     fi
     echo ""
-done
+done <<< "$TEST_IDS"
 
-# --- Repo-level tests: scripts/tests/ ---
-REPO_TEST_DIR="$REPO_ROOT/scripts/tests"
-if [ -d "$REPO_TEST_DIR" ] && ls "$REPO_TEST_DIR"/test_*.py >/dev/null 2>&1; then
-    TOTAL=$((TOTAL + 1))
-    echo "--- repo scripts/tests ---"
-    if uv run --extra dev pytest "$REPO_TEST_DIR" --tb=short -q 2>&1; then
-        :
-    else
-        FAILED=$((FAILED + 1))
-        FAILED_SKILLS+=("scripts/tests")
-    fi
-    echo ""
-fi
-
-echo "=== Summary: $((TOTAL - FAILED))/$TOTAL passed, $SKIPPED skipped ==="
-if [ ${#KNOWN_SKIP[@]} -gt 0 ]; then
-    echo "Skipped (known failures): ${KNOWN_SKIP[*]}"
-fi
+echo "=== Summary: $((TOTAL - FAILED))/$TOTAL passed ==="
+printf '%s\n' "$TEST_OUTPUT" | sed -n '/^Covered exclusions:/,$p'
 if [ $FAILED -gt 0 ]; then
     echo "FAILED: ${FAILED_SKILLS[*]}"
     exit 1

--- a/scripts/tests/test_ci_test_matrix.py
+++ b/scripts/tests/test_ci_test_matrix.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ci_test_matrix import (
+    MatrixError,
+    TestEntry,
+    aggregate,
+    build_entries,
+    discover,
+    install,
+    main,
+    matrix,
+    run,
+)
+
+
+def _test_file(root: Path, relative: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+
+def test_discover_supports_both_direct_skill_layouts_and_repo_tests(tmp_path):
+    _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
+    _test_file(tmp_path, "skills/beta/tests/test_beta.py")
+    _test_file(tmp_path, "scripts/tests/test_repo.py")
+
+    entries = discover(tmp_path)
+
+    assert list(entries) == ["alpha", "beta", "repo-scripts"]
+    assert entries["alpha"].test_paths == ("skills/alpha/scripts/tests",)
+    assert entries["beta"].test_paths == ("skills/beta/tests",)
+
+
+def test_discover_ignores_empty_and_nested_noncanonical_tests(tmp_path):
+    (tmp_path / "skills/empty/scripts/tests").mkdir(parents=True)
+    _test_file(tmp_path, "skills/outer/examples/skills/nested/scripts/tests/test_nested.py")
+
+    assert discover(tmp_path) == {}
+
+
+def test_new_skill_is_automatically_included_in_matrix(tmp_path):
+    _test_file(tmp_path, "skills/new-skill/scripts/tests/test_new.py")
+
+    entries = build_entries(tmp_path, policy={})
+
+    assert matrix(entries) == {"include": [{"id": "new-skill", "allowed_failure": False}]}
+
+
+def test_exception_policy_requires_reason(tmp_path):
+    _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
+
+    with pytest.raises(MatrixError, match="requires a reason"):
+        build_entries(tmp_path, {"alpha": {"excluded": True}})
+
+
+def test_unknown_policy_and_missing_override_path_fail_closed(tmp_path):
+    _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
+
+    with pytest.raises(MatrixError, match="undiscovered"):
+        build_entries(tmp_path, {"ghost": {"reason": "not real"}})
+    with pytest.raises(MatrixError, match="invalid test path"):
+        build_entries(
+            tmp_path,
+            {"alpha": {"test_paths": ("missing.py",), "reason": "partial contract"}},
+        )
+
+
+def test_zero_runnable_rows_fail(tmp_path):
+    _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
+
+    with pytest.raises(MatrixError, match="no runnable"):
+        build_entries(tmp_path, {"alpha": {"excluded": True, "reason": "known failure"}})
+
+
+def test_matrix_json_is_compact_and_contains_no_paths(tmp_path):
+    _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
+    payload = json.dumps(matrix(build_entries(tmp_path, {})), separators=(",", ":"))
+
+    assert payload == '{"include":[{"id":"alpha","allowed_failure":false}]}'
+    assert "skills/" not in payload
+
+
+def test_install_uses_safe_argv_and_double_dash(monkeypatch):
+    calls = []
+    monkeypatch.setattr("scripts.ci_test_matrix.shutil.which", lambda _name: None)
+    monkeypatch.setattr(
+        "scripts.ci_test_matrix.subprocess.run",
+        lambda command, check: calls.append((command, check)),
+    )
+    entry = TestEntry("alpha", ("tests",), "scripts", requirements=("safe-package>=1",))
+
+    install(entry)
+
+    assert calls == [([sys.executable, "-m", "pip", "install", "--", "safe-package>=1"], True)]
+
+
+def test_run_always_writes_manifest_with_test_result_and_coverage(monkeypatch, tmp_path):
+    def fake_run(command, cwd, env, check):
+        Path(env["COVERAGE_FILE"]).write_text("coverage", encoding="utf-8")
+        return SimpleNamespace(returncode=3)
+
+    monkeypatch.setattr("scripts.ci_test_matrix.subprocess.run", fake_run)
+    entry = TestEntry("alpha", ("tests",), "scripts")
+
+    assert run(entry, tmp_path, tmp_path / "artifacts") == 3
+    manifest = json.loads((tmp_path / "artifacts/manifest.alpha.json").read_text())
+    assert manifest == {
+        "allowed_failure": False,
+        "coverage_created": True,
+        "id": "alpha",
+        "test_exit": 3,
+    }
+
+
+def _artifact(tmp_path: Path, entry_id: str, **overrides) -> None:
+    payload = {
+        "id": entry_id,
+        "allowed_failure": False,
+        "test_exit": 0,
+        "coverage_created": True,
+        **overrides,
+    }
+    (tmp_path / f"manifest.{entry_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+    if payload["coverage_created"]:
+        (tmp_path / f"coverage.{entry_id}").write_text("data", encoding="utf-8")
+
+
+def test_aggregate_rejects_failed_blocking_manifest(tmp_path):
+    _artifact(tmp_path, "alpha", test_exit=1)
+    entries = {"alpha": TestEntry("alpha", ("tests",), "scripts")}
+
+    with pytest.raises(MatrixError, match="tests failed"):
+        aggregate(entries, tmp_path, tmp_path / "combined")
+
+
+def test_aggregate_rejects_manifest_policy_and_coverage_mismatch(tmp_path):
+    entries = {"alpha": TestEntry("alpha", ("tests",), "scripts")}
+    _artifact(tmp_path, "alpha", allowed_failure=True)
+    with pytest.raises(MatrixError, match="allowed-failure mismatch"):
+        aggregate(entries, tmp_path, tmp_path / "combined")
+
+    (tmp_path / "manifest.alpha.json").unlink()
+    (tmp_path / "coverage.alpha").unlink()
+    _artifact(tmp_path, "alpha", coverage_created=False)
+    (tmp_path / "coverage.alpha").write_text("unexpected", encoding="utf-8")
+    with pytest.raises(MatrixError, match="coverage manifest mismatch"):
+        aggregate(entries, tmp_path, tmp_path / "combined")
+
+
+def test_aggregate_warns_for_missing_allowed_row_and_combines_blocking_row(
+    monkeypatch, tmp_path, capsys
+):
+    _artifact(tmp_path, "alpha")
+    entries = {
+        "alpha": TestEntry("alpha", ("tests",), "scripts"),
+        "known": TestEntry("known", ("tests",), "scripts", allowed_failure=True),
+    }
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("scripts.ci_test_matrix.subprocess.run", fake_run)
+
+    assert aggregate(entries, tmp_path, tmp_path / "combined") == 0
+    assert "allowed-failure row known" in capsys.readouterr().err
+    assert calls[0][3] == "combine"
+    assert str(tmp_path / "coverage.alpha") in calls[0]
+    assert calls[1][3:5] == ["report", "--fail-under=40"]
+
+
+def test_cli_unknown_id_is_nonzero(monkeypatch, tmp_path, capsys):
+    _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
+    monkeypatch.setattr("scripts.ci_test_matrix.ROOT", tmp_path)
+    monkeypatch.setattr("scripts.ci_test_matrix.POLICY", {})
+
+    assert main(["run", "missing"]) == 1
+    assert "unknown test id" in capsys.readouterr().err

--- a/skills/edge-concept-synthesizer/scripts/tests/test_synthesize_edge_concepts.py
+++ b/skills/edge-concept-synthesizer/scripts/tests/test_synthesize_edge_concepts.py
@@ -1,5 +1,7 @@
 """Unit tests for synthesize_edge_concepts.py."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import synthesize_edge_concepts as sec

--- a/skills/edge-strategy-designer/scripts/tests/test_design_strategy_drafts.py
+++ b/skills/edge-strategy-designer/scripts/tests/test_design_strategy_drafts.py
@@ -1,5 +1,7 @@
 """Unit tests for design_strategy_drafts.py."""
 
+from __future__ import annotations
+
 import design_strategy_drafts as dsd
 
 

--- a/skills/finviz-screener/scripts/tests/test_open_finviz_screener.py
+++ b/skills/finviz-screener/scripts/tests/test_open_finviz_screener.py
@@ -475,9 +475,11 @@ class TestOpenBrowser:
         assert mock_run.call_args[0][0][0] == "google-chrome"
 
     @mock.patch("open_finviz_screener.webbrowser.open")
+    @mock.patch("open_finviz_screener.sys")
     @mock.patch("open_finviz_screener.subprocess.run")
-    def test_fallback_to_webbrowser(self, mock_run, mock_wb_open):
+    def test_fallback_to_webbrowser(self, mock_run, mock_sys, mock_wb_open):
         # Both macOS calls fail → webbrowser fallback
+        mock_sys.platform = "darwin"
         mock_run.side_effect = [
             subprocess.CalledProcessError(1, "open"),
             subprocess.CalledProcessError(1, "open"),


### PR DESCRIPTION
## Summary

Closes #210.

- Discover every direct skill test suite and repo-level script suite from the filesystem.
- Generate the GitHub Actions test matrix dynamically, so a new tested skill needs no `ci.yml` edit.
- Validate discovery against a single reasoned policy for partial, allowed-failure, and excluded suites.
- Run each suite in isolation, aggregate per-row coverage, and preserve the repository-wide 40% coverage gate.
- Make the local pre-push runner consume the same discovery and policy contract as CI.

## Why

The previous workflow listed pytest steps by hand. New skills could therefore ship tests that never ran in GitHub Actions, while the local runner used a separate glob and exception list. This change makes discovery fail closed and removes that duplicated test inventory.

## Review loops

- Plan review: 3 rounds. Findings addressed included per-row coverage threshold regressions, existing dependency/known-failure semantics, independent missing-coverage guards, safe dependency installation, artifact manifests, and coverage combine naming.
- Implementation review: 3 rounds. Findings addressed included deleting the legacy static coverage job, validating manifest exit and coverage state fail closed, expanding run/aggregate/install tests, and pinning discovery to Python 3.9.
- Final implementation review: no blocking or medium findings.

## Validation

- `pre-commit run --all-files` — passed
- `bash scripts/run_all_tests.sh` — 58/58 runnable rows passed; `pair-trade-screener` remains a reasoned covered exclusion
- `python3.9 -m pytest -q scripts/tests/test_ci_test_matrix.py` — 13 passed
- `ruff check` / `ruff format --check` on the new matrix helper and tests — passed
- Two-row real coverage combine smoke — combined successfully; aggregate coverage 75%, above the 40% gate
- `git diff --check` — passed
- Commit and pre-push hooks — passed

## CI behavior

The workflow now runs discovery, per-row matrix tests, and aggregate coverage on Python 3.9. Blocking rows fail closed on missing or inconsistent manifests/coverage. The existing theme-detector allowed-failure behavior and CANSLIM partial FMP contract are represented in the central policy.
