### PR TITLE
fix(vcp-screener): stable-first FMP fallback + public-dataset fallback for S&P 500 constituents

### DIFF
--- a/skills/vcp-screener/scripts/fmp_client.py
+++ b/skills/vcp-screener/scripts/fmp_client.py
@@ -13,6 +13,8 @@ Features:
 - S&P 500 constituents fetching
 """
 
+import csv
+import io
 import os
 import sys
 import time
@@ -218,6 +220,44 @@ class FMPClient:
         if failures >= self._ENDPOINT_FAILURE_THRESHOLD:
             self._disabled_endpoints.add(base_url)
 
+    # Public-dataset fallback for keys where no FMP tier serves constituents:
+    # stable/sp500-constituent 402s (Restricted Endpoint, paid-only) and
+    # api/v3/sp500_constituent 403s (Legacy Endpoint, pre-2025-08-31 subs only).
+    _CONSTITUENTS_CSV_URL = (
+        "https://raw.githubusercontent.com/datasets/"
+        "s-and-p-500-companies/main/data/constituents.csv"
+    )
+
+    def _fetch_constituents_csv(self) -> Optional[list[dict]]:
+        """Fetch the public S&P 500 list, mapped to the v3 response shape.
+
+        Uses a bare requests.get, NOT self.session — the FMP apikey header
+        must not leak to a third-party host.
+        """
+        try:
+            response = requests.get(self._CONSTITUENTS_CSV_URL, timeout=30)
+            if response.status_code != 200:
+                print(
+                    f"ERROR: constituents CSV fallback failed: {response.status_code}",
+                    file=sys.stderr,
+                )
+                return None
+            data = [
+                {
+                    # FMP uses dash-style class symbols (BRK-B), the CSV uses dots.
+                    "symbol": row["Symbol"].replace(".", "-"),
+                    "name": row["Security"],
+                    "sector": row["GICS Sector"],
+                    "subSector": row["GICS Sub-Industry"],
+                }
+                for row in csv.DictReader(io.StringIO(response.text))
+                if row.get("Symbol")
+            ]
+        except (requests.exceptions.RequestException, csv.Error, KeyError) as e:
+            print(f"ERROR: constituents CSV fallback failed: {e}", file=sys.stderr)
+            return None
+        return data or None
+
     def get_sp500_constituents(self) -> Optional[list[dict]]:
         """Fetch S&P 500 constituent list.
 
@@ -232,6 +272,10 @@ class FMPClient:
         # stable/sp500-constituent first; legacy api/v3/sp500_constituent now
         # 403s for current API keys. symbols_str is unused for this endpoint.
         data = self._request_with_fallback("constituents", "")
+        if not data:
+            # Free-tier keys get 402 from stable and 403 from v3 — no FMP
+            # endpoint serves constituents at all. Use the public dataset.
+            data = self._fetch_constituents_csv()
         if data:
             self.cache[cache_key] = data
         return data

--- a/skills/vcp-screener/scripts/fmp_client.py
+++ b/skills/vcp-screener/scripts/fmp_client.py
@@ -50,6 +50,11 @@ def _v3_hist_url(base, symbols_str, params):
     return f"{base}/{symbols_str}", params
 
 
+def _constituents_url(base, symbols_str, params):
+    """stable/sp500-constituent or api/v3/sp500_constituent (no symbol path)."""
+    return base, params
+
+
 _FMP_ENDPOINTS = {
     "quote": [
         ("https://financialmodelingprep.com/stable/quote", _stable_quote_url),
@@ -58,6 +63,10 @@ _FMP_ENDPOINTS = {
     "historical": [
         ("https://financialmodelingprep.com/stable/historical-price-full", _stable_hist_url),
         ("https://financialmodelingprep.com/api/v3/historical-price-full", _v3_hist_url),
+    ],
+    "constituents": [
+        ("https://financialmodelingprep.com/stable/sp500-constituent", _constituents_url),
+        ("https://financialmodelingprep.com/api/v3/sp500_constituent", _constituents_url),
     ],
 }
 
@@ -164,6 +173,14 @@ class FMPClient:
                 ):
                     valid = False
 
+            if endpoint_key == "constituents":
+                # Non-empty list of dicts carrying a symbol; rejects error
+                # payloads and the stable endpoint's occasional {} response.
+                if not isinstance(data, list) or len(data) == 0:
+                    valid = False
+                elif not isinstance(data[0], dict) or "symbol" not in data[0]:
+                    valid = False
+
             if endpoint_key == "historical":
                 if not isinstance(data, dict):
                     valid = False
@@ -212,8 +229,9 @@ class FMPClient:
         if cache_key in self.cache:
             return self.cache[cache_key]
 
-        url = f"{self.BASE_URL}/sp500_constituent"
-        data = self._rate_limited_get(url)
+        # stable/sp500-constituent first; legacy api/v3/sp500_constituent now
+        # 403s for current API keys. symbols_str is unused for this endpoint.
+        data = self._request_with_fallback("constituents", "")
         if data:
             self.cache[cache_key] = data
         return data

--- a/skills/vcp-screener/scripts/tests/test_fmp_client.py
+++ b/skills/vcp-screener/scripts/tests/test_fmp_client.py
@@ -82,3 +82,68 @@ def test_falls_back_when_stable_returns_wrong_shape():
     result = client.get_sp500_constituents()
     assert result == _CONSTITUENTS
     assert any(_V3 in u for u in client.session.requested)
+
+
+# On free-tier keys created after 2025-08-31, NO FMP endpoint serves
+# constituents: stable/sp500-constituent 402s (Restricted Endpoint) and
+# api/v3/sp500_constituent 403s (Legacy Endpoint). The client then falls
+# back to the public datasets/s-and-p-500-companies CSV.
+
+_CSV_TEXT = (
+    "Symbol,Security,GICS Sector,GICS Sub-Industry,Headquarters Location,"
+    "Date added,CIK,Founded\n"
+    'MMM,3M,Industrials,Industrial Conglomerates,"Saint Paul, Minnesota",'
+    "1957-03-04,66740,1902\n"
+    'BRK.B,Berkshire Hathaway,Financials,Multi-Sector Holdings,"Omaha, Nebraska",'
+    "2010-02-16,1067983,1839\n"
+)
+
+_NO_FMP_TIER = {
+    _STABLE: _FakeResponse(402, None, "Restricted Endpoint"),
+    _V3: _FakeResponse(403, None, "Legacy Endpoint"),
+}
+
+
+def test_falls_back_to_public_csv_when_no_fmp_tier_serves_constituents(monkeypatch):
+    client = _client(dict(_NO_FMP_TIER))
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return _FakeResponse(200, None, _CSV_TEXT)
+
+    monkeypatch.setattr("fmp_client.requests.get", fake_get)
+    result = client.get_sp500_constituents()
+
+    # Dot-class symbols are normalized to FMP's dash style (BRK.B -> BRK-B).
+    assert [c["symbol"] for c in result] == ["MMM", "BRK-B"]
+    assert result[0] == {
+        "symbol": "MMM",
+        "name": "3M",
+        "sector": "Industrials",
+        "subSector": "Industrial Conglomerates",
+    }
+    assert "s-and-p-500-companies" in captured["url"]
+    # The FMP apikey session header must not leak to the public host.
+    assert "headers" not in captured["kwargs"]
+    assert not any("s-and-p-500-companies" in u for u in client.session.requested)
+
+
+def test_returns_none_when_fmp_and_csv_fallback_all_fail(monkeypatch):
+    client = _client(dict(_NO_FMP_TIER))
+    monkeypatch.setattr(
+        "fmp_client.requests.get",
+        lambda url, **kwargs: _FakeResponse(500, None, "upstream down"),
+    )
+    assert client.get_sp500_constituents() is None
+
+
+def test_csv_fallback_not_used_when_fmp_succeeds(monkeypatch):
+    client = _client({_STABLE: _FakeResponse(200, _CONSTITUENTS)})
+
+    def fail_get(url, **kwargs):
+        raise AssertionError("public CSV must not be fetched when FMP works")
+
+    monkeypatch.setattr("fmp_client.requests.get", fail_get)
+    assert client.get_sp500_constituents() == _CONSTITUENTS

--- a/skills/vcp-screener/scripts/tests/test_fmp_client.py
+++ b/skills/vcp-screener/scripts/tests/test_fmp_client.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tests for FMPClient.get_sp500_constituents stable-first fallback.
+
+The legacy api/v3/sp500_constituent endpoint now 403s for current API keys,
+so the client tries stable/sp500-constituent first and falls back to v3.
+These tests drive a fake requests.Session so no network is touched.
+"""
+
+from fmp_client import FMPClient
+
+_STABLE = "stable/sp500-constituent"
+_V3 = "api/v3/sp500_constituent"
+
+_CONSTITUENTS = [
+    {"symbol": "AAPL", "name": "Apple Inc.", "sector": "Technology", "subSector": "Hardware"},
+    {"symbol": "MSFT", "name": "Microsoft Corp.", "sector": "Technology", "subSector": "Software"},
+]
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    """Maps a URL substring to a canned response; records requested URLs."""
+
+    def __init__(self, url_map):
+        self._url_map = url_map
+        self.headers = {}
+        self.requested = []
+
+    def get(self, url, params=None, timeout=None):
+        self.requested.append(url)
+        for fragment, response in self._url_map.items():
+            if fragment in url:
+                return response
+        return _FakeResponse(404, None, "unmapped")
+
+
+def _client(url_map):
+    client = FMPClient(api_key="test-key")
+    client.RATE_LIMIT_DELAY = 0  # no sleeps in tests
+    client.session = _FakeSession(url_map)
+    return client
+
+
+def test_stable_endpoint_used_when_available():
+    client = _client({_STABLE: _FakeResponse(200, _CONSTITUENTS)})
+    result = client.get_sp500_constituents()
+    assert result == _CONSTITUENTS
+    # v3 must not be called once stable succeeds.
+    assert not any(_V3 in u for u in client.session.requested)
+
+
+def test_falls_back_to_v3_on_stable_403():
+    client = _client(
+        {
+            _STABLE: _FakeResponse(403, None, "Forbidden"),
+            _V3: _FakeResponse(200, _CONSTITUENTS),
+        }
+    )
+    result = client.get_sp500_constituents()
+    assert result == _CONSTITUENTS
+    assert any(_STABLE in u for u in client.session.requested)
+    assert any(_V3 in u for u in client.session.requested)
+
+
+def test_falls_back_when_stable_returns_wrong_shape():
+    # Truthy-but-invalid payload (error dict) must not be accepted as data.
+    client = _client(
+        {
+            _STABLE: _FakeResponse(200, {"Error Message": "Legacy Endpoint"}),
+            _V3: _FakeResponse(200, _CONSTITUENTS),
+        }
+    )
+    result = client.get_sp500_constituents()
+    assert result == _CONSTITUENTS
+    assert any(_V3 in u for u in client.session.requested)


### PR DESCRIPTION
## Summary

`vcp-screener` fails on FMP API keys created after 2025-08-31: the S&P 500 constituents fetch hits `api/v3/sp500_constituent`, which now returns **403 Legacy Endpoint** for those keys, so `screen_vcp.py` exits 1 before screening anything.

This PR fixes it in two steps (two commits):

1. **Stable-first endpoint fallback** (`quote`, `historical-price-full`, constituents): try `financialmodelingprep.com/stable/...` first, fall back to `api/v3/...` for legacy-subscription users. Responses are shape-validated and normalized to the v3 format so callers are unchanged. Includes a per-endpoint circuit breaker after 3 consecutive failures.
2. **Public-dataset fallback for constituents**: live testing showed that on free-tier keys *no* FMP endpoint serves the constituents list at all — `stable/sp500-constituent` returns **402 Restricted Endpoint** (paid plans only) and v3 returns 403. When both FMP attempts fail, the client now fetches the public [`datasets/s-and-p-500-companies`](https://github.com/datasets/s-and-p-500-companies) CSV (stdlib `csv` parse, no new dependencies), mapped to the v3 response shape with dot-class symbols normalized to FMP's dash style (`BRK.B` → `BRK-B`). The fetch deliberately uses a bare `requests.get` so the FMP `apikey` session header never reaches the third-party host.

FMP behavior is unchanged for paid and legacy keys — the CSV is only reached when FMP itself cannot serve the list.

## Verification

- `skills/vcp-screener/scripts/tests/test_fmp_client.py`: 6/6 green (3 new tests cover the CSV fallback, the all-sources-fail path, and that the CSV is never fetched when FMP succeeds).
- Live run on a free-tier key: `get_sp500_constituents()` returns 503 constituents in the v3 shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
