### PR TITLE
fix(workflows): shapiro-contrarian follow-up (P2 x2 + P3, Issue #244)

### DIFF
--- a/docs/en/workflows.md
+++ b/docs/en/workflows.md
@@ -351,7 +351,7 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 
 - consumes: `futures_position_size`, `contrarian_setup_gate_report`
 - produces: `contrarian_thesis_entry`
-- **Decision:** Register each READY fade with direction, entry, stop (the gate's invalidation_level), and contract count. Confirm per-trade risk matches the sizer output and total portfolio heat is within budget.
+- **Decision:** Register each fade whose sizer output is sizing_status SIZED — never a NO_TRADE result — in this order: (1) create the IDEA thesis first (manual ingest or register() — attach-futures-position only attaches to an EXISTING thesis, it never creates one); (2) attach the SIZED report with attach-futures-position, which persists contracts / direction / multiplier / USD currency / risk onto the thesis position; (3) link the upstream cot_crowding_report, news_failure_verdict, price_action_confirmation_report, and contrarian_setup_gate_report to the thesis with thesis_store.link_report() so the fade's full evidence chain is auditable; (4) only transition to ACTIVE with open-position once the order actually fills at the broker. Confirm per-trade risk matches the sizer output and total portfolio heat is within budget.
 
 **Manual review:**
 
@@ -363,6 +363,8 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 - Verify the sizer's contract count and per-contract risk before any order; confirm total portfolio heat is within budget.
 - Futures margin is broker/time-dependent and NOT computed — verify initial and maintenance margin with the broker before trading.
 - All orders are placed manually at the broker; no auto-execution. Monitoring (COT normalization, stop, thesis invalidation) is manual until contrarian-position-monitor ships.
+- The gate's entry_trigger / sizer's planned entry is not an actual fill. Keep the SIZED report itself (it carries the planned entry); a manual-ingest source also keeps entry_price in origin.raw_provenance.entry_price. Either way, never write it to entry.actual_price before a real fill happens.
+- Do not transition the thesis to ACTIVE (open-position) until the order actually fills at the broker. Step 6 only reaches IDEA/ENTRY_READY with the futures position attached — no order is ever placed automatically.
 
 **Journal destination:** `trader-memory-core`
 

--- a/docs/ja/workflows.md
+++ b/docs/ja/workflows.md
@@ -353,7 +353,7 @@ permalink: /ja/workflows/
 
 - consumes: `futures_position_size`, `contrarian_setup_gate_report`
 - produces: `contrarian_thesis_entry`
-- **判断:** Register each READY fade with direction, entry, stop (the gate's invalidation_level), and contract count. Confirm per-trade risk matches the sizer output and total portfolio heat is within budget.
+- **判断:** Register each fade whose sizer output is sizing_status SIZED — never a NO_TRADE result — in this order: (1) create the IDEA thesis first (manual ingest or register() — attach-futures-position only attaches to an EXISTING thesis, it never creates one); (2) attach the SIZED report with attach-futures-position, which persists contracts / direction / multiplier / USD currency / risk onto the thesis position; (3) link the upstream cot_crowding_report, news_failure_verdict, price_action_confirmation_report, and contrarian_setup_gate_report to the thesis with thesis_store.link_report() so the fade's full evidence chain is auditable; (4) only transition to ACTIVE with open-position once the order actually fills at the broker. Confirm per-trade risk matches the sizer output and total portfolio heat is within budget.
 
 **手動レビュー:**
 
@@ -365,6 +365,8 @@ permalink: /ja/workflows/
 - Verify the sizer's contract count and per-contract risk before any order; confirm total portfolio heat is within budget.
 - Futures margin is broker/time-dependent and NOT computed — verify initial and maintenance margin with the broker before trading.
 - All orders are placed manually at the broker; no auto-execution. Monitoring (COT normalization, stop, thesis invalidation) is manual until contrarian-position-monitor ships.
+- The gate's entry_trigger / sizer's planned entry is not an actual fill. Keep the SIZED report itself (it carries the planned entry); a manual-ingest source also keeps entry_price in origin.raw_provenance.entry_price. Either way, never write it to entry.actual_price before a real fill happens.
+- Do not transition the thesis to ACTIVE (open-position) until the order actually fills at the broker. Step 6 only reaches IDEA/ENTRY_READY with the futures position attached — no order is ever placed automatically.
 
 **Journal 出力先:** `trader-memory-core`
 

--- a/skills-index.yaml
+++ b/skills-index.yaml
@@ -503,6 +503,7 @@ skills:
   - entry_price
   - stop_price
   - account_size
+  - risk_pct
   - contrarian_setup_gate_report
   outputs:
   - futures_position_size

--- a/workflows/shapiro-contrarian.yaml
+++ b/workflows/shapiro-contrarian.yaml
@@ -137,9 +137,20 @@ steps:
       - contrarian_thesis_entry
     decision_gate: true
     decision_question: >-
-      Register each READY fade with direction, entry, stop (the gate's
-      invalidation_level), and contract count. Confirm per-trade risk
-      matches the sizer output and total portfolio heat is within budget.
+      Register each fade whose sizer output is sizing_status SIZED —
+      never a NO_TRADE result — in this order: (1) create the IDEA
+      thesis first (manual ingest or register() — attach-futures-position
+      only attaches to an EXISTING thesis, it never creates one); (2)
+      attach the SIZED report with attach-futures-position, which
+      persists contracts / direction / multiplier / USD currency / risk
+      onto the thesis position; (3) link the upstream
+      cot_crowding_report, news_failure_verdict,
+      price_action_confirmation_report, and contrarian_setup_gate_report
+      to the thesis with thesis_store.link_report() so the fade's full
+      evidence chain is auditable; (4) only transition to ACTIVE with
+      open-position once the order actually fills at the broker.
+      Confirm per-trade risk matches the sizer output and total
+      portfolio heat is within budget.
     depends_on:
       - 4
       - 5
@@ -164,5 +175,14 @@ manual_review:
   - All orders are placed manually at the broker; no auto-execution.
     Monitoring (COT normalization, stop, thesis invalidation) is manual
     until contrarian-position-monitor ships.
+  - The gate's entry_trigger / sizer's planned entry is not an actual
+    fill. Keep the SIZED report itself (it carries the planned entry);
+    a manual-ingest source also keeps entry_price in
+    origin.raw_provenance.entry_price. Either way, never write it to
+    entry.actual_price before a real fill happens.
+  - Do not transition the thesis to ACTIVE (open-position) until the
+    order actually fills at the broker. Step 6 only reaches
+    IDEA/ENTRY_READY with the futures position attached — no order is
+    ever placed automatically.
 
 journal_destination: trader-memory-core


### PR DESCRIPTION
## Summary

Independent-review follow-up on the merged `workflows/shapiro-contrarian.yaml` (PR #251, Issue #244). Three fixes identified in accept-testing:

- **P2-1**: `futures-position-sizer`'s `skills-index.yaml` `inputs` now include `risk_pct` alongside `entry_price`/`stop_price`/`account_size` — it's a real input to the sizing calculation (`risk_budget = account_size * risk_pct / 100`), even though (unlike `--account-size`) the CLI flag isn't `argparse`-required and defaults to `1.0`.
- **P2-2**: `workflows/shapiro-contrarian.yaml` step 6's `decision_question` now spells out the real `trader-memory-core` handoff — only a `SIZED` sizer report (never `NO_TRADE`) gets registered via `attach-futures-position`, and the upstream `cot_crowding_report`/`news_failure_verdict`/`price_action_confirmation_report`/`contrarian_setup_gate_report` get cross-referenced onto the thesis via `thesis_store.link_report()`. Two `manual_review` cautions added from smoke-testing the actual handoff: `attach-futures-position` does not populate `entry.target_price` (a planned entry is not an actual fill), and the thesis never auto-transitions to `ACTIVE` — that only happens once a real broker fill triggers `open-position`.
- **P3**: Issue #244's body updated — the first 6 build-order boxes checked (all 6 pipeline skills + this workflow manifest, PR #251), with the 7th (`contrarian-position-monitor`) noted as moved to #243, deferred until after live/shadow operation. #244 stays **CLOSED** (body-only edit, not re-opened).

## Verification

- `validate_skills_index.py --strict-workflows --strict-metadata` → OK
- `generate_workflow_docs.py --check` → initial DRIFT (step 6 + manual_review text) → regenerated → OK
- `generate_skill_docs.py --check` / `generate_catalog_from_index.py --check` / navigator `build_snapshot.py --check` / `package_skills.py --check` → all clean (no drift — none of these changes touch SKILL.md, catalog tables, or normalized navigator fields)
- `pre-commit run --all-files` → clean on the first pass
- `scripts/run_all_tests.sh` → 67/67 skill suites pass
- `trading-skills-navigator` suite → 80 passed (unchanged — this PR doesn't touch `recommend.py`)
- `git diff --check` → clean

## Scope / tracking

No `Closes` keyword — Issue #244 is already CLOSED; this PR only updates its body to reflect the actual completion state. `contrarian-position-monitor` remains tracked separately in #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
