### PR TITLE
fix(workflows): stock_memo dangling required artifact (Issue #260)

### DIFF
--- a/docs/en/workflows.md
+++ b/docs/en/workflows.md
@@ -144,13 +144,14 @@ Operational workflow manifests for the solo-trader OS. Each workflow names the e
 
 **Step 6: Register the candidate thesis** (decision gate) → `trader-memory-core`
 
-- consumes: `kanchi_candidates`, `account_location_advice`, `review_queue`
+- consumes: `kanchi_candidates`, `stock_memo`, `account_location_advice`, `review_queue`
 - produces: `kanchi_thesis_entry`
-- **Decision:** For each actionable candidate, register the thesis with the Kanchi verdict, stock memo, and (if available) tax/account-location advice and any review-monitor flags. Confirm no unresolved blockers, sizing, sector concentration, and tranche plan before entering an order. Never transition the thesis to ACTIVE until a real broker fill happens -- this step only reaches IDEA / ENTRY_READY.
+- **Decision:** For each actionable candidate, ingest the kanchi_candidates verdict as an IDEA thesis, then link the saved stock_memo file (and, if available, tax/account-location advice and any review-monitor flags) to it with thesis_store.link_report() so the fully-documented Kanchi memo is part of the auditable record, not just referenced in prose. Confirm no unresolved blockers, sizing, sector concentration, and tranche plan before entering an order. Never transition the thesis to ACTIVE until a real broker fill happens -- this step only reaches IDEA / ENTRY_READY.
 
 **Manual review:**
 
 - A HOLD-REVIEW, STEP1-RECHECK, or FAIL Kanchi verdict is fail-closed -- it never advances to sizing or thesis registration.
+- The step-3 stock memo (`references/stock-note-template.md` in kanchi-dividend-sop, a hand-written one-pager) is not embedded in the kanchi_candidates JSON -- save it to a file, then after the IDEA thesis is registered, call `thesis_store.link_report(state_dir, thesis_id, "kanchi-dividend-sop", <memo_path>, date)` to attach it. Without this call the thesis has no documented memo in its `linked_reports`, even though one was written.
 - No order is ever placed automatically, and the thesis never auto-transitions to ACTIVE; every fill is entered manually at the broker, then recorded with open-position.
 - Screeners (steps 1-2) are optional -- a manually supplied ticker list is an equally valid path into step 3.
 - Tax and account-location advice (step 4) is advisory, not authoritative -- verify with a tax professional or the actual broker/custodian statements before acting on it.

--- a/docs/ja/workflows.md
+++ b/docs/ja/workflows.md
@@ -146,13 +146,14 @@ permalink: /ja/workflows/
 
 **ステップ 6: Register the candidate thesis** （判断ゲート） → `trader-memory-core`
 
-- consumes: `kanchi_candidates`, `account_location_advice`, `review_queue`
+- consumes: `kanchi_candidates`, `stock_memo`, `account_location_advice`, `review_queue`
 - produces: `kanchi_thesis_entry`
-- **判断:** For each actionable candidate, register the thesis with the Kanchi verdict, stock memo, and (if available) tax/account-location advice and any review-monitor flags. Confirm no unresolved blockers, sizing, sector concentration, and tranche plan before entering an order. Never transition the thesis to ACTIVE until a real broker fill happens -- this step only reaches IDEA / ENTRY_READY.
+- **判断:** For each actionable candidate, ingest the kanchi_candidates verdict as an IDEA thesis, then link the saved stock_memo file (and, if available, tax/account-location advice and any review-monitor flags) to it with thesis_store.link_report() so the fully-documented Kanchi memo is part of the auditable record, not just referenced in prose. Confirm no unresolved blockers, sizing, sector concentration, and tranche plan before entering an order. Never transition the thesis to ACTIVE until a real broker fill happens -- this step only reaches IDEA / ENTRY_READY.
 
 **手動レビュー:**
 
 - A HOLD-REVIEW, STEP1-RECHECK, or FAIL Kanchi verdict is fail-closed -- it never advances to sizing or thesis registration.
+- The step-3 stock memo (`references/stock-note-template.md` in kanchi-dividend-sop, a hand-written one-pager) is not embedded in the kanchi_candidates JSON -- save it to a file, then after the IDEA thesis is registered, call `thesis_store.link_report(state_dir, thesis_id, "kanchi-dividend-sop", <memo_path>, date)` to attach it. Without this call the thesis has no documented memo in its `linked_reports`, even though one was written.
 - No order is ever placed automatically, and the thesis never auto-transitions to ACTIVE; every fill is entered manually at the broker, then recorded with open-position.
 - Screeners (steps 1-2) are optional -- a manually supplied ticker list is an equally valid path into step 3.
 - Tax and account-location advice (step 4) is advisory, not authoritative -- verify with a tax professional or the actual broker/custodian statements before acting on it.

--- a/workflows/kanchi-dividend-weekly.yaml
+++ b/workflows/kanchi-dividend-weekly.yaml
@@ -117,18 +117,22 @@ steps:
     skill: trader-memory-core
     consumes:
       - kanchi_candidates
+      - stock_memo
       - account_location_advice
       - review_queue
     produces:
       - kanchi_thesis_entry
     decision_gate: true
     decision_question: >-
-      For each actionable candidate, register the thesis with the Kanchi
-      verdict, stock memo, and (if available) tax/account-location advice
-      and any review-monitor flags. Confirm no unresolved blockers, sizing,
-      sector concentration, and tranche plan before entering an order. Never
-      transition the thesis to ACTIVE until a real broker fill happens --
-      this step only reaches IDEA / ENTRY_READY.
+      For each actionable candidate, ingest the kanchi_candidates verdict as
+      an IDEA thesis, then link the saved stock_memo file (and, if
+      available, tax/account-location advice and any review-monitor flags)
+      to it with thesis_store.link_report() so the fully-documented Kanchi
+      memo is part of the auditable record, not just referenced in prose.
+      Confirm no unresolved blockers, sizing, sector concentration, and
+      tranche plan before entering an order. Never transition the thesis to
+      ACTIVE until a real broker fill happens -- this step only reaches
+      IDEA / ENTRY_READY.
     depends_on:
       - 3
       - 4
@@ -137,6 +141,13 @@ steps:
 manual_review:
   - A HOLD-REVIEW, STEP1-RECHECK, or FAIL Kanchi verdict is fail-closed --
     it never advances to sizing or thesis registration.
+  - The step-3 stock memo (`references/stock-note-template.md` in
+    kanchi-dividend-sop, a hand-written one-pager) is not embedded in the
+    kanchi_candidates JSON -- save it to a file, then after the IDEA thesis
+    is registered, call
+    `thesis_store.link_report(state_dir, thesis_id, "kanchi-dividend-sop",
+    <memo_path>, date)` to attach it. Without this call the thesis has no
+    documented memo in its `linked_reports`, even though one was written.
   - No order is ever placed automatically, and the thesis never
     auto-transitions to ACTIVE; every fill is entered manually at the
     broker, then recorded with open-position.


### PR DESCRIPTION
## Summary

Independent-review follow-up on the merged `kanchi-dividend-weekly` manifest (PR #264): `stock_memo` was a dangling required artifact -- declared `required: true` and produced at step 3, but never consumed at step 6, so the hand-written one-page Kanchi memo was never part of the auditable thesis record even though step 6's `decision_question` claimed to register it.

Closes #260

## Fix

- `workflows/kanchi-dividend-weekly.yaml` step 6 `consumes` now includes `stock_memo` (producer is step 3, earlier, so `WF007` stays satisfied).
- Step 6's `decision_question` rewritten to name the concrete operation: ingest the `kanchi_candidates` verdict as an `IDEA` thesis, then link the saved `stock_memo` file to it with `thesis_store.link_report()` -- the same pattern the Shapiro playbook already uses for its four upstream reports.
- `manual_review` gained a dedicated bullet: the memo is a separate file, not embedded in the `kanchi_candidates` JSON, so it needs its own `link_report()` call after registration or it's silently missing from `linked_reports`.

## Mechanical verification

Before the fix:
```
required_but_never_consumed: ['stock_memo']
```
After the fix, only the workflow's terminal artifact remains (expected -- it's step 6's own output, referenced downstream via `downstream_hints`, not consumed within this manifest):
```
required_but_never_consumed: ['kanchi_thesis_entry']
```

## Offline smoke test (no repo `state/`/`reports/`/`logs/` residue)

Ingested a `CLEAN-PASS` fixture candidate as an `IDEA` thesis via `trader_memory_cli.py ingest --source kanchi-dividend-sop`, wrote a filled-in `stock-note-template.md`-shaped memo to a file, then called `thesis_store.link_report()` to attach it. `store get` confirms:

```yaml
status: IDEA          # unchanged -- no ACTIVE transition attempted
entry:
  actual_price: null   # confirms no auto-execution
linked_reports:
- skill: kanchi-dividend-sop
  file: <memo path>
  date: '2026-07-15'
```

The Kanchi memo is now present in `linked_reports`.

## Verification

- `validate_skills_index.py --strict-workflows --strict-metadata` → OK
- `generate_workflow_docs.py --check` → initial DRIFT (consumes change) → regenerated → OK
- `generate_skill_docs.py --check` / `generate_catalog_from_index.py --check` / navigator `build_snapshot.py --check` / `package_skills.py --check` → all clean (consumes isn't part of any generated/normalized output, so nothing else drifted)
- `pre-commit run --all-files` → clean on the first pass
- `scripts/run_all_tests.sh` → 67/67 skill suites pass
- `git diff --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
