### PR TITLE
feat(validator): detect dangling required workflow artifacts

### DIFF
--- a/docs/dev/metadata-and-workflow-schema.md
+++ b/docs/dev/metadata-and-workflow-schema.md
@@ -208,6 +208,7 @@ These are validated under `--strict-workflows`:
 | Every `required_skills` entry appears in at least one non-optional step | `WF009` |
 | Every non-optional `step.skill` appears in `required_skills` | `WF010` |
 | Workflow file referenced by an index entry's `workflows:` exists | `WF001` |
+| Required artifact produced before the final step is not consumed by any later step | `WF013` |
 
 ### 2.3 `consumes:` semantics — "use if available", not "required input"
 
@@ -393,6 +394,7 @@ python3 scripts/validate_skills_index.py --strict-metadata
 | `WF010` | Non-optional step `skill` missing from `required_skills` |
 | `WF011` | `required_skills` / `optional_skills` entry not in `skills-index.yaml` |
 | `WF012` | `artifacts[].produced_by_step` does not match the corresponding step's `produces` (either direction) |
+| `WF013` | Required artifact produced before the final step is not consumed by any later step |
 
 ### Skillset-level (`scripts/validate_skillsets.py`, always strict)
 

--- a/scripts/tests/test_validate_skills_index.py
+++ b/scripts/tests/test_validate_skills_index.py
@@ -669,6 +669,241 @@ def test_wf012_step_produces_undeclared_artifact(tmp_path: Path) -> None:
     assert "WF012" in codes(findings)
 
 
+def _setup_wf013_repo(
+    tmp_path: Path,
+    *,
+    artifacts: list[dict],
+    steps: list[dict],
+) -> None:
+    """Create a valid two-skill workflow for WF013 contract tests."""
+    write_skill(tmp_path, "alpha")
+    write_skill(tmp_path, "beta")
+    write_index(
+        tmp_path,
+        [
+            minimal_skill("alpha", workflows=["sample"]),
+            minimal_skill("beta"),
+        ],
+    )
+    write_workflow(
+        tmp_path,
+        "sample",
+        {
+            "schema_version": 1,
+            "id": "sample",
+            "required_skills": ["alpha"],
+            "optional_skills": [],
+            "artifacts": artifacts,
+            "steps": steps,
+            "journal_destination": "beta",
+        },
+    )
+
+
+def test_wf013_kanchi_weekly_intermediate_required_artifact_is_dangling(tmp_path: Path) -> None:
+    """A pre-fix kanchi-weekly-style required intermediate artifact must fail."""
+    _setup_wf013_repo(
+        tmp_path,
+        artifacts=[
+            {"id": "kanchi_candidates", "produced_by_step": 3, "required": True},
+            {"id": "stock_memo", "produced_by_step": 3, "required": True},
+            {"id": "kanchi_thesis_entry", "produced_by_step": 6, "required": True},
+        ],
+        steps=[
+            {
+                "step": 3,
+                "name": "Run Kanchi underwriting",
+                "skill": "alpha",
+                "produces": ["kanchi_candidates", "stock_memo"],
+                "decision_gate": False,
+            },
+            {
+                "step": 6,
+                "name": "Register candidate thesis",
+                "skill": "alpha",
+                "consumes": ["kanchi_candidates"],
+                "produces": ["kanchi_thesis_entry"],
+                "decision_gate": False,
+            },
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    wf013 = [finding for finding in findings if finding.code == "WF013"]
+    assert len(wf013) == 1, findings
+    assert "stock_memo" in wf013[0].message
+
+
+def test_wf013_final_required_artifact_passes(tmp_path: Path) -> None:
+    _setup_wf013_repo(
+        tmp_path,
+        artifacts=[
+            {
+                "id": "final_report",
+                "produced_by_step": 2,
+                "required": True,
+                "downstream_hints": ["another-workflow"],
+            }
+        ],
+        steps=[
+            {"step": 1, "name": "Prepare", "skill": "alpha", "decision_gate": False},
+            {
+                "step": 2,
+                "name": "Report",
+                "skill": "alpha",
+                "produces": ["final_report"],
+                "decision_gate": False,
+            },
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert codes(findings) == [], findings
+
+
+def test_wf013_terminal_artifact_without_downstream_hints_passes(tmp_path: Path) -> None:
+    _setup_wf013_repo(
+        tmp_path,
+        artifacts=[{"id": "terminal_output", "produced_by_step": 2, "required": True}],
+        steps=[
+            {"step": 1, "name": "Prepare", "skill": "alpha", "decision_gate": False},
+            {
+                "step": 2,
+                "name": "Finish",
+                "skill": "alpha",
+                "produces": ["terminal_output"],
+                "decision_gate": False,
+            },
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert codes(findings) == [], findings
+
+
+def test_wf013_multiple_final_required_artifacts_pass(tmp_path: Path) -> None:
+    artifacts = [
+        {"id": "final_report", "produced_by_step": 2, "required": True},
+        {"id": "audit_record", "produced_by_step": 2, "required": True},
+    ]
+    _setup_wf013_repo(
+        tmp_path,
+        artifacts=artifacts,
+        steps=[
+            {"step": 1, "name": "Prepare", "skill": "alpha", "decision_gate": False},
+            {
+                "step": 2,
+                "name": "Publish",
+                "skill": "alpha",
+                "produces": ["final_report", "audit_record"],
+                "decision_gate": False,
+            },
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert codes(findings) == [], findings
+
+
+def test_wf013_intermediate_optional_artifact_may_be_dangling(tmp_path: Path) -> None:
+    _setup_wf013_repo(
+        tmp_path,
+        artifacts=[{"id": "notes", "produced_by_step": 1, "required": False}],
+        steps=[
+            {
+                "step": 1,
+                "name": "Prepare",
+                "skill": "alpha",
+                "produces": ["notes"],
+                "decision_gate": False,
+            },
+            {"step": 2, "name": "Finish", "skill": "alpha", "decision_gate": False},
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert codes(findings) == [], findings
+
+
+def test_wf013_required_artifact_consumed_by_later_step_passes(tmp_path: Path) -> None:
+    _setup_wf013_repo(
+        tmp_path,
+        artifacts=[{"id": "input_data", "produced_by_step": 1, "required": True}],
+        steps=[
+            {
+                "step": 1,
+                "name": "Prepare",
+                "skill": "alpha",
+                "produces": ["input_data"],
+                "decision_gate": False,
+            },
+            {
+                "step": 2,
+                "name": "Use data",
+                "skill": "alpha",
+                "consumes": ["input_data"],
+                "decision_gate": False,
+            },
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert codes(findings) == [], findings
+
+
+def test_wf013_required_must_be_yaml_boolean_true(tmp_path: Path) -> None:
+    _setup_wf013_repo(
+        tmp_path,
+        artifacts=[{"id": "notes", "produced_by_step": 1, "required": "true"}],
+        steps=[
+            {
+                "step": 1,
+                "name": "Prepare",
+                "skill": "alpha",
+                "produces": ["notes"],
+                "decision_gate": False,
+            },
+            {"step": 2, "name": "Finish", "skill": "alpha", "decision_gate": False},
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF013" not in codes(findings)
+
+
+def test_wf013_ignores_non_integer_step_when_finding_final_step(tmp_path: Path) -> None:
+    _setup_wf013_repo(
+        tmp_path,
+        artifacts=[{"id": "terminal", "produced_by_step": 2, "required": True}],
+        steps=[
+            {"step": 1, "name": "Prepare", "skill": "alpha", "decision_gate": False},
+            {
+                "step": 2,
+                "name": "Finish",
+                "skill": "alpha",
+                "produces": ["terminal"],
+                "decision_gate": False,
+            },
+            {"step": "3", "name": "Invalid", "skill": "alpha", "decision_gate": False},
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF013" not in codes(findings)
+
+
+def test_wf013_does_not_stack_on_wf012_mismatch(tmp_path: Path) -> None:
+    _setup_wf013_repo(
+        tmp_path,
+        artifacts=[{"id": "broken", "produced_by_step": 1, "required": True}],
+        steps=[
+            {"step": 1, "name": "Prepare", "skill": "alpha", "decision_gate": False},
+            {"step": 2, "name": "Finish", "skill": "alpha", "decision_gate": False},
+        ],
+    )
+    findings = validate(tmp_path, strict_workflows=True)
+    assert "WF012" in codes(findings)
+    assert "WF013" not in codes(findings)
+
+
+def test_wf013_current_workflow_corpus_passes() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    findings = validate(project_root, strict_workflows=True, strict_metadata=True)
+    assert codes(findings) == [], findings
+
+
 def test_wf010_step_skill_not_in_required_skills(tmp_path: Path) -> None:
     _setup_minimal_workflow_repo(
         tmp_path,

--- a/scripts/validate_skills_index.py
+++ b/scripts/validate_skills_index.py
@@ -6,7 +6,7 @@ Strictness levels:
   --strict-workflows   : also resolve workflow references and check internal-consistency
   --strict-metadata    : also enforce timeframe/difficulty/inputs/outputs completeness
 
-Emits stable error codes (IDX001-009, WF001-010). See
+Emits stable error codes (IDX001-012, WF001-013). See
 docs/dev/metadata-and-workflow-schema.md for the full catalog.
 """
 
@@ -441,6 +441,7 @@ def _validate_workflow_internal(
 
     # Build step.produces map for WF012 cross-check
     step_produces: dict[int, set[str]] = {}
+    valid_steps: dict[int, dict] = {}
 
     seen_step_numbers: set[int] = set()
     non_optional_step_skills: set[str] = set()
@@ -451,6 +452,8 @@ def _validate_workflow_internal(
         step_num = step.get("step")
         if isinstance(step_num, int):
             seen_step_numbers.add(step_num)
+        if isinstance(step_num, int) and not isinstance(step_num, bool):
+            valid_steps[step_num] = step
         skill_id = str(step.get("skill") or "")
         is_optional = bool(step.get("optional", False))
         if isinstance(step_num, int):
@@ -573,6 +576,43 @@ def _validate_workflow_internal(
                         "error",
                         f"{rel_loc} step {step_num}",
                         f"step produces {art_id!r} which is not declared in artifacts:",
+                    )
+                )
+
+    # WF013: a required artifact produced before the final valid integer step
+    # must be consumed by a later step. Only artifacts whose production
+    # contract is WF012-valid participate, so malformed artifacts do not get a
+    # redundant WF013 finding.
+    if valid_steps:
+        final_step = max(valid_steps)
+        for art in artifacts:
+            if not isinstance(art, dict) or art.get("required") is not True:
+                continue
+            art_id = str(art.get("id") or "")
+            produced_by = art.get("produced_by_step")
+            if (
+                not art_id
+                or not isinstance(produced_by, int)
+                or isinstance(produced_by, bool)
+                or produced_by not in valid_steps
+                or art_id not in set(valid_steps[produced_by].get("produces") or [])
+                or produced_by >= final_step
+            ):
+                continue
+            consumed_later = any(
+                step_num > produced_by and art_id in set(step.get("consumes") or [])
+                for step_num, step in valid_steps.items()
+            )
+            if not consumed_later:
+                findings.append(
+                    Finding(
+                        "WF013",
+                        "error",
+                        rel_loc,
+                        (
+                            f"required artifact {art_id!r} produced at step {produced_by} "
+                            "is not consumed by any later step"
+                        ),
                     )
                 )
 


### PR DESCRIPTION
## Summary

- add WF013 for required artifacts produced before the final valid integer step but not consumed by a later step
- keep terminal, optional, downstream-hint-free, and multiple terminal artifacts legal
- limit WF013 to WF012-valid production contracts and YAML boolean `required: true`
- document WF013 in both workflow validation catalogs

## TDD evidence

- confirmed the pre-implementation red test: `1 failed, 43 passed`
- the failing fixture reproduced the pre-fix `kanchi-dividend-weekly` contract where `stock_memo` was produced at step 3 and not consumed at step 6
- final validator tests: `47 passed`

## Validation

- `python3 -m pytest scripts/tests/test_validate_skills_index.py -q`
- `python3 scripts/validate_skills_index.py --strict-workflows --strict-metadata`
- targeted `pre-commit run --files ...`
- `pre-commit run --all-files`
- pre-push strict validation and all skill tests
- `git diff --check`

## Independent review

Independent review returned no findings after deriving expectations from the confirmed WF013 contract. It directly verified the pre-fix Kanchi fixture, terminal artifacts without `downstream_hints`, multiple terminal artifacts, YAML boolean handling, valid-integer final-step selection, later-step consumption, WF012 non-stacking, and zero false positives against the current corpus.

Closes #268
