### PR TITLE
docs: add bilingual GitHub contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report / バグ報告
+description: Report broken behavior with reproducible details. / 再現可能なバグを報告します。
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Claude Trading Skills.
+
+        Claude Trading Skills is educational and process-focused. Please report
+        reproducible product behavior, not requests for personalized trading advice.
+
+        ご協力ありがとうございます。再現可能な動作を報告し、個別の投資助言は依頼しないでください。
+  - type: textarea
+    id: summary
+    attributes:
+      label: What is broken? / 何が壊れていますか？
+      description: Summarize the bug in one or two sentences. / バグを1〜2文で要約してください。
+      placeholder: "The vcp-screener command fails when..."
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce / 再現手順
+      description: Include the commands, files, inputs, or workflow steps. / コマンド、ファイル、入力、手順を書いてください。
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior / 期待した動作
+      description: Explain what should happen instead. / 本来どう動くべきか説明してください。
+      placeholder: "The command should..."
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior / 実際の動作
+      description: Paste the relevant sanitized error or output. / 秘密情報を除いたエラーや出力を貼ってください。
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: affected-area
+    attributes:
+      label: Affected skill, workflow, or file / 影響するスキル・ワークフロー・ファイル
+      description: Name the affected repository path if known. / 分かれば影響するリポジトリ内のパスを書いてください。
+      placeholder: "skills/vcp-screener or workflows/swing-opportunity-daily.yaml"
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment / 実行環境
+      description: Include the OS, Python version, runner, and dependency manager. / OS、Python、実行方法、依存管理を書いてください。
+      placeholder: "macOS 15, Python 3.9, uv, Claude Code"
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context / 補足
+      description: Add sanitized sample data, screenshots, or links if useful. / 必要なら秘密情報を除いたデータ、画像、リンクを追加してください。
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements / 確認事項
+      description: Confirm both items before submitting. / 送信前に両方を確認してください。
+      options:
+        - label: I removed secrets, API keys, personal information, and brokerage account data. / 秘密情報、APIキー、個人情報、証券口座情報を除外しました。
+          required: true
+        - label: This is not a request for financial advice, buy/sell recommendations, profit guarantees, or broker execution. / 金融助言、売買推奨、利益保証、発注実行の依頼ではありません。
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Project vision and scope / プロジェクトの方針
+    url: https://github.com/tradermonty/claude-trading-skills/blob/main/PROJECT_VISION.md
+    about: Read the project boundary before filing. / 投稿前にプロジェクトの範囲を確認してください。
+  - name: Documentation site / ドキュメント
+    url: https://tradermonty.github.io/claude-trading-skills/
+    about: Check the published guides and workflows first. / 最初に公開ガイドとワークフローを確認してください。

--- a/.github/ISSUE_TEMPLATE/real_use_pitfall.yml
+++ b/.github/ISSUE_TEMPLATE/real_use_pitfall.yml
@@ -1,0 +1,59 @@
+name: Real-use pitfall / 実運用の課題
+description: Share practical friction found during real use. / 実際の利用で見つけた困りごとを共有します。
+title: "[Pitfall]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for setup friction, unclear warnings, missing runbook steps,
+        unsafe defaults, or unclear educational boundaries found during real use.
+
+        setupのつまずき、不明確な警告、runbook不足、危険な初期値、教育目的の境界の課題に利用してください。
+  - type: textarea
+    id: pitfall
+    attributes:
+      label: Pitfall / 困った点
+      description: Explain what went wrong or became confusing in real use. / 実際の利用で何が失敗または分かりにくかったか説明してください。
+      placeholder: "I expected the workflow to stop when..."
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / 利用状況
+      description: Name the workflow, skill, data source, or documentation path. / 利用したworkflow、skill、data source、文書のパスを書いてください。
+      placeholder: "docs/en/find-your-workflow.md with..."
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact / 影響
+      description: Explain the effect on setup, review quality, risk management, or learning. / setup、レビュー品質、リスク管理、学習への影響を書いてください。
+      placeholder: "This caused me to..."
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix / 改善案
+      description: Suggest clearer wording, a test, a guardrail, or a runbook step. / 文言、テスト、ガードレール、runbook手順などを提案してください。
+      placeholder: "Add a warning before..."
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context / 補足
+      description: Add sanitized examples, screenshots, or links if useful. / 必要なら秘密情報を除いた例、画像、リンクを追加してください。
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements / 確認事項
+      description: Confirm both items before submitting. / 送信前に両方を確認してください。
+      options:
+        - label: I removed secrets, API keys, personal information, and brokerage account data. / 秘密情報、APIキー、個人情報、証券口座情報を除外しました。
+          required: true
+        - label: This is not a request for financial advice, buy/sell recommendations, profit guarantees, or broker execution. / 金融助言、売買推奨、利益保証、発注実行の依頼ではありません。
+          required: true

--- a/.github/ISSUE_TEMPLATE/skill_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/skill_improvement.yml
@@ -1,0 +1,74 @@
+name: Skill improvement / スキル改善
+description: Propose a focused improvement to an existing skill. / 既存スキルの具体的な改善を提案します。
+title: "[Skill improvement]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for focused improvements to tests, fixtures, documentation,
+        error handling, metadata, packaging, or safety boundaries.
+
+        テスト、fixture、文書、エラー処理、metadata、package、安全境界の改善に利用してください。
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill name / スキル名
+      description: Use the directory name under `skills/` if known. / 分かれば `skills/` 配下のディレクトリ名を書いてください。
+      placeholder: "portfolio-manager"
+    validations:
+      required: true
+  - type: dropdown
+    id: improvement-type
+    attributes:
+      label: Improvement type / 改善種別
+      description: Select the closest category. / 最も近い分類を選んでください。
+      options:
+        - Tests or fixtures
+        - Documentation or examples
+        - Error handling or validation
+        - Metadata or workflow references
+        - Package or generated artifact drift
+        - Safety boundary or no-advice wording
+        - Other focused improvement
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / 課題
+      description: Explain what makes the skill hard to use, test, or trust. / 何が使いにくい、検証しにくい、信頼しにくいか説明してください。
+      placeholder: "The current SKILL.md does not explain..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed change / 提案する変更
+      description: Keep the change narrow and verifiable. / 変更範囲を小さく、検証可能にしてください。
+      placeholder: "Add fixtures that cover..."
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Suggested validation / 想定する検証
+      description: Name targeted tests, package checks, or documentation checks. / 対象テスト、package、文書checkを書いてください。
+      placeholder: "python3.9 -m pytest skills/<skill>/scripts/tests -q"
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context / 補足
+      description: Add sanitized examples, links, or prior output if useful. / 必要なら秘密情報を除いた例、リンク、過去の出力を追加してください。
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements / 確認事項
+      description: Confirm both items before submitting. / 送信前に両方を確認してください。
+      options:
+        - label: I removed secrets, API keys, personal information, and brokerage account data. / 秘密情報、APIキー、個人情報、証券口座情報を除外しました。
+          required: true
+        - label: This is not a request for financial advice, buy/sell recommendations, profit guarantees, or broker execution. / 金融助言、売買推奨、利益保証、発注実行の依頼ではありません。
+          required: true

--- a/.github/ISSUE_TEMPLATE/workflow_recipe.yml
+++ b/.github/ISSUE_TEMPLATE/workflow_recipe.yml
@@ -1,0 +1,70 @@
+name: Workflow recipe / ワークフロー改善
+description: Improve a multi-skill workflow or sample recipe. / 複数スキルの流れや実行例を改善します。
+title: "[Workflow recipe]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for workflow recipes, sample runs, prompts, handoffs,
+        and repeatable process improvements that preserve human decision gates.
+
+        ワークフロー、実行例、prompt、handoff、人間の判断ゲートを残す手順改善に利用してください。
+  - type: input
+    id: workflow-name
+    attributes:
+      label: Workflow or routine / ワークフロー名
+      description: Name the workflow manifest, sample, or routine if known. / 分かればmanifest、sample、routine名を書いてください。
+      placeholder: "workflows/market-regime-daily.yaml"
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case / 利用場面
+      description: Explain who it helps and which decision process improves. / 誰のどの判断プロセスを改善するか説明してください。
+      placeholder: "A 15-minute morning market check for..."
+    validations:
+      required: true
+  - type: textarea
+    id: current-gap
+    attributes:
+      label: Current gap / 現状の不足
+      description: Explain what is missing, unclear, or hard to repeat. / 何が不足、不明確、再現困難か説明してください。
+      placeholder: "The current workflow does not..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-recipe
+    attributes:
+      label: Proposed recipe / 提案する流れ
+      description: List skills, inputs, outputs, and decision gates. / スキル、入力、出力、判断ゲートを書いてください。
+      placeholder: |
+        1. Run market-breadth-analyzer with...
+        2. Feed the output to exposure-coach...
+        3. Stop if...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-artifacts
+    attributes:
+      label: Expected artifacts / 期待する成果物
+      description: Name reports, YAML, Markdown, screenshots, or journal entries. / レポート、YAML、Markdown、画像、記録を書いてください。
+      placeholder: "reports/..., a workflow manifest, and a sample run"
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context / 補足
+      description: Add sanitized examples or links if useful. / 必要なら秘密情報を除いた例やリンクを追加してください。
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements / 確認事項
+      description: Confirm both items before submitting. / 送信前に両方を確認してください。
+      options:
+        - label: I removed secrets, API keys, personal information, and brokerage account data. / 秘密情報、APIキー、個人情報、証券口座情報を除外しました。
+          required: true
+        - label: This is not a request for financial advice, buy/sell recommendations, profit guarantees, or broker execution. / 金融助言、売買推奨、利益保証、発注実行の依頼ではありません。
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+## Summary / 概要
+
+-
+
+## Related issue / 関連Issue
+
+- Refs or Closes #
+
+## Scope and safety / スコープと安全性
+
+- [ ] This PR does not provide financial advice, buy/sell signals, profit guarantees, or broker execution. / 金融助言、売買推奨、利益保証、発注実行を含みません。
+- [ ] I removed secrets, API keys, personal information, brokerage account data, and proprietary customer data. / 秘密情報、APIキー、個人情報、証券口座情報、顧客固有情報を含みません。
+- [ ] This PR contains no unsafe live write and does not mix unrelated cleanup. / 危険なlive writeや無関係な整理を含みません。
+
+## Local validation / ローカル検証
+
+- [ ] Targeted tests passed with `python3.9 -m pytest <target> -q` (or the repository-compatible Python noted below). / 対象テストが通過しました。
+- [ ] The full skill suite passed with `bash scripts/run_all_tests.sh`, or N/A is explained below. / 全skill testまたはN/A理由を記録しました。
+- [ ] `ruff check skills/ scripts/` passed. / lintが通過しました。
+- [ ] `ruff format --check skills/ scripts/` passed. / format checkが通過しました。
+- [ ] `codespell --toml pyproject.toml skills/ scripts/` passed. / スペルcheckが通過しました。
+- [ ] `pre-commit run --all-files` passed. / 全pre-commit hookが通過しました。
+- [ ] `git diff --check` passed. / whitespace checkが通過しました。
+
+## CI and generated-artifact gates / CI・生成物ゲート
+
+Mark non-applicable items as N/A and explain them under reviewer notes. / 非該当項目はN/Aとし、レビュー補足に理由を書いてください。
+
+- [ ] GitHub Actions Lint, Security, Metadata + Workflow checks, tests, and Coverage are green. / GitHub Actionsの全gateがgreenです。
+- [ ] If a skill changed, EN and JA skill docs are present or regenerated, and its `.skill` package passed `python3 scripts/package_skills.py --check --skill <skill-name>`. / skill変更時は英日文書とpackageを確認しました。
+- [ ] If a skill package needed regeneration, `python3 scripts/package_skills.py --skill <skill-name>` was run before the package check. / 必要なpackageを再生成しました。
+- [ ] Index/workflow metadata passed `python3 scripts/validate_skills_index.py`, `python3 scripts/validate_skills_index.py --strict-workflows`, and `python3 scripts/validate_skills_index.py --strict-metadata`. / index・workflow metadataを検証しました。
+- [ ] Skillsets passed `python3 scripts/validate_skillsets.py`. / skillsetを検証しました。
+- [ ] Skill docs passed `python3 scripts/generate_skill_docs.py --check`. / skill文書のdriftを確認しました。
+- [ ] Workflow docs passed `python3 scripts/generate_workflow_docs.py --check`. / workflow文書のdriftを確認しました。
+- [ ] Skillset docs passed `python3 scripts/generate_skillset_docs.py --check`. / skillset文書のdriftを確認しました。
+- [ ] README/catalog output passed `python3 scripts/generate_catalog_from_index.py --check`. / catalogのdriftを確認しました。
+- [ ] Navigator snapshot passed `python3 skills/trading-skills-navigator/scripts/build_snapshot.py --check`. / navigator snapshotを確認しました。
+- [ ] Vendored FMP clients passed `python3 scripts/generate_fmp_client.py --check`. / FMP clientのdriftを確認しました。
+- [ ] Changed skill packages passed `python3 scripts/check_package_drift_for_changed_skills.py`. / 変更skillのpackage driftを確認しました。
+- [ ] FMP package mirrors passed the repository CI command below. / FMP package mirrorのdriftを確認しました。
+
+```bash
+python3 scripts/package_skills.py --check --skill pead-screener --skill earnings-trade-analyzer --skill ibd-distribution-day-monitor --skill vcp-screener --skill parabolic-short-trade-planner --skill ftd-detector --skill canslim-screener --skill macro-regime-detector --skill market-top-detector
+```
+
+## Reviewer notes and N/A reasons / レビュー補足・N/A理由
+
+-

--- a/scripts/tests/test_github_templates.py
+++ b/scripts/tests/test_github_templates.py
@@ -1,0 +1,282 @@
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+ISSUE_TEMPLATE_DIR = ROOT / ".github" / "ISSUE_TEMPLATE"
+PR_TEMPLATE = ROOT / ".github" / "pull_request_template.md"
+
+EXPECTED_FORM_LABELS = {
+    "bug_report.yml": ["bug"],
+    "skill_improvement.yml": ["enhancement"],
+    "workflow_recipe.yml": ["documentation"],
+    "real_use_pitfall.yml": ["documentation"],
+}
+EXPECTED_CHOOSER_FILES = set(EXPECTED_FORM_LABELS) | {"config.yml"}
+
+FORM_REQUIRED_KEYS = {"name", "description", "title", "labels", "body"}
+FORM_ALLOWED_KEYS = FORM_REQUIRED_KEYS | {"assignees"}
+BODY_TYPES = {"markdown", "input", "textarea", "dropdown", "checkboxes"}
+USER_INPUT_TYPES = BODY_TYPES - {"markdown"}
+ITEM_ALLOWED_KEYS = {
+    "markdown": {"type", "attributes"},
+    "input": {"type", "id", "attributes", "validations"},
+    "textarea": {"type", "id", "attributes", "validations"},
+    "dropdown": {"type", "id", "attributes", "validations"},
+    "checkboxes": {"type", "id", "attributes", "validations"},
+}
+ATTRIBUTE_ALLOWED_KEYS = {
+    "markdown": {"value"},
+    "input": {"label", "description", "placeholder", "value"},
+    "textarea": {"label", "description", "placeholder", "value", "render"},
+    "dropdown": {"label", "description", "multiple", "options"},
+    "checkboxes": {"label", "description", "options"},
+}
+ATTRIBUTE_REQUIRED_KEYS = {
+    "markdown": {"value"},
+    "input": {"label", "description"},
+    "textarea": {"label", "description"},
+    "dropdown": {"label", "description", "options"},
+    "checkboxes": {"label", "description", "options"},
+}
+VALIDATION_ALLOWED_KEYS = {"required"}
+CHECKBOX_OPTION_ALLOWED_KEYS = {"label", "required"}
+SAFE_ID = re.compile(r"^[A-Za-z0-9_-]+$")
+JAPANESE_TEXT = re.compile(r"[ぁ-んァ-ン一-龯]")
+
+EXPECTED_CONTACT_LINKS = [
+    "https://github.com/tradermonty/claude-trading-skills/blob/main/PROJECT_VISION.md",
+    "https://tradermonty.github.io/claude-trading-skills/",
+]
+
+FMP_PACKAGE_DRIFT_COMMAND = (
+    "python3 scripts/package_skills.py --check "
+    "--skill pead-screener "
+    "--skill earnings-trade-analyzer "
+    "--skill ibd-distribution-day-monitor "
+    "--skill vcp-screener "
+    "--skill parabolic-short-trade-planner "
+    "--skill ftd-detector "
+    "--skill canslim-screener "
+    "--skill macro-regime-detector "
+    "--skill market-top-detector"
+)
+
+
+def load_yaml(path: Path) -> object:
+    with path.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def assert_nonblank_string(value: object, context: tuple[object, ...]) -> str:
+    assert isinstance(value, str), context
+    assert value.strip(), context
+    return value
+
+
+def test_issue_template_directory_has_exact_chooser_files() -> None:
+    actual_files = {path.name for path in ISSUE_TEMPLATE_DIR.iterdir() if path.is_file()}
+    assert actual_files == EXPECTED_CHOOSER_FILES
+
+
+def test_issue_template_config_has_exact_contact_links() -> None:
+    config = load_yaml(ISSUE_TEMPLATE_DIR / "config.yml")
+
+    assert isinstance(config, dict)
+    assert set(config) == {"blank_issues_enabled", "contact_links"}
+    assert config["blank_issues_enabled"] is False
+
+    contact_links = config["contact_links"]
+    assert isinstance(contact_links, list)
+    assert [link.get("url") for link in contact_links] == EXPECTED_CONTACT_LINKS
+    for index, link in enumerate(contact_links):
+        assert isinstance(link, dict), index
+        assert set(link) == {"name", "url", "about"}, index
+        for key in ("name", "url", "about"):
+            value = assert_nonblank_string(link[key], (index, key))
+            if key != "url":
+                assert JAPANESE_TEXT.search(value), (index, key)
+
+
+def test_issue_forms_match_github_schema_invariants() -> None:
+    form_names: set[str] = set()
+
+    for filename, expected_labels in EXPECTED_FORM_LABELS.items():
+        form = load_yaml(ISSUE_TEMPLATE_DIR / filename)
+        assert isinstance(form, dict), filename
+        assert FORM_REQUIRED_KEYS <= set(form), filename
+        assert set(form) <= FORM_ALLOWED_KEYS, (filename, set(form) - FORM_ALLOWED_KEYS)
+
+        name = assert_nonblank_string(form["name"], (filename, "name"))
+        description = assert_nonblank_string(form["description"], (filename, "description"))
+        title = assert_nonblank_string(form["title"], (filename, "title"))
+        assert len(name) <= 64, filename
+        assert len(description) <= 200, filename
+        assert len(title) <= 256, filename
+        assert JAPANESE_TEXT.search(name), (filename, "name")
+        assert JAPANESE_TEXT.search(description), (filename, "description")
+        assert name not in form_names, (filename, name)
+        form_names.add(name)
+
+        assert form["labels"] == expected_labels, filename
+        if "assignees" in form:
+            assert isinstance(form["assignees"], list), filename
+            assert all(isinstance(value, str) for value in form["assignees"]), filename
+
+        body = form["body"]
+        assert isinstance(body, list), filename
+        assert body, filename
+        assert len(body) <= 10, filename
+        assert any(item.get("type") in USER_INPUT_TYPES for item in body), filename
+
+        ids: set[str] = set()
+        labels: set[str] = set()
+        acknowledgement_options: list[str] | None = None
+
+        for index, item in enumerate(body):
+            assert isinstance(item, dict), (filename, index)
+            item_type = item.get("type")
+            assert item_type in BODY_TYPES, (filename, index, item_type)
+            assert set(item) <= ITEM_ALLOWED_KEYS[item_type], (
+                filename,
+                index,
+                set(item) - ITEM_ALLOWED_KEYS[item_type],
+            )
+
+            attributes = item.get("attributes")
+            assert isinstance(attributes, dict), (filename, index, "attributes")
+            assert ATTRIBUTE_REQUIRED_KEYS[item_type] <= set(attributes), (
+                filename,
+                index,
+                "required attributes",
+            )
+            assert set(attributes) <= ATTRIBUTE_ALLOWED_KEYS[item_type], (
+                filename,
+                index,
+                set(attributes) - ATTRIBUTE_ALLOWED_KEYS[item_type],
+            )
+
+            if item_type == "markdown":
+                assert_nonblank_string(attributes["value"], (filename, index, "value"))
+                continue
+
+            item_id = assert_nonblank_string(item.get("id"), (filename, index, "id"))
+            assert SAFE_ID.fullmatch(item_id), (filename, item_id)
+            assert item_id not in ids, (filename, item_id)
+            ids.add(item_id)
+
+            label = assert_nonblank_string(attributes["label"], (filename, item_id, "label"))
+            description_text = assert_nonblank_string(
+                attributes["description"], (filename, item_id, "description")
+            )
+            assert label not in labels, (filename, label)
+            labels.add(label)
+            assert JAPANESE_TEXT.search(label), (filename, item_id, "label")
+            assert JAPANESE_TEXT.search(description_text), (
+                filename,
+                item_id,
+                "description",
+            )
+
+            validations = item.get("validations", {})
+            assert isinstance(validations, dict), (filename, item_id, "validations")
+            assert set(validations) <= VALIDATION_ALLOWED_KEYS, (filename, item_id)
+            if "required" in validations:
+                assert isinstance(validations["required"], bool), (filename, item_id)
+
+            if item_type not in {"dropdown", "checkboxes"}:
+                continue
+
+            options = attributes["options"]
+            assert isinstance(options, list), (filename, item_id, "options")
+            assert options, (filename, item_id, "options")
+
+            if item_type == "dropdown":
+                normalized_options: list[str] = []
+                for option in options:
+                    option_text = assert_nonblank_string(option, (filename, item_id, "option"))
+                    assert option_text.casefold() != "none", (filename, item_id)
+                    normalized_options.append(option_text)
+                assert len(normalized_options) == len(set(normalized_options)), (
+                    filename,
+                    item_id,
+                    "duplicate options",
+                )
+                continue
+
+            checkbox_labels: list[str] = []
+            for option in options:
+                assert isinstance(option, dict), (filename, item_id, "option")
+                assert set(option) <= CHECKBOX_OPTION_ALLOWED_KEYS, (
+                    filename,
+                    item_id,
+                    set(option) - CHECKBOX_OPTION_ALLOWED_KEYS,
+                )
+                option_label = assert_nonblank_string(
+                    option.get("label"), (filename, item_id, "option label")
+                )
+                assert JAPANESE_TEXT.search(option_label), (
+                    filename,
+                    item_id,
+                    "option label",
+                )
+                assert option.get("required") is True, (filename, item_id)
+                checkbox_labels.append(option_label)
+            assert len(checkbox_labels) == len(set(checkbox_labels)), (
+                filename,
+                item_id,
+                "duplicate options",
+            )
+            if item_id == "acknowledgements":
+                acknowledgement_options = checkbox_labels
+
+        assert acknowledgement_options is not None, filename
+        acknowledgements = " ".join(acknowledgement_options).casefold()
+        for phrase in ("secret", "api key", "personal", "financial advice"):
+            assert phrase in acknowledgements, (filename, phrase)
+        assert "broker execution" in acknowledgements, filename
+
+
+def test_pull_request_template_matches_local_and_ci_gates() -> None:
+    template = PR_TEMPLATE.read_text(encoding="utf-8")
+
+    required_commands = [
+        "python3.9 -m pytest",
+        "bash scripts/run_all_tests.sh",
+        "ruff check skills/ scripts/",
+        "ruff format --check skills/ scripts/",
+        "codespell --toml pyproject.toml skills/ scripts/",
+        "pre-commit run --all-files",
+        "git diff --check",
+        "python3 scripts/validate_skills_index.py",
+        "python3 scripts/validate_skills_index.py --strict-workflows",
+        "python3 scripts/validate_skills_index.py --strict-metadata",
+        "python3 scripts/validate_skillsets.py",
+        "python3 scripts/generate_skill_docs.py --check",
+        "python3 scripts/generate_workflow_docs.py --check",
+        "python3 scripts/generate_skillset_docs.py --check",
+        "python3 scripts/generate_catalog_from_index.py --check",
+        "python3 skills/trading-skills-navigator/scripts/build_snapshot.py --check",
+        "python3 scripts/generate_fmp_client.py --check",
+        "python3 scripts/check_package_drift_for_changed_skills.py",
+        FMP_PACKAGE_DRIFT_COMMAND,
+    ]
+    for command in required_commands:
+        assert command in template, command
+
+    required_phrases = [
+        "Local validation / ローカル検証",
+        "CI and generated-artifact gates / CI・生成物ゲート",
+        "N/A",
+        "EN and JA",
+        ".skill",
+        "financial advice",
+        "broker execution",
+        "secrets",
+        "personal information",
+        "金融助言",
+        "個人情報",
+    ]
+    for phrase in required_phrases:
+        assert phrase in template, phrase


### PR DESCRIPTION
## Summary

- add four bilingual GitHub Issue Forms for bug reports, skill improvements, workflow recipes, and real-use pitfalls
- add an issue chooser configuration with verified project-scope and documentation links
- add a bilingual pull request template aligned with the repository's local, CI, generated-artifact, package, and security gates
- add repository-level contract tests for GitHub Issue Form schema invariants, Japanese guidance, privacy acknowledgements, live label mappings, chooser links, and PR gate commands

## Validation

- `python3.9 -m pytest scripts/tests/test_github_templates.py -q` — 4 passed
- `ruff check skills/ scripts/` — passed
- `ruff format --check skills/ scripts/` — passed
- metadata/index/skillset validators — passed
- catalog, skill docs, workflow docs, skillset docs, navigator snapshot, FMP client, and package drift checks — passed
- explicit FMP package mirror check — passed
- `bash scripts/run_all_tests.sh` — 69/69 suites passed (rerun outside the sandbox after the initial `~/.cache/uv` permission failure)
- `pre-commit run --all-files` — passed
- `git diff --check` — passed
- commit and pre-push hooks — passed

## Review loops

- plan review: 2 rounds (round 1 requested stronger GitHub schema invariants and complete CI gate coverage; round 2 approved with no findings)
- implementation review: 1 round (approved with no blocking, high, medium, or low findings)

## Issue lifecycle

This PR fully implements the four requested chooser forms, the gate-aligned PR template, inline Japanese guidance, and regression tests. Merging it should close the issue.

Closes #199
