### PR TITLE
docs: add bilingual Your First Week onboarding guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -50,6 +50,8 @@ English README is available at [`README.md`](README.md).
 
 manifest の読み方や手動実行手順は [`workflows/README.md`](workflows/README.md) を参照してください。「自分の状況にどのワークフローが合うか」を 1 ページで知りたい場合は [ワークフローの選び方](docs/ja/find-your-workflow.md)（[English](docs/en/find-your-workflow.md)）を参照してください。
 
+初めて使う場合は、[最初の1週間](docs/ja/your-first-week.md)（[English](docs/en/your-first-week.md)）で、インストール、有料データAPI不要の相場確認、最初のジャーナル登録、最初の週次レビューまで順に進めてください。
+
 ### 実際に必要な費用
 
 Claude Skills を使うには、Skills 機能に対応した有料 Claude プランが必要です。FMP、FINVIZ Elite、Alpaca などのデータ/API・ブローカー連携は特定のワークフロー向けの任意または個別要件です。下の5スキルの入口は公開 CSV、チャート画像、ローカルファイルで動くため、Claude プラン以外の有料データ API 契約は不要です。

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ New users should start with one of these operational workflows. Each link points
 
 See [`workflows/README.md`](workflows/README.md) for how to read a manifest and run it manually. For a one-page "which workflow fits my situation?" guide, see [Find Your Workflow](docs/en/find-your-workflow.md) ([日本語](docs/ja/find-your-workflow.md)).
 
+New here? Follow [Your First Week](docs/en/your-first-week.md) ([日本語](docs/ja/your-first-week.md)) from installation through a no-paid-data-API market check, first journal entry, and first weekly review.
+
 ### What This Actually Costs
 
 Claude Skills require a paid Claude plan that supports the Skills feature. FMP, FINVIZ Elite, and Alpaca are optional data or broker integrations for specific workflows; the five-skill starter path below works with public CSVs, chart screenshots, and local files, so it does not require any paid data API subscription beyond your Claude plan.

--- a/docs/en/your-first-week.md
+++ b/docs/en/your-first-week.md
@@ -1,0 +1,245 @@
+---
+layout: default
+title: Your First Week
+parent: English
+nav_order: 8
+lang_peer: /ja/your-first-week/
+permalink: /en/your-first-week/
+---
+
+# Your First Week
+{: .no_toc }
+
+A seven-day path from installation to a repeatable market check, first journal entry,
+and first weekly review.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of Contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## Before You Start
+
+This guide needs a Claude plan that supports Skills, Python 3.9+, `git`, `uv`, and
+internet access to public CSV files. It needs **no paid market-data API** and no FMP,
+FINVIZ Elite, or broker credentials.
+
+> "No paid API" does not mean "offline." The two market analyzers download public CSV
+> files. The journal and weekly review stay local. Nothing in this guide places an order
+> or turns a report into a buy/sell signal.
+{: .note }
+
+The copy-and-paste commands below are for Claude Code or a terminal at the repository
+root. Web App users can upload the corresponding `.skill` files from
+[`skill-packages/`](https://github.com/tradermonty/claude-trading-skills/tree/main/skill-packages):
+`trading-skills-navigator`, `market-breadth-analyzer`, `uptrend-analyzer`,
+`exposure-coach`, `trader-memory-core`, and `weekly-performance-digest`.
+
+## Day 1 — Install a Reproducible Environment
+
+Clone the repository if you have not already done so, then install the locked runtime
+dependencies:
+
+```bash
+git clone https://github.com/tradermonty/claude-trading-skills.git
+cd claude-trading-skills
+uv sync --locked
+mkdir -p reports/first-week state/first-week-theses first-week-inputs
+```
+
+Keep every command in this guide at the repository root. We use `uv run python`
+consistently so `requests`, `PyYAML`, and `jsonschema` come from the locked project
+environment.
+
+## Day 2 — Let the Navigator Choose the Path
+
+Ask the deterministic Navigator for a beginner-friendly 15-minute routine:
+
+<!-- first-week-navigator-command:start -->
+```bash
+uv run python skills/trading-skills-navigator/scripts/recommend.py \
+  --query "I want a 15-minute daily market check without paid API keys" \
+  --no-api \
+  --time-budget 15m \
+  --experience beginner \
+  --format json
+```
+<!-- first-week-navigator-command:end -->
+
+Confirm these fields in the JSON:
+
+```text
+primary_workflow.id = market-regime-daily
+primary_workflow.api_profile = no-api-basic
+no_api_path = true
+```
+
+The Navigator recommends; it does not execute other skills. The
+[`market-regime-daily`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/market-regime-daily.yaml)
+manifest remains the source of truth for step order and required artifacts.
+
+## Day 3 — Run the No-Paid-API Market Check
+
+Run the two required public-data analyzers:
+
+```bash
+uv run python skills/market-breadth-analyzer/scripts/market_breadth_analyzer.py \
+  --output-dir reports/first-week
+
+uv run python skills/uptrend-analyzer/scripts/uptrend_analyzer.py \
+  --output-dir reports/first-week
+```
+
+Select exactly one timestamped output from each analyzer. The breadth pattern
+deliberately excludes `market_breadth_history.json`.
+
+```bash
+breadth_json="$(find reports/first-week -maxdepth 1 -type f \
+  -name 'market_breadth_????-??-??_??????.json' -print | sort | tail -n 1)"
+uptrend_json="$(find reports/first-week -maxdepth 1 -type f \
+  -name 'uptrend_analysis_????-??-??_??????.json' -print | sort | tail -n 1)"
+
+test -n "$breadth_json" && test -f "$breadth_json"
+test -n "$uptrend_json" && test -f "$uptrend_json"
+```
+
+The workflow's market-top step is optional, so the minimal path skips it. Pass only
+the two available artifacts to Exposure Coach:
+
+```bash
+uv run python skills/exposure-coach/scripts/calculate_exposure.py \
+  --breadth "$breadth_json" \
+  --uptrend "$uptrend_json" \
+  --output-dir reports/first-week
+```
+
+Inspect the newest `exposure_posture_*.json`:
+
+```bash
+exposure_json="$(find reports/first-week -maxdepth 1 -type f \
+  -name 'exposure_posture_????-??-??_??????.json' -print | sort | tail -n 1)"
+test -n "$exposure_json" && test -f "$exposure_json"
+
+uv run python - "$exposure_json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as report_file:
+    report = json.load(report_file)
+
+for key in (
+    "inputs_provided",
+    "inputs_missing",
+    "confidence",
+    "recommendation",
+    "exposure_ceiling_pct",
+):
+    print(f"{key}: {report[key]}")
+PY
+```
+
+Expect `breadth` and `uptrend` in `inputs_provided`, the omitted dimensions in
+`inputs_missing`, and `confidence: LOW`. With the critical regime and top-risk inputs
+missing, the fail-safe recommendation is `REDUCE_ONLY` or `CASH_PRIORITY`, never
+`NEW_ENTRY_ALLOWED`. This is a **degraded, incomplete-input posture**, not a complete
+market verdict and not evidence that the market is bearish. Optional enhancements may
+have additional data requirements; check their current skill guides before using them.
+
+## Day 4 — Create Your First Journal Entry
+
+Create a manual IDEA. Use a real ticker and a falsifiable statement, but do not invent
+an entry or position just to complete the tutorial.
+
+<!-- first-week-manual-json:start -->
+```json
+{
+  "ticker": "AMD",
+  "thesis_statement": "Observe whether AMD holds above the prior breakout area for five sessions.",
+  "thesis_type": "growth_momentum"
+}
+```
+<!-- first-week-manual-json:end -->
+
+Save that JSON and ingest it:
+
+```bash
+cat > first-week-inputs/manual-idea.json <<'JSON'
+{
+  "ticker": "AMD",
+  "thesis_statement": "Observe whether AMD holds above the prior breakout area for five sessions.",
+  "thesis_type": "growth_momentum"
+}
+JSON
+```
+
+<!-- first-week-ingest-command:start -->
+```bash
+uv run python skills/trader-memory-core/scripts/trader_memory_cli.py ingest \
+  --source manual \
+  --input first-week-inputs/manual-idea.json \
+  --state-dir state/first-week-theses
+```
+<!-- first-week-ingest-command:end -->
+
+The command prints the generated thesis ID and creates an `IDEA`. It does not mark a
+trade active and does not place an order.
+
+## Day 5 — Read the Journal Before Changing It
+
+List the state you actually recorded:
+
+```bash
+uv run python skills/trader-memory-core/scripts/trader_memory_cli.py store \
+  --state-dir state/first-week-theses \
+  list
+
+uv run python skills/trader-memory-core/scripts/trader_memory_cli.py review \
+  --state-dir state/first-week-theses \
+  review-due
+```
+
+Check that the ticker, thesis type, and status match your input. Leave the thesis as
+`IDEA` until you have separately validated a setup. Never edit the YAML state files by
+hand; the CLI preserves schema and lifecycle checks.
+
+## Day 6 — Turn the Steps into a Routine
+
+Repeat Day 3 before considering new swing-trade risk. Keep this short checklist:
+
+1. Read both analyzer freshness warnings.
+2. Confirm which inputs Exposure Coach actually accepted.
+3. Treat missing inputs as missing; do not fill them with assumptions.
+4. Record the posture and your reasoning, not a prediction.
+5. Make every order and risk decision outside this workflow under your own rules.
+
+The daily output is useful when it changes your process: reduce research when the
+posture is restrictive, or proceed to separate stock-level analysis when a complete
+review allows it. It is never a standalone signal.
+
+## Day 7 — Run Your First Weekly Review
+
+Generate the trailing-seven-day digest from the local journal:
+
+```bash
+uv run python skills/weekly-performance-digest/scripts/generate_weekly_digest.py \
+  --state-dir state/first-week-theses \
+  --output-dir reports/first-week \
+  --verbose
+```
+
+If you closed no trades, a zero-trade report is the correct result. Do not create a fake
+trade to populate the metrics. Read the generated `weekly_digest_*.md` and answer:
+
+1. Did I run the market check before considering risk?
+2. Did I distinguish missing inputs from neutral signals?
+3. Did I write a falsifiable thesis instead of a story?
+4. What one process rule will I keep or change next week?
+
+You have now completed the smallest Plan → Record → Review → Improve loop without a
+paid data API. Continue with [Find Your Workflow]({{ '/en/find-your-workflow/' | relative_url }})
+only after this routine feels repeatable.

--- a/docs/ja/your-first-week.md
+++ b/docs/ja/your-first-week.md
@@ -1,0 +1,243 @@
+---
+layout: default
+title: 最初の1週間
+parent: 日本語
+nav_order: 8
+lang_peer: /en/your-first-week/
+permalink: /ja/your-first-week/
+---
+
+# 最初の1週間
+{: .no_toc }
+
+インストールから、再現可能な相場確認、最初のジャーナル登録、最初の週次レビューまでを
+7日間で進めるガイドです。
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>目次</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## 始める前に
+
+必要なものは、Skills機能に対応したClaudeプラン、Python 3.9以上、`git`、`uv`、
+公開CSVへ接続できるインターネット環境です。FMP、FINVIZ Elite、ブローカー認証情報などの
+**有料マーケットデータAPIは不要**です。
+
+> 「有料API不要」は「オフライン」という意味ではありません。2つの相場分析スキルは
+> 公開CSVをダウンロードします。ジャーナルと週次レビューはローカルで完結します。
+> このガイドは発注せず、レポートを売買シグナルとして扱いません。
+{: .note }
+
+以下のコピー可能なコマンドは、Claude Codeまたはリポジトリルートのターミナル向けです。
+Web Appでは
+[`skill-packages/`](https://github.com/tradermonty/claude-trading-skills/tree/main/skill-packages)
+から `trading-skills-navigator`、`market-breadth-analyzer`、`uptrend-analyzer`、
+`exposure-coach`、`trader-memory-core`、`weekly-performance-digest` の
+`.skill` ファイルをアップロードできます。
+
+## 1日目 — 再現可能な環境を準備する
+
+まだ取得していない場合はリポジトリをクローンし、lock済みのruntime依存を導入します。
+
+```bash
+git clone https://github.com/tradermonty/claude-trading-skills.git
+cd claude-trading-skills
+uv sync --locked
+mkdir -p reports/first-week state/first-week-theses first-week-inputs
+```
+
+以降はすべてリポジトリルートで実行します。`requests`、`PyYAML`、`jsonschema` を
+lock済み環境から使うため、Pythonコマンドを `uv run python` に統一します。
+
+## 2日目 — Navigatorに入口を選ばせる
+
+初心者向けの15分ルーチンを決定論的Navigatorに問い合わせます。
+
+<!-- first-week-navigator-command:start -->
+```bash
+uv run python skills/trading-skills-navigator/scripts/recommend.py \
+  --query "I want a 15-minute daily market check without paid API keys" \
+  --no-api \
+  --time-budget 15m \
+  --experience beginner \
+  --format json
+```
+<!-- first-week-navigator-command:end -->
+
+JSON内の次のフィールドを確認します。
+
+```text
+primary_workflow.id = market-regime-daily
+primary_workflow.api_profile = no-api-basic
+no_api_path = true
+```
+
+Navigatorは推奨だけを行い、他のスキルを自動実行しません。手順と必須artifactの正本は
+[`market-regime-daily`](https://github.com/tradermonty/claude-trading-skills/blob/main/workflows/market-regime-daily.yaml)
+manifestです。
+
+## 3日目 — 有料APIなしの相場確認を実行する
+
+公開データを使う必須の2分析を実行します。
+
+```bash
+uv run python skills/market-breadth-analyzer/scripts/market_breadth_analyzer.py \
+  --output-dir reports/first-week
+
+uv run python skills/uptrend-analyzer/scripts/uptrend_analyzer.py \
+  --output-dir reports/first-week
+```
+
+各分析からタイムスタンプ付きJSONを1ファイルだけ選びます。breadthのpatternは
+`market_breadth_history.json` を意図的に除外します。
+
+```bash
+breadth_json="$(find reports/first-week -maxdepth 1 -type f \
+  -name 'market_breadth_????-??-??_??????.json' -print | sort | tail -n 1)"
+uptrend_json="$(find reports/first-week -maxdepth 1 -type f \
+  -name 'uptrend_analysis_????-??-??_??????.json' -print | sort | tail -n 1)"
+
+test -n "$breadth_json" && test -f "$breadth_json"
+test -n "$uptrend_json" && test -f "$uptrend_json"
+```
+
+workflowのmarket-top手順は任意なので、この最小導線では省略します。取得できた2つの
+artifactだけをExposure Coachへ渡します。
+
+```bash
+uv run python skills/exposure-coach/scripts/calculate_exposure.py \
+  --breadth "$breadth_json" \
+  --uptrend "$uptrend_json" \
+  --output-dir reports/first-week
+```
+
+最新の `exposure_posture_*.json` を確認します。
+
+```bash
+exposure_json="$(find reports/first-week -maxdepth 1 -type f \
+  -name 'exposure_posture_????-??-??_??????.json' -print | sort | tail -n 1)"
+test -n "$exposure_json" && test -f "$exposure_json"
+
+uv run python - "$exposure_json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as report_file:
+    report = json.load(report_file)
+
+for key in (
+    "inputs_provided",
+    "inputs_missing",
+    "confidence",
+    "recommendation",
+    "exposure_ceiling_pct",
+):
+    print(f"{key}: {report[key]}")
+PY
+```
+
+`inputs_provided` に `breadth` と `uptrend`、`inputs_missing` に省略した系統が入り、
+`confidence: LOW` になることを確認します。重要入力のregimeとtop-riskがないため、
+fail-safeの推奨は `REDUCE_ONLY` または `CASH_PRIORITY` であり、
+`NEW_ENTRY_ALLOWED` にはなりません。これは**入力不足時の縮退ポスチャー**で、
+相場全体が弱気であるという完全な判定ではありません。任意の拡張を使う場合は、
+その時点の各スキルガイドで追加データ要件を確認してください。
+
+## 4日目 — 最初のジャーナル項目を作る
+
+手入力で `IDEA` を1件作成します。実在tickerと反証可能な文を使い、チュートリアルを
+埋めるためだけの架空エントリーやpositionは作らないでください。
+
+<!-- first-week-manual-json:start -->
+```json
+{
+  "ticker": "AMD",
+  "thesis_statement": "Observe whether AMD holds above the prior breakout area for five sessions.",
+  "thesis_type": "growth_momentum"
+}
+```
+<!-- first-week-manual-json:end -->
+
+このJSONを保存し、ingestします。
+
+```bash
+cat > first-week-inputs/manual-idea.json <<'JSON'
+{
+  "ticker": "AMD",
+  "thesis_statement": "Observe whether AMD holds above the prior breakout area for five sessions.",
+  "thesis_type": "growth_momentum"
+}
+JSON
+```
+
+<!-- first-week-ingest-command:start -->
+```bash
+uv run python skills/trader-memory-core/scripts/trader_memory_cli.py ingest \
+  --source manual \
+  --input first-week-inputs/manual-idea.json \
+  --state-dir state/first-week-theses
+```
+<!-- first-week-ingest-command:end -->
+
+コマンドは生成したthesis IDを表示し、`IDEA` を作成します。取引をACTIVEにせず、
+注文も出しません。
+
+## 5日目 — 変更する前にジャーナルを読む
+
+実際に記録されたstateを一覧します。
+
+```bash
+uv run python skills/trader-memory-core/scripts/trader_memory_cli.py store \
+  --state-dir state/first-week-theses \
+  list
+
+uv run python skills/trader-memory-core/scripts/trader_memory_cli.py review \
+  --state-dir state/first-week-theses \
+  review-due
+```
+
+ticker、thesis type、statusが入力どおりか確認します。別途setupを検証するまでは
+`IDEA` のままにします。schemaとlifecycle検証を維持するため、YAML stateを手編集せず、
+必ずCLIを使ってください。
+
+## 6日目 — 手順をルーチンにする
+
+新しいスイングリスクを検討する前に3日目を繰り返します。短いchecklistを守ります。
+
+1. 両analyzerの鮮度警告を読む。
+2. Exposure Coachが実際に受理した入力を確認する。
+3. 不足入力を不足のまま扱い、推測で埋めない。
+4. 予想ではなく、ポスチャーと判断理由を記録する。
+5. 発注とリスク判断はこのworkflowの外で、自分のルールに従って行う。
+
+日次出力は、制限的なポスチャーなら調査を減らし、完全なレビューで許可された場合だけ
+別の個別銘柄分析へ進む、といったプロセス改善に使います。単独の売買シグナルではありません。
+
+## 7日目 — 最初の週次レビューを行う
+
+ローカルジャーナルから直近7日間のdigestを生成します。
+
+```bash
+uv run python skills/weekly-performance-digest/scripts/generate_weekly_digest.py \
+  --state-dir state/first-week-theses \
+  --output-dir reports/first-week \
+  --verbose
+```
+
+クローズした取引がなければ、0件レポートが正しい結果です。指標を埋めるための架空取引を
+作らないでください。生成された `weekly_digest_*.md` を読み、次に答えます。
+
+1. リスクを検討する前に相場確認を行ったか。
+2. 不足入力とneutral signalを区別したか。
+3. 物語ではなく、反証可能なthesisを書いたか。
+4. 来週も維持または変更するprocess ruleは何か。
+
+これで、有料データAPIを使わずに最小の Plan → Record → Review → Improve ループを
+完了しました。このルーチンが再現可能になってから
+[ワークフローの選び方]({{ '/ja/find-your-workflow/' | relative_url }})へ進んでください。

--- a/scripts/tests/test_your_first_week_docs.py
+++ b/scripts/tests/test_your_first_week_docs.py
@@ -1,0 +1,239 @@
+"""Contract tests for the bilingual Your First Week onboarding guide."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+EN_GUIDE = ROOT / "docs" / "en" / "your-first-week.md"
+JA_GUIDE = ROOT / "docs" / "ja" / "your-first-week.md"
+
+MANUAL_JSON_RE = re.compile(
+    r"<!-- first-week-manual-json:start -->\s*"
+    r"```json\n(?P<payload>.*?)\n```\s*"
+    r"<!-- first-week-manual-json:end -->",
+    re.DOTALL,
+)
+MANUAL_HEREDOC_RE = re.compile(
+    r"cat > first-week-inputs/manual-idea\.json <<'JSON'\n"
+    r"(?P<payload>.*?)\nJSON",
+    re.DOTALL,
+)
+NAVIGATOR_COMMAND_RE = re.compile(
+    r"<!-- first-week-navigator-command:start -->\s*"
+    r"```bash\n(?P<command>.*?)\n```\s*"
+    r"<!-- first-week-navigator-command:end -->",
+    re.DOTALL,
+)
+INGEST_COMMAND_RE = re.compile(
+    r"<!-- first-week-ingest-command:start -->\s*"
+    r"```bash\n(?P<command>.*?)\n```\s*"
+    r"<!-- first-week-ingest-command:end -->",
+    re.DOTALL,
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _frontmatter(path: Path) -> dict:
+    text = _read(path)
+    assert text.startswith("---\n")
+    _, raw, _ = text.split("---", 2)
+    return yaml.safe_load(raw)
+
+
+def _command_tokens(pattern: re.Pattern[str], guide: Path) -> list[str]:
+    match = pattern.search(_read(guide))
+    assert match is not None
+    command = match.group("command").replace("\\\n", " ")
+    return shlex.split(command)
+
+
+@pytest.mark.parametrize(
+    ("path", "peer", "permalink"),
+    [
+        (EN_GUIDE, "/ja/your-first-week/", "/en/your-first-week/"),
+        (JA_GUIDE, "/en/your-first-week/", "/ja/your-first-week/"),
+    ],
+)
+def test_frontmatter_contract(path: Path, peer: str, permalink: str) -> None:
+    metadata = _frontmatter(path)
+    assert metadata["nav_order"] == 8
+    assert metadata["lang_peer"] == peer
+    assert metadata["permalink"] == permalink
+
+
+def test_guides_cover_all_seven_days_and_readmes_link_them() -> None:
+    english = _read(EN_GUIDE)
+    japanese = _read(JA_GUIDE)
+
+    for day in range(1, 8):
+        assert f"## Day {day} " in english
+        assert f"## {day}日目 " in japanese
+
+    assert "[Your First Week](docs/en/your-first-week.md)" in _read(ROOT / "README.md")
+    assert "[最初の1週間](docs/ja/your-first-week.md)" in _read(ROOT / "README.ja.md")
+
+
+@pytest.mark.parametrize("guide", [EN_GUIDE, JA_GUIDE])
+def test_navigator_command_returns_the_documented_no_api_workflow(guide: Path) -> None:
+    documented = _command_tokens(NAVIGATOR_COMMAND_RE, guide)
+    assert documented[:3] == ["uv", "run", "python"]
+
+    result = subprocess.run(
+        [sys.executable, *documented[3:]],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    recommendation = json.loads(result.stdout)
+    assert recommendation["primary_workflow"]["id"] == "market-regime-daily"
+    assert recommendation["primary_workflow"]["api_profile"] == "no-api-basic"
+    assert recommendation["no_api_path"] is True
+
+
+@pytest.mark.parametrize("guide", [EN_GUIDE, JA_GUIDE])
+def test_manual_journal_json_is_valid_and_complete(guide: Path, tmp_path: Path) -> None:
+    text = _read(guide)
+    displayed_match = MANUAL_JSON_RE.search(text)
+    heredoc_match = MANUAL_HEREDOC_RE.search(text)
+    assert displayed_match is not None
+    assert heredoc_match is not None
+
+    payload = json.loads(displayed_match.group("payload"))
+    assert json.loads(heredoc_match.group("payload")) == payload
+
+    assert payload["ticker"]
+    assert payload["thesis_statement"]
+    assert payload["thesis_type"] in {
+        "dividend_income",
+        "growth_momentum",
+        "mean_reversion",
+        "earnings_drift",
+        "pivot_breakout",
+    }
+
+    documented = _command_tokens(INGEST_COMMAND_RE, guide)
+    assert documented == [
+        "uv",
+        "run",
+        "python",
+        "skills/trader-memory-core/scripts/trader_memory_cli.py",
+        "ingest",
+        "--source",
+        "manual",
+        "--input",
+        "first-week-inputs/manual-idea.json",
+        "--state-dir",
+        "state/first-week-theses",
+    ]
+
+    input_path = tmp_path / "manual-idea.json"
+    state_dir = tmp_path / "theses"
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+    executable = [sys.executable, *documented[3:]]
+    executable[executable.index("first-week-inputs/manual-idea.json")] = str(input_path)
+    executable[executable.index("state/first-week-theses")] = str(state_dir)
+
+    environment = os.environ.copy()
+    environment["TRADER_MEMORY_CLI_INNER"] = "1"
+    result = subprocess.run(
+        executable,
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    assert "Registered 1 thesis(es)" in result.stdout
+    assert len(list(state_dir.glob("th_*.yaml"))) == 1
+
+
+def test_timestamp_selector_excludes_breadth_history() -> None:
+    pattern = "market_breadth_????-??-??_??????.json"
+    assert fnmatch.fnmatch("market_breadth_2026-07-22_203519.json", pattern)
+    assert not fnmatch.fnmatch("market_breadth_history.json", pattern)
+
+    for guide in (EN_GUIDE, JA_GUIDE):
+        text = _read(guide)
+        assert f"-name '{pattern}'" in text
+        assert "-name 'uptrend_analysis_????-??-??_??????.json'" in text
+
+
+@pytest.mark.parametrize(
+    ("breadth_score", "uptrend_score", "expected_recommendation"),
+    [(80, 80, "REDUCE_ONLY"), (20, 20, "CASH_PRIORITY")],
+)
+def test_partial_exposure_inputs_are_fail_safe(
+    tmp_path: Path,
+    breadth_score: int,
+    uptrend_score: int,
+    expected_recommendation: str,
+) -> None:
+    breadth = tmp_path / "breadth.json"
+    uptrend = tmp_path / "uptrend.json"
+    output = tmp_path / "reports"
+    breadth.write_text(json.dumps({"breadth_score": breadth_score}), encoding="utf-8")
+    uptrend.write_text(json.dumps({"uptrend_score": uptrend_score}), encoding="utf-8")
+
+    subprocess.run(
+        [
+            sys.executable,
+            "skills/exposure-coach/scripts/calculate_exposure.py",
+            "--breadth",
+            str(breadth),
+            "--uptrend",
+            str(uptrend),
+            "--output-dir",
+            str(output),
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    report_path = next(output.glob("exposure_posture_*.json"))
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["inputs_provided"] == ["breadth", "uptrend"]
+    assert report["confidence"] == "LOW"
+    assert report["recommendation"] == expected_recommendation
+    assert report["recommendation"] != "NEW_ENTRY_ALLOWED"
+
+
+def test_empty_weekly_digest_is_a_valid_first_review(tmp_path: Path) -> None:
+    state_dir = tmp_path / "theses"
+    output_dir = tmp_path / "reports"
+    state_dir.mkdir()
+
+    subprocess.run(
+        [
+            sys.executable,
+            "skills/weekly-performance-digest/scripts/generate_weekly_digest.py",
+            "--state-dir",
+            str(state_dir),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    report_path = next(output_dir.glob("weekly_digest_*.json"))
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["summary"]["total_trades"] == 0


### PR DESCRIPTION
## Summary

- add complete English and Japanese "Your First Week" guides
- walk new users through installation, Navigator routing, the no-paid-data-API `market-regime-daily` path, a first `trader-memory-core` journal entry, and a first weekly digest
- link both guides from the README starting paths
- add contract tests that execute the documented Navigator and ingest commands, validate the bilingual manual JSON/heredoc, enforce fail-safe partial-input exposure behavior, and verify an empty weekly digest

## Validation

- `python3.9 -m pytest scripts/tests/test_your_first_week_docs.py -q` — 11 passed
- `ruff check scripts/tests/test_your_first_week_docs.py`
- `ruff format --check scripts/tests/test_your_first_week_docs.py`
- `bash scripts/run_all_tests.sh` — 69/69 suites passed
- `python3 scripts/package_skills.py --check`
- catalog, skill-doc, workflow-doc, skillset-doc, and Navigator snapshot drift checks
- strict skills-index and skillset validators
- `pre-commit run --all-files`
- `git diff --check`

## Review loops

- plan review: 3 rounds; final round `NO FINDINGS`
- implementation review: 2 rounds; final round `NO FINDINGS`

## Issue

This delivers the complete EN/JA seven-day narrative, uses only public CSV/local inputs for the starter path, and links it from both README starting paths.

Closes #204
