### PR TITLE
docs: add bilingual trading glossary

### DIFF
--- a/docs/en/find-your-workflow.md
+++ b/docs/en/find-your-workflow.md
@@ -104,6 +104,8 @@ single source of truth that powers this page.
 
 - [Getting Started](getting-started.md) — install paths for Claude Code,
   Claude web app, and CLI
+- [Glossary]({{ '/en/glossary/' | relative_url }}) — plain-language definitions
+  of the trading terms used in these workflows
 - [Skill Catalog](skill-catalog.md) — full alphabetical catalog of every skill
 - [Workflows](workflows.md) — auto-generated manifest reference for every
   workflow

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -13,6 +13,8 @@ permalink: /en/getting-started/
 Installation instructions, API key setup, and a hands-on tutorial to run your first skill.
 {: .fs-6 .fw-300 }
 
+New to the trading vocabulary used below? Keep the [Glossary]({{ '/en/glossary/' | relative_url }}) open as a plain-language reference.
+
 <details open markdown="block">
   <summary>Table of Contents</summary>
   {: .text-delta }

--- a/docs/en/glossary.md
+++ b/docs/en/glossary.md
@@ -1,0 +1,277 @@
+---
+layout: default
+title: Glossary
+parent: English
+nav_order: 7
+lang_peer: /ja/glossary/
+permalink: /en/glossary/
+---
+
+# Glossary
+{: .no_toc }
+
+Plain-language definitions for trading terms used across Claude Trading Skills. These definitions explain the vocabulary; they are not trading recommendations or promises of future results.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of Contents</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## Terms
+
+### Average True Range (ATR)
+{: #atr }
+
+Average True Range estimates how much an instrument typically moves over a chosen number of periods, including overnight gaps. It measures movement size rather than direction and is often used to scale stops or position risk to current volatility.
+
+**Used by:** [Position Sizer]({{ '/en/skills/position-sizer/' | relative_url }})
+
+### Breadth
+{: #breadth }
+
+Market breadth describes how widely a market move is shared across its constituent stocks. A rising index supported by many advancing stocks is broader than the same index gain driven by only a few large companies.
+
+**Used by:** [Market Breadth Analyzer]({{ '/en/skills/market-breadth-analyzer/' | relative_url }})
+
+### Breakout
+{: #breakout }
+
+A breakout occurs when price moves through a previously important boundary, such as resistance or the top of a trading range. Traders usually look for confirmation from volume, market conditions, and a defined failure level because crossing the boundary alone does not guarantee follow-through.
+
+**Used by:** [Breakout Trade Planner]({{ '/en/skills/breakout-trade-planner/' | relative_url }})
+
+### CANSLIM
+{: #canslim }
+
+CANSLIM is a growth-investing framework covering Current quarterly earnings, Annual earnings growth, something New, Supply and demand, Leader or laggard status, Institutional sponsorship, and Market direction. It combines company fundamentals with price, volume, and market context.
+
+**Used by:** [CANSLIM Screener]({{ '/en/skills/canslim-screener/' | relative_url }})
+
+### Catalyst
+{: #catalyst }
+
+A catalyst is an event or new piece of information that can change expectations about an instrument, such as earnings, guidance, a product launch, regulation, or a management change. A catalyst can create movement, but it does not determine whether the market reaction will be positive or lasting.
+
+**Used by:** [Stockbee Episodic Pivot Analyzer]({{ '/en/skills/stockbee-episodic-pivot-analyzer/' | relative_url }})
+
+### Core + Satellite
+{: #core-satellite }
+
+Core + Satellite is a portfolio structure that separates long-horizon, diversified holdings (the Core) from a smaller allocation for more active or concentrated opportunities (the Satellite). The separation helps keep short-term trades from silently changing the risk profile of the long-term portfolio.
+
+**Used by:** [Kanchi Dividend SOP]({{ '/en/skills/kanchi-dividend-sop/' | relative_url }})
+
+### Correlation
+{: #correlation }
+
+Correlation summarizes how two return series have moved together, commonly on a scale from -1 to +1. It is historical, can change across regimes, and does not prove that one asset causes the other to move.
+
+**Used by:** [Pair Trade Screener]({{ '/en/skills/pair-trade-screener/' | relative_url }})
+
+### Commitments of Traders (COT)
+{: #cot }
+
+The Commitments of Traders report is a weekly CFTC breakdown of futures positions held by categories such as commercial hedgers and managed money. Analysts use it to study positioning and crowding, usually together with price confirmation rather than as a standalone timing signal.
+
+**Used by:** [COT Contrarian Detector]({{ '/en/skills/cot-contrarian-detector/' | relative_url }})
+
+### Distribution Day
+{: #distribution-day }
+
+A distribution day is commonly defined as a meaningful decline in a major index on higher volume than the prior session. A cluster of recent distribution days can suggest institutional selling pressure, but one day by itself is not a complete market signal.
+
+**Used by:** [IBD Distribution Day Monitor]({{ '/en/skills/ibd-distribution-day-monitor/' | relative_url }})
+
+### Drawdown
+{: #drawdown }
+
+Drawdown is the decline from a portfolio or strategy's previous peak to a later low, usually expressed as a percentage. It describes the depth of a loss period and should be considered together with its duration and the recovery required to regain the peak.
+
+**Used by:** [Drawdown Circuit Breaker]({{ '/en/skills/drawdown-circuit-breaker/' | relative_url }})
+
+### Edge
+{: #edge }
+
+An edge is a repeatable informational, behavioral, analytical, or execution advantage that is expected to produce favorable results over many comparable decisions. It is a testable hypothesis, not certainty on any individual trade, and can weaken as market conditions change.
+
+**Used by:** [Edge Concept Synthesizer]({{ '/en/skills/edge-concept-synthesizer/' | relative_url }})
+
+### Entry
+{: #entry }
+
+An entry is the predefined condition or price area at which a trade may be opened. A useful entry rule also states what evidence must be present, how much can be risked, and what condition would make the setup invalid.
+
+**Used by:** [Breakout Trade Planner]({{ '/en/skills/breakout-trade-planner/' | relative_url }})
+
+### Episodic Pivot
+{: #episodic-pivot }
+
+An episodic pivot is a sharp price and volume change associated with a significant company-specific event, often a large earnings or guidance surprise. The event can reset expectations and start a new trend, but liquidity, follow-through, and risk limits still need separate evaluation.
+
+**Used by:** [Stockbee Episodic Pivot Analyzer]({{ '/en/skills/stockbee-episodic-pivot-analyzer/' | relative_url }})
+
+### Expectancy
+{: #expectancy }
+
+Expectancy is the average amount a process is expected to win or lose per trade over a sufficiently large sample. A common form combines win rate and average win, then subtracts loss rate multiplied by average loss; it does not predict the next result.
+
+**Used by:** [Weekly Performance Digest]({{ '/en/skills/weekly-performance-digest/' | relative_url }})
+
+### Exposure
+{: #exposure }
+
+Exposure is the amount of portfolio capital affected by market movement, often expressed as a percentage of equity and separated into long, short, gross, or net exposure. Position values alone can hide leverage, so the denominator and sign convention matter.
+
+**Used by:** [Exposure Coach]({{ '/en/skills/exposure-coach/' | relative_url }})
+
+### Follow-Through Day (FTD)
+{: #ftd }
+
+A follow-through day is a strong gain in a major index on higher volume after a possible market low, used in some growth-investing methods as evidence that a rally may be gaining institutional support. It is a confirmation condition, not a guarantee that the rally will continue.
+
+**Used by:** [FTD Detector]({{ '/en/skills/ftd-detector/' | relative_url }})
+
+### Gap
+{: #gap }
+
+A gap is a price interval between one session's trading range and the next session's opening activity where little or no trading occurred. Gaps often reflect new information, but their size, volume, location, and subsequent price response determine their practical meaning.
+
+**Used by:** [Earnings Trade Analyzer]({{ '/en/skills/earnings-trade-analyzer/' | relative_url }})
+
+### Hedge Ratio
+{: #hedge-ratio }
+
+A hedge ratio specifies how much of one instrument is paired against another to reduce a chosen risk, such as market or spread exposure. In a pair trade it is commonly estimated from historical prices, but estimation error and changing relationships can leave residual risk.
+
+**Used by:** [Pair Trade Screener]({{ '/en/skills/pair-trade-screener/' | relative_url }})
+
+### Liquidity
+{: #liquidity }
+
+Liquidity describes how easily an instrument can be bought or sold in the desired size without materially moving its price. Volume, bid-ask spread, and market depth are useful clues, and liquidity can deteriorate during volatile or off-hours trading.
+
+**Used by:** [Pair Trade Screener]({{ '/en/skills/pair-trade-screener/' | relative_url }})
+
+### Maximum Adverse Excursion (MAE)
+{: #mae }
+
+Maximum Adverse Excursion is the largest unrealized move against a position while it was open, measured from the entry. Reviewing MAE across comparable trades can show whether stops are too tight or losses are being allowed to grow, but it should not be optimized from a tiny sample.
+
+**Used by:** [Trader Memory Core]({{ '/en/skills/trader-memory-core/' | relative_url }})
+
+### Maximum Favorable Excursion (MFE)
+{: #mfe }
+
+Maximum Favorable Excursion is the largest unrealized move in a position's favor while it was open, measured from the entry. Comparing MFE with the realized result can help review exit execution without assuming that the best intratrade price was actually achievable.
+
+**Used by:** [Trader Memory Core]({{ '/en/skills/trader-memory-core/' | relative_url }})
+
+### Market Regime
+{: #market-regime }
+
+A market regime is a broad environment characterized by features such as trend, volatility, breadth, liquidity, and macro conditions. A process may use different exposure or setup rules in a stable uptrend than in a high-volatility decline.
+
+**Used by:** [Macro Regime Detector]({{ '/en/skills/macro-regime-detector/' | relative_url }})
+
+### Momentum
+{: #momentum }
+
+Momentum is the tendency for relatively strong or weak price movement to persist for some period. It can be measured over different horizons, so a stock may have strong short-term momentum while remaining weak on a longer-term basis.
+
+**Used by:** [Stockbee Momentum Burst Screener]({{ '/en/skills/stockbee-momentum-burst-screener/' | relative_url }})
+
+### Post-Earnings Announcement Drift (PEAD)
+{: #pead }
+
+Post-Earnings Announcement Drift is the documented tendency for prices to continue moving in the direction of an earnings surprise after the initial announcement. A PEAD setup still needs defined eligibility, entry, liquidity, and invalidation rules because not every earnings move persists.
+
+**Used by:** [PEAD Screener]({{ '/en/skills/pead-screener/' | relative_url }})
+
+### Position Sizing
+{: #position-sizing }
+
+Position sizing determines how many shares, contracts, or dollars to allocate to a trade. Risk-based sizing starts with the amount the portfolio can lose and the distance to the invalidation or stop level, rather than choosing size from conviction alone.
+
+**Used by:** [Position Sizer]({{ '/en/skills/position-sizer/' | relative_url }})
+
+### Pullback
+{: #pullback }
+
+A pullback is a temporary move against the direction of a prevailing trend, such as a decline within an uptrend. It may offer a planned entry area, but it can also be the start of a reversal, so trend quality and invalidation levels remain important.
+
+**Used by:** [Dividend Growth Pullback Screener]({{ '/en/skills/dividend-growth-pullback-screener/' | relative_url }})
+
+### R-Multiple
+{: #r-multiple }
+
+An R-multiple expresses a trade result relative to its initial planned risk, where +2R means a gain twice the initial risk and -1R means the planned risk was lost. It makes results more comparable across trades of different sizes, provided the initial risk was recorded consistently.
+
+**Used by:** [Weekly Performance Digest]({{ '/en/skills/weekly-performance-digest/' | relative_url }})
+
+### Relative Strength
+{: #relative-strength }
+
+Relative strength compares an instrument's performance with a benchmark or peer group over a chosen period. It is different from the Relative Strength Index (RSI): relative strength is a comparison, while RSI is a bounded momentum oscillator.
+
+**Used by:** [CANSLIM Screener]({{ '/en/skills/canslim-screener/' | relative_url }})
+
+### Risk-On / Risk-Off
+{: #risk-on-risk-off }
+
+Risk-on describes conditions in which investors broadly favor assets perceived as more sensitive to growth or market risk, while risk-off describes a shift toward capital preservation and defensive assets. These labels summarize cross-market behavior and are not binary forecasts.
+
+**Used by:** [Market Environment Analysis]({{ '/en/skills/market-environment-analysis/' | relative_url }})
+
+### Relative Strength Index (RSI)
+{: #rsi }
+
+The Relative Strength Index is a momentum oscillator typically scaled from 0 to 100 using the balance of recent gains and losses. Thresholds such as 70 or 30 describe the calculation's recent extreme, not an automatic instruction to sell or buy.
+
+**Used by:** [Dividend Growth Pullback Screener]({{ '/en/skills/dividend-growth-pullback-screener/' | relative_url }})
+
+### Stop-Loss
+{: #stop-loss }
+
+A stop-loss is a predefined price or condition for exiting when a trade no longer fits its plan. It limits intended risk but cannot guarantee the exact exit price during gaps, fast markets, or insufficient liquidity.
+
+**Used by:** [Breakout Trade Planner]({{ '/en/skills/breakout-trade-planner/' | relative_url }})
+
+### Support and Resistance
+{: #support-resistance }
+
+Support is an area where buying has previously absorbed selling, while resistance is an area where selling has previously absorbed buying. They are zones inferred from market behavior rather than permanent price barriers.
+
+**Used by:** [Technical Analyst]({{ '/en/skills/technical-analyst/' | relative_url }})
+
+### Thesis and Invalidation
+{: #thesis-invalidation }
+
+A trade thesis states why an opportunity should work and which observable evidence supports it; invalidation states what evidence would show that the reasoning is no longer acceptable. Writing both before entry makes later review less vulnerable to hindsight and shifting explanations.
+
+**Used by:** [Trader Memory Core]({{ '/en/skills/trader-memory-core/' | relative_url }})
+
+### Volatility
+{: #volatility }
+
+Volatility describes the magnitude and variability of price changes, not their direction. Higher volatility usually means a wider range of possible outcomes and may require smaller positions or wider risk limits to keep portfolio risk comparable.
+
+**Used by:** [Position Sizer]({{ '/en/skills/position-sizer/' | relative_url }})
+
+### Volatility Contraction Pattern (VCP)
+{: #vcp }
+
+A Volatility Contraction Pattern is a price structure in which successive pullbacks become smaller while supply appears to diminish near a potential pivot. It is a setup framework associated with Mark Minervini, not proof that a breakout will succeed.
+
+**Used by:** [VCP Screener]({{ '/en/skills/vcp-screener/' | relative_url }})
+
+### Z-Score
+{: #z-score }
+
+A z-score expresses how far a current value is from a historical mean in units of standard deviation. In spread analysis it helps describe unusual divergence, but its interpretation depends on a sufficiently stable distribution and lookback period.
+
+**Used by:** [Pair Trade Screener]({{ '/en/skills/pair-trade-screener/' | relative_url }})

--- a/docs/en/playbooks/index.md
+++ b/docs/en/playbooks/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Playbooks
 parent: English
-nav_order: 7
+nav_order: 8
 has_children: true
 lang_peer: /ja/playbooks/
 permalink: /en/playbooks/

--- a/docs/ja/find-your-workflow.md
+++ b/docs/ja/find-your-workflow.md
@@ -104,6 +104,7 @@ FMP / FINVIZ / Alpaca の有料サブスクをまだ持っていない場合は�
 ## 関連ページ
 
 - [はじめに](getting-started.md) — Claude Code / Claude ウェブアプリ / CLI 向けインストール手順
+- [用語集]({{ '/ja/glossary/' | relative_url }}) — ワークフローで使うトレード用語の平易な説明
 - [スキル一覧](skill-catalog.md) — 全スキルのアルファベット順カタログ
 - [ワークフロー](workflows.md) — 全ワークフローの自動生成 manifest リファレンス
 - [スキルセット](skillsets.md) — 目的別インストールバンドル

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -13,6 +13,8 @@ permalink: /ja/getting-started/
 Claude Trading Skillsのインストール方法、APIキーの設定、最初のスキル実行までをガイドします。
 {: .fs-6 .fw-300 }
 
+以下に出てくるトレード用語が初めての場合は、平易な説明をまとめた[用語集]({{ '/ja/glossary/' | relative_url }})を参照してください。
+
 <details open markdown="block">
   <summary>目次</summary>
   {: .text-delta }

--- a/docs/ja/glossary.md
+++ b/docs/ja/glossary.md
@@ -1,0 +1,277 @@
+---
+layout: default
+title: 用語集
+parent: 日本語
+nav_order: 7
+lang_peer: /en/glossary/
+permalink: /ja/glossary/
+---
+
+# 用語集
+{: .no_toc }
+
+Claude Trading Skills 全体で使うトレード用語を、初めての方向けに説明します。ここでの定義は語彙を理解するためのものであり、売買の推奨や将来成果の保証ではありません。
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>目次</summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+
+---
+
+## 用語一覧
+
+### ATR（Average True Range）
+{: #atr }
+
+ATR は、窓を開けた値動きも含め、指定した期間に価格が通常どの程度動くかを推定する指標です。方向ではなく値動きの大きさを測り、現在のボラティリティに応じてストップ幅やポジションリスクを調整するときに使います。
+
+**関連スキル:** [Position Sizer]({{ '/ja/skills/position-sizer/' | relative_url }})
+
+### ブレッドス（Breadth）
+{: #breadth }
+
+ブレッドスは、市場の値動きに構成銘柄がどの程度広く参加しているかを表します。多数の銘柄が上昇して支える指数高は、少数の大型株だけで上がる場合よりも裾野が広いと判断できます。
+
+**関連スキル:** [Market Breadth Analyzer]({{ '/ja/skills/market-breadth-analyzer/' | relative_url }})
+
+### ブレイクアウト（Breakout）
+{: #breakout }
+
+ブレイクアウトは、価格がレジスタンスや取引レンジ上限など、以前から重要だった境界を超えることです。境界を超えただけでは継続を保証しないため、通常は出来高、市場環境、失敗と判断する水準も併せて確認します。
+
+**関連スキル:** [Breakout Trade Planner]({{ '/ja/skills/breakout-trade-planner/' | relative_url }})
+
+### CANSLIM
+{: #canslim }
+
+CANSLIM は、Current quarterly earnings、Annual earnings growth、New、Supply and demand、Leader or laggard、Institutional sponsorship、Market direction の観点を組み合わせる成長株投資の枠組みです。企業業績だけでなく、価格・出来高・市場環境も評価します。
+
+**関連スキル:** [CANSLIM Screener]({{ '/ja/skills/canslim-screener/' | relative_url }})
+
+### カタリスト（Catalyst）
+{: #catalyst }
+
+カタリストは、決算、業績見通し、新製品、規制、経営陣の交代など、銘柄への期待を変え得る出来事や新情報です。値動きのきっかけにはなりますが、市場の反応が好意的か、長続きするかまでは決めません。
+
+**関連スキル:** [Stockbee Episodic Pivot Analyzer]({{ '/ja/skills/stockbee-episodic-pivot-analyzer/' | relative_url }})
+
+### コア・サテライト（Core + Satellite）
+{: #core-satellite }
+
+コア・サテライトは、長期・分散保有を担うコアと、より能動的または集中した機会に使う小さなサテライト枠を分けるポートフォリオ構成です。短期トレードが長期資産全体のリスク特性を知らないうちに変えることを防ぎやすくします。
+
+**関連スキル:** [Kanchi Dividend SOP]({{ '/ja/skills/kanchi-dividend-sop/' | relative_url }})
+
+### 相関（Correlation）
+{: #correlation }
+
+相関は、2つのリターン系列が過去にどの程度一緒に動いたかを、一般に -1 から +1 の範囲で要約します。相場環境によって変化し得る過去の関係であり、一方が他方を動かす因果関係を証明するものではありません。
+
+**関連スキル:** [Pair Trade Screener]({{ '/ja/skills/pair-trade-screener/' | relative_url }})
+
+### COT（Commitments of Traders）
+{: #cot }
+
+COT は、米国商品先物取引委員会（CFTC）が毎週公表する、商業ヘッジャーや運用業者などの区分別先物ポジション報告です。ポジションの偏りや混雑度を調べるために使い、通常は単独の売買タイミングではなく価格確認と組み合わせます。
+
+**関連スキル:** [COT Contrarian Detector]({{ '/ja/skills/cot-contrarian-detector/' | relative_url }})
+
+### ディストリビューション・デー（Distribution Day）
+{: #distribution-day }
+
+ディストリビューション・デーは一般に、主要指数が前日より多い出来高を伴って明確に下落した日を指します。直近で複数回重なると機関投資家の売り圧力を示す可能性がありますが、1日だけで市場全体を判断するものではありません。
+
+**関連スキル:** [IBD Distribution Day Monitor]({{ '/ja/skills/ibd-distribution-day-monitor/' | relative_url }})
+
+### ドローダウン（Drawdown）
+{: #drawdown }
+
+ドローダウンは、ポートフォリオや戦略がそれまでのピークからその後の安値まで下落した幅で、通常はパーセントで表します。損失局面の深さに加え、継続期間やピーク回復に必要な上昇率も併せて見る必要があります。
+
+**関連スキル:** [Drawdown Circuit Breaker]({{ '/ja/skills/drawdown-circuit-breaker/' | relative_url }})
+
+### エッジ（Edge）
+{: #edge }
+
+エッジは、同種の判断を多数繰り返したときに有利な結果が期待できる、情報・行動・分析・執行上の再現可能な優位性です。個々のトレードを確実に勝たせるものではなく、市場環境の変化で弱まる可能性がある検証対象の仮説です。
+
+**関連スキル:** [Edge Concept Synthesizer]({{ '/ja/skills/edge-concept-synthesizer/' | relative_url }})
+
+### エントリー（Entry）
+{: #entry }
+
+エントリーは、トレードを開始してよいと事前に定めた条件または価格帯です。実用的なルールでは、必要な証拠、許容するリスク、セットアップが無効になる条件も併せて定義します。
+
+**関連スキル:** [Breakout Trade Planner]({{ '/ja/skills/breakout-trade-planner/' | relative_url }})
+
+### エピソディック・ピボット（Episodic Pivot）
+{: #episodic-pivot }
+
+エピソディック・ピボットは、大幅な決算サプライズや業績見通し変更など、企業固有の重要イベントに伴う急激な価格・出来高変化です。期待の見直しから新しいトレンドが始まる可能性はありますが、流動性、フォロースルー、リスク上限は別途評価します。
+
+**関連スキル:** [Stockbee Episodic Pivot Analyzer]({{ '/ja/skills/stockbee-episodic-pivot-analyzer/' | relative_url }})
+
+### 期待値（Expectancy）
+{: #expectancy }
+
+期待値は、十分な件数のトレードを通じて、1回当たり平均でどの程度の利益または損失が見込まれるかを表します。代表的な計算は勝率と平均利益の積から敗率と平均損失の積を引きますが、次の1回の結果を予測するものではありません。
+
+**関連スキル:** [Weekly Performance Digest]({{ '/ja/skills/weekly-performance-digest/' | relative_url }})
+
+### エクスポージャー（Exposure）
+{: #exposure }
+
+エクスポージャーは、市場の値動きにさらされるポートフォリオ資本の量で、通常は純資産に対する割合としてロング、ショート、グロス、ネットに分けて表します。ポジション時価だけではレバレッジを隠すことがあるため、分母と符号の定義が重要です。
+
+**関連スキル:** [Exposure Coach]({{ '/ja/skills/exposure-coach/' | relative_url }})
+
+### フォロースルー・デー（Follow-Through Day / FTD）
+{: #ftd }
+
+フォロースルー・デーは、相場の安値候補の後に主要指数が出来高増を伴って大きく上昇した日で、一部の成長株投資法では上昇に機関投資家の支えが加わり始めた証拠として使います。確認条件の一つであり、上昇継続の保証ではありません。
+
+**関連スキル:** [FTD Detector]({{ '/ja/skills/ftd-detector/' | relative_url }})
+
+### ギャップ（Gap）
+{: #gap }
+
+ギャップは、前の取引セッションの価格帯と次のセッション開始時の価格帯との間に、ほとんど売買されていない空白が生じることです。新情報を反映する場合が多い一方、実務上の意味は大きさ、出来高、発生位置、その後の値動きで変わります。
+
+**関連スキル:** [Earnings Trade Analyzer]({{ '/ja/skills/earnings-trade-analyzer/' | relative_url }})
+
+### ヘッジ比率（Hedge Ratio）
+{: #hedge-ratio }
+
+ヘッジ比率は、市場リスクやスプレッドリスクなど、特定のリスクを減らすために一方の銘柄へもう一方をどれだけ組み合わせるかを示します。ペアトレードでは過去価格から推定することが多いものの、推定誤差や関係変化による残存リスクがあります。
+
+**関連スキル:** [Pair Trade Screener]({{ '/ja/skills/pair-trade-screener/' | relative_url }})
+
+### 流動性（Liquidity）
+{: #liquidity }
+
+流動性は、希望する数量を価格へ大きな影響を与えずに売買できる程度を表します。出来高、売買スプレッド、板の厚さが手掛かりになりますが、急変時や通常時間外には低下することがあります。
+
+**関連スキル:** [Pair Trade Screener]({{ '/ja/skills/pair-trade-screener/' | relative_url }})
+
+### 最大逆行幅（Maximum Adverse Excursion / MAE）
+{: #mae }
+
+MAE は、ポジション保有中にエントリーから最も不利な方向へ動いた未実現幅です。同種トレードの MAE を振り返ると、ストップが狭すぎるか、損失を拡大させているかを検討できますが、少数事例だけに最適化すべきではありません。
+
+**関連スキル:** [Trader Memory Core]({{ '/ja/skills/trader-memory-core/' | relative_url }})
+
+### 最大順行幅（Maximum Favorable Excursion / MFE）
+{: #mfe }
+
+MFE は、ポジション保有中にエントリーから最も有利な方向へ動いた未実現幅です。実現結果と比べることで出口執行を振り返れますが、保有中の最良価格で実際に約定できたと仮定してはいけません。
+
+**関連スキル:** [Trader Memory Core]({{ '/ja/skills/trader-memory-core/' | relative_url }})
+
+### 市場レジーム（Market Regime）
+{: #market-regime }
+
+市場レジームは、トレンド、ボラティリティ、ブレッドス、流動性、マクロ環境などで特徴付けられる広い相場環境です。安定した上昇局面と高ボラティリティの下落局面では、同じプロセスでもエクスポージャーやセットアップ規則を変えることがあります。
+
+**関連スキル:** [Macro Regime Detector]({{ '/ja/skills/macro-regime-detector/' | relative_url }})
+
+### モメンタム（Momentum）
+{: #momentum }
+
+モメンタムは、相対的に強いまたは弱い価格変化が一定期間続く傾向です。測定期間によって結果が変わるため、短期モメンタムが強い銘柄でも長期では弱い場合があります。
+
+**関連スキル:** [Stockbee Momentum Burst Screener]({{ '/ja/skills/stockbee-momentum-burst-screener/' | relative_url }})
+
+### 決算発表後ドリフト（Post-Earnings Announcement Drift / PEAD）
+{: #pead }
+
+PEAD は、決算サプライズ後に価格が最初の反応と同じ方向へ動き続ける傾向として研究されている現象です。すべての決算反応が継続するわけではないため、適格条件、エントリー、流動性、無効化ルールを明確にする必要があります。
+
+**関連スキル:** [PEAD Screener]({{ '/ja/skills/pead-screener/' | relative_url }})
+
+### ポジションサイジング（Position Sizing）
+{: #position-sizing }
+
+ポジションサイジングは、トレードに割り当てる株数、契約数、金額を決めることです。リスク基準の方法では、確信度だけで数量を決めず、ポートフォリオが許容できる損失額と無効化またはストップまでの距離から計算します。
+
+**関連スキル:** [Position Sizer]({{ '/ja/skills/position-sizer/' | relative_url }})
+
+### プルバック（Pullback）
+{: #pullback }
+
+プルバックは、上昇トレンド中の下落など、優勢なトレンドと一時的に反対方向へ動くことです。計画的なエントリー機会になり得ますが、反転の始まりである可能性もあるため、トレンドの質と無効化水準が重要です。
+
+**関連スキル:** [Dividend Growth Pullback Screener]({{ '/ja/skills/dividend-growth-pullback-screener/' | relative_url }})
+
+### R倍数（R-Multiple）
+{: #r-multiple }
+
+R倍数は、トレード結果を当初計画したリスクに対する比率で表し、+2R は初期リスクの2倍の利益、-1R は計画したリスク分の損失を意味します。初期リスクを一貫して記録すれば、異なるサイズのトレードを比較しやすくなります。
+
+**関連スキル:** [Weekly Performance Digest]({{ '/ja/skills/weekly-performance-digest/' | relative_url }})
+
+### 相対強度（Relative Strength）
+{: #relative-strength }
+
+相対強度は、選んだ期間における銘柄の成績をベンチマークや同業群と比較します。Relative Strength Index（RSI）とは別物で、相対強度は比較、RSI は一定範囲内のモメンタム・オシレーターです。
+
+**関連スキル:** [CANSLIM Screener]({{ '/ja/skills/canslim-screener/' | relative_url }})
+
+### リスクオン／リスクオフ（Risk-On / Risk-Off）
+{: #risk-on-risk-off }
+
+リスクオンは投資家が成長や市場リスクへの感応度が高い資産を広く選好する状態、リスクオフは資本保全や防御的資産へ傾く状態を表します。市場横断の動きを要約する呼び方であり、二者択一の予測ではありません。
+
+**関連スキル:** [Market Environment Analysis]({{ '/ja/skills/market-environment-analysis/' | relative_url }})
+
+### RSI（Relative Strength Index）
+{: #rsi }
+
+RSI は、直近の上昇幅と下落幅のバランスから計算し、通常は 0 から 100 で表すモメンタム・オシレーターです。70 や 30 といった水準は最近の計算上の極端さを示すもので、自動的な売買指示ではありません。
+
+**関連スキル:** [Dividend Growth Pullback Screener]({{ '/ja/skills/dividend-growth-pullback-screener/' | relative_url }})
+
+### ストップロス（Stop-Loss）
+{: #stop-loss }
+
+ストップロスは、トレードが計画に合わなくなったときに退出するため、事前に定める価格または条件です。意図したリスクを制限しますが、ギャップ、急変相場、流動性不足では想定価格での退出を保証できません。
+
+**関連スキル:** [Breakout Trade Planner]({{ '/ja/skills/breakout-trade-planner/' | relative_url }})
+
+### サポートとレジスタンス（Support and Resistance）
+{: #support-resistance }
+
+サポートは過去に買いが売りを吸収した価格帯、レジスタンスは売りが買いを吸収した価格帯です。市場行動から推定するゾーンであり、永久に価格を止める壁ではありません。
+
+**関連スキル:** [Technical Analyst]({{ '/ja/skills/technical-analyst/' | relative_url }})
+
+### 仮説と無効化（Thesis and Invalidation）
+{: #thesis-invalidation }
+
+トレード仮説は機会が機能すると考える理由と観察可能な根拠を示し、無効化条件はその理由を受け入れられなくなる証拠を示します。両方をエントリー前に書くことで、後知恵や説明のすり替えを減らせます。
+
+**関連スキル:** [Trader Memory Core]({{ '/ja/skills/trader-memory-core/' | relative_url }})
+
+### ボラティリティ（Volatility）
+{: #volatility }
+
+ボラティリティは、価格変化の大きさとばらつきを表し、方向は示しません。ボラティリティが高いほど結果の振れ幅が広がるため、ポートフォリオリスクを同程度に保つには数量を減らすか、リスク幅を広げる必要がある場合があります。
+
+**関連スキル:** [Position Sizer]({{ '/ja/skills/position-sizer/' | relative_url }})
+
+### VCP（Volatility Contraction Pattern）
+{: #vcp }
+
+VCP は、潜在的なピボット付近で供給が減るように見え、連続するプルバックが徐々に小さくなる価格構造です。Mark Minervini と関連するセットアップの枠組みであり、ブレイクアウト成功の証明ではありません。
+
+**関連スキル:** [VCP Screener]({{ '/ja/skills/vcp-screener/' | relative_url }})
+
+### Zスコア（Z-Score）
+{: #z-score }
+
+Zスコアは、現在値が過去平均から標準偏差何個分離れているかを表します。スプレッド分析では異常な乖離の大きさを示しますが、十分に安定した分布と適切な参照期間が前提です。
+
+**関連スキル:** [Pair Trade Screener]({{ '/ja/skills/pair-trade-screener/' | relative_url }})

--- a/docs/ja/playbooks/index.md
+++ b/docs/ja/playbooks/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: プレイブック
 parent: 日本語
-nav_order: 7
+nav_order: 8
 has_children: true
 lang_peer: /en/playbooks/
 permalink: /ja/playbooks/

--- a/scripts/tests/test_glossary_docs.py
+++ b/scripts/tests/test_glossary_docs.py
@@ -1,0 +1,150 @@
+"""Contract tests for the hand-maintained bilingual glossary."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+GLOSSARY_PATHS = {
+    "en": PROJECT_ROOT / "docs" / "en" / "glossary.md",
+    "ja": PROJECT_ROOT / "docs" / "ja" / "glossary.md",
+}
+TERM_PATTERN = re.compile(
+    r"^### (?P<heading>[^\n]+)\n"
+    r"\{:\s+#(?P<term_id>[a-z0-9-]+)\s+\}\n\n"
+    r"(?P<definition>[^\n]+)\n\n"
+    r"\*\*(?:Used by|関連スキル):\*\* (?P<used_by>[^\n]+)$",
+    re.MULTILINE,
+)
+SKILL_LINK_PATTERN = re.compile(
+    r"\[[^\]]+\]\(\{\{ '/(?P<lang>en|ja)/skills/"
+    r"(?P<slug>[a-z0-9-]+)/' \| relative_url \}\}\)"
+)
+REQUIRED_TERM_IDS = {
+    "breadth",
+    "canslim",
+    "core-satellite",
+    "episodic-pivot",
+    "expectancy",
+    "ftd",
+    "mae",
+    "mfe",
+    "pead",
+    "r-multiple",
+    "vcp",
+}
+
+
+@dataclass(frozen=True)
+class GlossaryTerm:
+    heading: str
+    term_id: str
+    definition: str
+    used_by: str
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _frontmatter(path: Path) -> dict[str, object]:
+    text = _read(path)
+    match = re.match(r"\A---\n(?P<yaml>.*?)\n---\n", text, re.DOTALL)
+    assert match is not None, f"{path} is missing YAML frontmatter"
+    parsed = yaml.safe_load(match.group("yaml"))
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def _terms(path: Path) -> list[GlossaryTerm]:
+    return [GlossaryTerm(**match.groupdict()) for match in TERM_PATTERN.finditer(_read(path))]
+
+
+def test_glossaries_have_matching_complete_term_structure() -> None:
+    texts = {lang: _read(path) for lang, path in GLOSSARY_PATHS.items()}
+    terms = {lang: _terms(path) for lang, path in GLOSSARY_PATHS.items()}
+
+    assert "## Terms" in texts["en"]
+    assert "## 用語一覧" in texts["ja"]
+    assert len(terms["en"]) >= 30
+    assert [term.term_id for term in terms["en"]] == [term.term_id for term in terms["ja"]]
+
+    for lang, language_terms in terms.items():
+        term_ids = [term.term_id for term in language_terms]
+        heading_count = len(re.findall(r"^### ", texts[lang], re.MULTILINE))
+        assert heading_count == len(language_terms), f"{lang} has a malformed glossary term"
+        assert len(term_ids) == len(set(term_ids)), f"duplicate {lang} term ID"
+        assert REQUIRED_TERM_IDS <= set(term_ids), f"{lang} is missing a required beginner term"
+        for term in language_terms:
+            assert len(term.definition.strip()) >= 30, (
+                f"{lang}:{term.term_id} needs a plain-language definition"
+            )
+
+
+def test_each_term_links_to_matching_existing_skill_guides() -> None:
+    terms = {lang: _terms(path) for lang, path in GLOSSARY_PATHS.items()}
+    by_id = {
+        lang: {term.term_id: term for term in language_terms}
+        for lang, language_terms in terms.items()
+    }
+
+    for term_id in by_id["en"]:
+        slugs_by_lang: dict[str, set[str]] = {}
+        for lang in ("en", "ja"):
+            used_by = by_id[lang][term_id].used_by
+            links = list(SKILL_LINK_PATTERN.finditer(used_by))
+            assert links, f"{lang}:{term_id} needs at least one skill link"
+            assert len(links) == used_by.count("]("), (
+                f"{lang}:{term_id} contains a non-canonical skill link"
+            )
+
+            slugs_by_lang[lang] = set()
+            for link in links:
+                assert link.group("lang") == lang
+                slug = link.group("slug")
+                slugs_by_lang[lang].add(slug)
+                assert (PROJECT_ROOT / "docs" / lang / "skills" / f"{slug}.md").is_file(), (
+                    f"{lang}:{term_id} links to missing skill {slug}"
+                )
+
+        assert slugs_by_lang["en"] == slugs_by_lang["ja"], (
+            f"{term_id} has different EN/JA skill links"
+        )
+
+
+def test_glossary_frontmatter_and_navigation_are_reciprocal() -> None:
+    expected = {
+        "en": {
+            "title": "Glossary",
+            "parent": "English",
+            "nav_order": 7,
+            "lang_peer": "/ja/glossary/",
+            "permalink": "/en/glossary/",
+        },
+        "ja": {
+            "title": "用語集",
+            "parent": "日本語",
+            "nav_order": 7,
+            "lang_peer": "/en/glossary/",
+            "permalink": "/ja/glossary/",
+        },
+    }
+    for lang, path in GLOSSARY_PATHS.items():
+        frontmatter = _frontmatter(path)
+        for key, value in expected[lang].items():
+            assert frontmatter[key] == value
+
+        playbooks = _frontmatter(PROJECT_ROOT / "docs" / lang / "playbooks" / "index.md")
+        assert playbooks["nav_order"] == 8
+
+
+def test_beginner_pages_link_to_the_localized_glossary() -> None:
+    for lang in ("en", "ja"):
+        expected_link = f"{{{{ '/{lang}/glossary/' | relative_url }}}}"
+        for filename in ("getting-started.md", "find-your-workflow.md"):
+            page = PROJECT_ROOT / "docs" / lang / filename
+            assert expected_link in _read(page), f"{page} does not link to the localized glossary"


### PR DESCRIPTION
## Summary

- add matching English and Japanese glossaries with 36 plain-language trading terms
- link every term to an existing skill that uses the concept and keep EN/JA term IDs and skill slugs in parity
- add glossary navigation from Getting Started and Find Your Workflow, and reserve a distinct docs nav position
- add contract tests for required terms, bilingual structure, canonical Jekyll URLs, link targets, and navigation

## Validation

- `uv run --extra dev bash scripts/run_all_tests.sh` — 69/69 matrix rows passed
- `python3 -m pytest -q scripts/tests` — 430 passed
- Ruff, codespell, metadata validators, package checks, and all documentation drift checks passed
- local Jekyll build was not run because the required gems were not installed; source-level tests verify canonical generated URL syntax and target pages

Closes #200
