### PR TITLE
docs: add deterministic core workflow samples

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -43,10 +43,10 @@ English README is available at [`README.md`](README.md).
 | 目的 | ワークフロー | 主要スキル | API プロファイル |
 | --- | --- | --- | --- |
 | 毎朝15分で相場を確認したい | [`market-regime-daily`](workflows/market-regime-daily.yaml) | market-breadth-analyzer, uptrend-analyzer, exposure-coach | API なし可 |
-| 長期ポートフォリオを週次で見直したい | [`core-portfolio-weekly`](workflows/core-portfolio-weekly.yaml) | portfolio-manager, kanchi-dividend-review-monitor, trader-memory-core | Alpaca 必須。手動 CSV は劣後フォールバック |
-| 相場環境が許すときだけスイング候補を探す | [`swing-opportunity-daily`](workflows/swing-opportunity-daily.yaml) | vcp-screener, drawdown-circuit-breaker, technical-analyst, position-sizer, trader-memory-core, pre-trade-discipline-gate | FMP 必須。リスク/規律ゲートはローカル state |
+| 長期ポートフォリオを週次で見直したい | [`core-portfolio-weekly`](workflows/core-portfolio-weekly.yaml)（[実行例](examples/workflows/core-portfolio-weekly/sample-run/)） | portfolio-manager, kanchi-dividend-review-monitor, trader-memory-core | Alpaca 必須。手動 CSV は劣後フォールバック |
+| 相場環境が許すときだけスイング候補を探す | [`swing-opportunity-daily`](workflows/swing-opportunity-daily.yaml)（[実行例](examples/workflows/swing-opportunity-daily/sample-run/)） | vcp-screener, drawdown-circuit-breaker, technical-analyst, position-sizer, trader-memory-core, pre-trade-discipline-gate | FMP 必須。リスク/規律ゲートはローカル state |
 | 約定後にトレードを記録して学ぶ | [`trade-memory-loop`](workflows/trade-memory-loop.yaml) | trader-memory-core, signal-postmortem | API なし可 |
-| 月次でパフォーマンスとルールを見直す | [`monthly-performance-review`](workflows/monthly-performance-review.yaml) | trader-memory-core, signal-postmortem, backtest-expert | API なし可 |
+| 月次でパフォーマンスとルールを見直す | [`monthly-performance-review`](workflows/monthly-performance-review.yaml)（[実行例](examples/workflows/monthly-performance-review/sample-run/)） | trader-memory-core, signal-postmortem, backtest-expert | API なし可 |
 
 manifest の読み方や手動実行手順は [`workflows/README.md`](workflows/README.md) を参照してください。「自分の状況にどのワークフローが合うか」を 1 ページで知りたい場合は [ワークフローの選び方](docs/ja/find-your-workflow.md)（[English](docs/en/find-your-workflow.md)）を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ New users should start with one of these operational workflows. Each link points
 | Goal | Workflow | Anchor Skills | API Profile |
 | --- | --- | --- | --- |
 | 15-minute daily market check | [`market-regime-daily`](workflows/market-regime-daily.yaml) | market-breadth-analyzer, uptrend-analyzer, exposure-coach | No API for basic path |
-| Weekly long-term portfolio review | [`core-portfolio-weekly`](workflows/core-portfolio-weekly.yaml) | portfolio-manager, kanchi-dividend-review-monitor, trader-memory-core | Alpaca required; manual CSV is a degraded fallback |
-| Find swing candidates only when risk is allowed | [`swing-opportunity-daily`](workflows/swing-opportunity-daily.yaml) | vcp-screener, drawdown-circuit-breaker, technical-analyst, position-sizer, trader-memory-core, pre-trade-discipline-gate | FMP for screeners; local state for risk and discipline gates |
+| Weekly long-term portfolio review | [`core-portfolio-weekly`](workflows/core-portfolio-weekly.yaml) ([sample](examples/workflows/core-portfolio-weekly/sample-run/)) | portfolio-manager, kanchi-dividend-review-monitor, trader-memory-core | Alpaca required; manual CSV is a degraded fallback |
+| Find swing candidates only when risk is allowed | [`swing-opportunity-daily`](workflows/swing-opportunity-daily.yaml) ([sample](examples/workflows/swing-opportunity-daily/sample-run/)) | vcp-screener, drawdown-circuit-breaker, technical-analyst, position-sizer, trader-memory-core, pre-trade-discipline-gate | FMP for screeners; local state for risk and discipline gates |
 | Record and learn from every closed trade | [`trade-memory-loop`](workflows/trade-memory-loop.yaml) | trader-memory-core, signal-postmortem | No API for manual path |
-| Review monthly performance and adjust rules | [`monthly-performance-review`](workflows/monthly-performance-review.yaml) | trader-memory-core, signal-postmortem, backtest-expert | No API for manual path |
+| Review monthly performance and adjust rules | [`monthly-performance-review`](workflows/monthly-performance-review.yaml) ([sample](examples/workflows/monthly-performance-review/sample-run/)) | trader-memory-core, signal-postmortem, backtest-expert | No API for manual path |
 
 See [`workflows/README.md`](workflows/README.md) for how to read a manifest and run it manually. For a one-page "which workflow fits my situation?" guide, see [Find Your Workflow](docs/en/find-your-workflow.md) ([日本語](docs/ja/find-your-workflow.md)).
 

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -19,19 +19,39 @@ future fixture/replay harness can consume.
 |---|---|---|---|---|
 | [`market-regime-daily/sample-run/`](market-regime-daily/sample-run/) | [`market-regime-daily.yaml`](../../workflows/market-regime-daily.yaml) | daily | required-only | market-breadth-analyzer → uptrend-analyzer → exposure-coach |
 | [`market-regime-daily/sample-run-full-path/`](market-regime-daily/sample-run-full-path/) | same | daily | **full-path** | + optional market-top-detector at step 3 |
+| [`core-portfolio-weekly/sample-run/`](core-portfolio-weekly/sample-run/) | [`core-portfolio-weekly.yaml`](../../workflows/core-portfolio-weekly.yaml) | weekly | required-only | portfolio-manager → trader-memory-core |
+| [`core-portfolio-weekly/sample-run-full-path/`](core-portfolio-weekly/sample-run-full-path/) | same | weekly | **full-path** | + optional kanchi-dividend-review-monitor at step 3 |
+| [`swing-opportunity-daily/sample-run/`](swing-opportunity-daily/sample-run/) | [`swing-opportunity-daily.yaml`](../../workflows/swing-opportunity-daily.yaml) | daily | required-only | circuit breaker → VCP → chart validation → sizing → journal → discipline gate |
+| [`swing-opportunity-daily/sample-run-full-path/`](swing-opportunity-daily/sample-run-full-path/) | same | daily | **full-path** | + all five optional candidate/plan steps |
 | [`trade-memory-loop/sample-run/`](trade-memory-loop/sample-run/) | [`trade-memory-loop.yaml`](../../workflows/trade-memory-loop.yaml) | per closed trade | required-only | trader-memory-core → signal-postmortem → trader-memory-core |
 | [`trade-memory-loop/sample-run-full-path/`](trade-memory-loop/sample-run-full-path/) | same | per closed trade | **full-path** | + optional backtest-expert at step 3 |
+| [`monthly-performance-review/sample-run/`](monthly-performance-review/sample-run/) | [`monthly-performance-review.yaml`](../../workflows/monthly-performance-review.yaml) | monthly | required-only | trader-memory-core → signal-postmortem → trader-memory-core |
+| [`monthly-performance-review/sample-run-full-path/`](monthly-performance-review/sample-run-full-path/) | same | monthly | **full-path** | + coaching, backtest, skill review, and improvement backlog |
 
-Each workflow ships two sample variants:
+The three samples added for `core-portfolio-weekly`,
+`swing-opportunity-daily`, and `monthly-performance-review` use this strict
+variant contract:
 
-- **`sample-run/` (required-only)** — exercises just the required steps. The
-  one optional step in each workflow is intentionally skipped and documented
-  in that example's `manifest.yaml` (`optional_steps_skipped`).
-- **`sample-run-full-path/` (full-path)** — runs the optional step too, so
-  every step in the workflow manifest is exercised. For `market-regime-daily`
-  this also strips the top-level `*_score` workflow hand-off fields from the
-  upstream fixtures so the sample exercises the **nested-shape parser** in
-  `exposure-coach` directly (see the "Artifact convention" note below).
+- **`sample-run/` (required-only)** — includes every artifact declared
+  `required: true` and records every optional workflow step in
+  `optional_steps_skipped`.
+- **`sample-run-full-path/` (full-path)** — runs every workflow step and
+  includes every declared artifact, including optional artifacts emitted by a
+  required step.
+
+The older `market-regime-daily` and `trade-memory-loop` examples predate this
+strict coverage contract and retain their historical fixture layouts.
+`market-regime-daily/sample-run-full-path/` also strips the top-level
+`*_score` workflow hand-off fields from the upstream fixtures so the sample
+exercises the **nested-shape parser** in `exposure-coach` directly (see the
+"Artifact convention" note below).
+
+Every sample is a static teaching fixture. Fixed dates and explicitly fictional
+symbols/accounts make the calculations reproducible. They contain no broker
+credentials, real account data, order submission, or investment advice.
+`swing-opportunity-daily` also carries a self-contained, non-restrictive
+`market-regime-daily` prerequisite artifact; the sample stops at the manual
+pre-trade discipline gate.
 
 ## Artifact convention: `raw-plus-handoff`
 
@@ -61,11 +81,13 @@ post-PR-#137 `exposure-coach` extractors over them reproduces the scores in
 unchanged (raw-plus-handoff convention preserved) as a reference for
 workflows that already produce both shapes.
 
-## Coupling
+## Validation and coupling
 
-These files are intentionally **decoupled** from the generated-docs / drift-gate
-machinery: no generator, validator, snapshot builder, catalog, CI metadata
-job, or pytest path reads `examples/`. Editing or extending them cannot cause
-catalog/snapshot/docs drift. (They are still subject to the standard
-hygiene pre-commit hooks — whitespace, YAML syntax, `detect-secrets`,
-`no-absolute-paths`, etc.)
+These files remain **decoupled** from generated docs, catalogs, snapshots,
+skill packages, and workflow generation. A focused pytest contract covers the
+three strict samples above: manifest/workflow parity, optional-step coverage,
+safe relative paths, schema/business invariants where available, and
+cross-artifact arithmetic. The historical examples are not silently rewritten
+by that contract. All files also remain subject to standard hygiene hooks
+(whitespace, YAML syntax, `detect-secrets`, `no-absolute-paths`, and related
+checks).

--- a/examples/workflows/core-portfolio-weekly/README.md
+++ b/examples/workflows/core-portfolio-weekly/README.md
@@ -1,0 +1,24 @@
+# Example: `core-portfolio-weekly`
+
+Two deterministic teaching runs for the
+[`core-portfolio-weekly`](../../../workflows/core-portfolio-weekly.yaml)
+workflow. Both use the same fixed, fictional `$100,000` account and stop before
+any broker action.
+
+> **Illustrative only — not investment advice.** `FICTA`, `FICTB`, and `FICTC`
+> are invented symbols. The account, holdings, prices, and recommendations are
+> hand-authored fixtures; they are not real brokerage data.
+
+| Variant | Optional dividend review | Outcome |
+|---|---|---|
+| [`sample-run/`](sample-run/) | skipped | Trim 50 fictional `FICTA` shares to restore the 25% target and retain 15% cash |
+| [`sample-run-full-path/`](sample-run-full-path/) | included | Same rebalance, plus a T2 `WARN` that pauses optional adds to fictional `FICTC` |
+
+The required-only variant contains only artifacts marked `required: true` in
+the workflow manifest. The full-path variant also runs
+`kanchi-dividend-review-monitor` and includes its optional artifact.
+
+Each `manifest.yaml` maps workflow steps and artifact IDs to files. The
+holdings, allocation, rebalance plan, and journal entry use identical values so
+the focused contract test can recompute totals and detect hand-off drift.
+Nothing here places or schedules an order.

--- a/examples/workflows/core-portfolio-weekly/sample-run-full-path/01_holdings_snapshot.json
+++ b/examples/workflows/core-portfolio-weekly/sample-run-full-path/01_holdings_snapshot.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-27",
+  "source": "fictional_manual_snapshot",
+  "account": {
+    "account_id": "SIM-****-208",
+    "status": "ACTIVE",
+    "equity": 100000.0,
+    "cash": 10000.0,
+    "long_market_value": 90000.0,
+    "buying_power": 10000.0
+  },
+  "positions": [
+    {
+      "symbol": "FICTA",
+      "quantity": 300,
+      "current_price": 100.0,
+      "market_value": 30000.0,
+      "portfolio_weight_pct": 30.0,
+      "sector": "Fictional Technology"
+    },
+    {
+      "symbol": "FICTB",
+      "quantity": 400,
+      "current_price": 75.0,
+      "market_value": 30000.0,
+      "portfolio_weight_pct": 30.0,
+      "sector": "Fictional Healthcare"
+    },
+    {
+      "symbol": "FICTC",
+      "quantity": 600,
+      "current_price": 50.0,
+      "market_value": 30000.0,
+      "portfolio_weight_pct": 30.0,
+      "sector": "Fictional Consumer Staples"
+    }
+  ],
+  "warnings": [
+    "Fictional teaching fixture; verify every holding against the real broker before acting."
+  ]
+}

--- a/examples/workflows/core-portfolio-weekly/sample-run-full-path/02_allocation_report.json
+++ b/examples/workflows/core-portfolio-weekly/sample-run-full-path/02_allocation_report.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-27",
+  "portfolio_value": 100000.0,
+  "allocation": [
+    {"bucket": "FICTA", "current_pct": 30.0, "target_pct": 25.0, "variance_pct": 5.0},
+    {"bucket": "FICTB", "current_pct": 30.0, "target_pct": 30.0, "variance_pct": 0.0},
+    {"bucket": "FICTC", "current_pct": 30.0, "target_pct": 30.0, "variance_pct": 0.0},
+    {"bucket": "CASH", "current_pct": 10.0, "target_pct": 15.0, "variance_pct": -5.0}
+  ],
+  "allocation_total_pct": 100.0,
+  "largest_position": {"symbol": "FICTA", "weight_pct": 30.0},
+  "decision": "REBALANCE_PROPOSED",
+  "rationale": "Reduce the fictional FICTA allocation by five percentage points and restore the cash target."
+}

--- a/examples/workflows/core-portfolio-weekly/sample-run-full-path/02_allocation_report.md
+++ b/examples/workflows/core-portfolio-weekly/sample-run-full-path/02_allocation_report.md
@@ -1,0 +1,11 @@
+# Fictional Allocation Report
+
+- Portfolio value: **$100,000.00**
+- Current cash: **10.0%**
+- Allocation total: **100.0%**
+- Largest position: **FICTA at 30.0%**
+- Decision: **REBALANCE_PROPOSED**
+
+The teaching plan proposes trimming **50 FICTA shares** at the fixed reference
+price of **$100.00**, moving **$5,000.00** to cash. The dividend review also
+places **FICTC** in **WARN**; optional adds remain paused. No order is placed.

--- a/examples/workflows/core-portfolio-weekly/sample-run-full-path/03_dividend_monitor_input.json
+++ b/examples/workflows/core-portfolio-weekly/sample-run-full-path/03_dividend_monitor_input.json
@@ -1,0 +1,18 @@
+{
+  "as_of": "2026-06-27",
+  "holdings": [
+    {
+      "ticker": "FICTC",
+      "instrument_type": "stock",
+      "dividend": {
+        "latest_regular": 0.55,
+        "prior_regular": 0.50
+      },
+      "cashflow": {
+        "fcf": 80.0,
+        "dividends_paid": 85.0,
+        "coverage_ratio_history": [0.70, 0.78]
+      }
+    }
+  ]
+}

--- a/examples/workflows/core-portfolio-weekly/sample-run-full-path/03_dividend_review_findings.json
+++ b/examples/workflows/core-portfolio-weekly/sample-run-full-path/03_dividend_review_findings.json
@@ -1,0 +1,35 @@
+{
+  "generated_at": "2026-06-27T16:00:00+00:00",
+  "as_of": "2026-06-27",
+  "summary": {
+    "OK": 0,
+    "WARN": 1,
+    "REVIEW": 0
+  },
+  "results": [
+    {
+      "ticker": "FICTC",
+      "instrument_type": "stock",
+      "status": "WARN",
+      "actions": [
+        "pause_buy_adds_optional",
+        "append_next_earnings_checklist"
+      ],
+      "findings": [
+        {
+          "trigger": "T2",
+          "status": "WARN",
+          "reason": "Current period payout coverage ratio exceeds 1.0.",
+          "evidence": {
+            "instrument_type": "stock",
+            "denominator_key": "fcf",
+            "denominator_value": 80.0,
+            "dividends_paid": 85.0,
+            "coverage_ratio_history": [0.7, 0.78],
+            "current_ratio": 1.0625
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/examples/workflows/core-portfolio-weekly/sample-run-full-path/04_rebalance_actions.yaml
+++ b/examples/workflows/core-portfolio-weekly/sample-run-full-path/04_rebalance_actions.yaml
@@ -1,0 +1,22 @@
+schema_version: "1.0"
+as_of: "2026-06-27"
+decision: PROPOSED_MANUAL_ACTIONS
+dividend_review:
+  status: WARN
+  symbol: FICTC
+  trigger: T2
+  response: PAUSE_OPTIONAL_ADDS_PENDING_HUMAN_REVIEW
+actions:
+  - action_id: RA-001
+    symbol: FICTA
+    action: TRIM
+    shares: 50
+    reference_price: 100.0
+    estimated_value: 5000.0
+    status: PROPOSED_NOT_SUBMITTED
+projected_allocation:
+  FICTA_pct: 25.0
+  FICTB_pct: 30.0
+  FICTC_pct: 30.0
+  cash_pct: 15.0
+manual_execution_required: true

--- a/examples/workflows/core-portfolio-weekly/sample-run-full-path/05_weekly_journal_entry.yaml
+++ b/examples/workflows/core-portfolio-weekly/sample-run-full-path/05_weekly_journal_entry.yaml
@@ -1,0 +1,24 @@
+schema_version: "1.0"
+journal_type: core_portfolio_weekly
+review_date: "2026-06-27"
+source_snapshot: 01_holdings_snapshot.json
+allocation_decision: REBALANCE_PROPOSED
+dividend_review_status: WARN
+dividend_review:
+  symbol: FICTC
+  trigger: T2
+  response: PAUSE_OPTIONAL_ADDS_PENDING_HUMAN_REVIEW
+proposed_actions:
+  - action_id: RA-001
+    symbol: FICTA
+    action: TRIM
+    shares: 50
+    estimated_value: 5000.0
+    broker_status: NOT_SUBMITTED
+projected_cash_pct: 15.0
+human_confirmation:
+  broker_state_verified: false
+  disclosure_reviewed: false
+  tax_impact_reviewed: false
+  execution_authorized: false
+note: Fictional teaching journal; no broker order was placed.

--- a/examples/workflows/core-portfolio-weekly/sample-run-full-path/manifest.yaml
+++ b/examples/workflows/core-portfolio-weekly/sample-run-full-path/manifest.yaml
@@ -1,0 +1,51 @@
+workflow_id: core-portfolio-weekly
+sample_type: full-path
+illustrative: true
+prompt: prompt.md
+
+optional_steps_skipped: []
+
+verification_inputs:
+  - file: 03_dividend_monitor_input.json
+    purpose: deterministic input to kanchi-dividend-review-monitor
+
+artifacts:
+  - step: 1
+    artifact_id: holdings_snapshot
+    skill: portfolio-manager
+    files:
+      canonical: 01_holdings_snapshot.json
+  - step: 2
+    artifact_id: allocation_report
+    skill: portfolio-manager
+    files:
+      canonical: 02_allocation_report.json
+      companion: 02_allocation_report.md
+  - step: 3
+    artifact_id: dividend_review_findings
+    skill: kanchi-dividend-review-monitor
+    files:
+      canonical: 03_dividend_review_findings.json
+  - step: 4
+    artifact_id: rebalance_actions
+    skill: portfolio-manager
+    files:
+      canonical: 04_rebalance_actions.yaml
+  - step: 5
+    artifact_id: weekly_journal_entry
+    skill: trader-memory-core
+    files:
+      canonical: 05_weekly_journal_entry.yaml
+
+verification:
+  data_date: "2026-06-27"
+  expected:
+    equity: 100000.0
+    positions_market_value: 90000.0
+    cash: 10000.0
+    allocation_total_pct: 100.0
+    dividend_warn_symbol: FICTC
+    dividend_warn_trigger: T2
+    action_symbol: FICTA
+    shares_to_trim: 50
+    projected_cash_pct: 15.0

--- a/examples/workflows/core-portfolio-weekly/sample-run-full-path/prompt.md
+++ b/examples/workflows/core-portfolio-weekly/sample-run-full-path/prompt.md
@@ -1,0 +1,15 @@
+# Prompt: full-path weekly core portfolio review
+
+Run every step of `core-portfolio-weekly` for the fixed fictional snapshot
+dated `2026-06-27`.
+
+- Treat the holdings and dividend-monitor inputs as sanitized teaching
+  fixtures, never as live Alpaca or issuer data.
+- Run the T1-T5 dividend anomaly review before deciding the rebalance.
+- Carry the resulting `WARN` into the rebalance and weekly journal without
+  turning it into an automatic sale.
+- Do not place, route, or schedule any broker order. Pause optional adds to the
+  warned holding until a human reviews the underlying disclosure.
+
+All symbols and amounts are fictional. This sample is educational and is not
+investment advice.

--- a/examples/workflows/core-portfolio-weekly/sample-run/01_holdings_snapshot.json
+++ b/examples/workflows/core-portfolio-weekly/sample-run/01_holdings_snapshot.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-27",
+  "source": "fictional_manual_snapshot",
+  "account": {
+    "account_id": "SIM-****-208",
+    "status": "ACTIVE",
+    "equity": 100000.0,
+    "cash": 10000.0,
+    "long_market_value": 90000.0,
+    "buying_power": 10000.0
+  },
+  "positions": [
+    {
+      "symbol": "FICTA",
+      "quantity": 300,
+      "current_price": 100.0,
+      "market_value": 30000.0,
+      "portfolio_weight_pct": 30.0,
+      "sector": "Fictional Technology"
+    },
+    {
+      "symbol": "FICTB",
+      "quantity": 400,
+      "current_price": 75.0,
+      "market_value": 30000.0,
+      "portfolio_weight_pct": 30.0,
+      "sector": "Fictional Healthcare"
+    },
+    {
+      "symbol": "FICTC",
+      "quantity": 600,
+      "current_price": 50.0,
+      "market_value": 30000.0,
+      "portfolio_weight_pct": 30.0,
+      "sector": "Fictional Consumer Staples"
+    }
+  ],
+  "warnings": [
+    "Fictional teaching fixture; verify every holding against the real broker before acting."
+  ]
+}

--- a/examples/workflows/core-portfolio-weekly/sample-run/02_allocation_report.json
+++ b/examples/workflows/core-portfolio-weekly/sample-run/02_allocation_report.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-27",
+  "portfolio_value": 100000.0,
+  "allocation": [
+    {"bucket": "FICTA", "current_pct": 30.0, "target_pct": 25.0, "variance_pct": 5.0},
+    {"bucket": "FICTB", "current_pct": 30.0, "target_pct": 30.0, "variance_pct": 0.0},
+    {"bucket": "FICTC", "current_pct": 30.0, "target_pct": 30.0, "variance_pct": 0.0},
+    {"bucket": "CASH", "current_pct": 10.0, "target_pct": 15.0, "variance_pct": -5.0}
+  ],
+  "allocation_total_pct": 100.0,
+  "largest_position": {"symbol": "FICTA", "weight_pct": 30.0},
+  "decision": "REBALANCE_PROPOSED",
+  "rationale": "Reduce the fictional FICTA allocation by five percentage points and restore the cash target."
+}

--- a/examples/workflows/core-portfolio-weekly/sample-run/02_allocation_report.md
+++ b/examples/workflows/core-portfolio-weekly/sample-run/02_allocation_report.md
@@ -1,0 +1,10 @@
+# Fictional Allocation Report
+
+- Portfolio value: **$100,000.00**
+- Current cash: **10.0%**
+- Allocation total: **100.0%**
+- Largest position: **FICTA at 30.0%**
+- Decision: **REBALANCE_PROPOSED**
+
+The teaching plan proposes trimming **50 FICTA shares** at the fixed reference
+price of **$100.00**, moving **$5,000.00** to cash. No order is placed.

--- a/examples/workflows/core-portfolio-weekly/sample-run/04_rebalance_actions.yaml
+++ b/examples/workflows/core-portfolio-weekly/sample-run/04_rebalance_actions.yaml
@@ -1,0 +1,20 @@
+schema_version: "1.0"
+as_of: "2026-06-27"
+decision: PROPOSED_MANUAL_ACTIONS
+dividend_review:
+  status: NOT_RUN
+  reason: Optional step 3 was skipped in the required-only sample.
+actions:
+  - action_id: RA-001
+    symbol: FICTA
+    action: TRIM
+    shares: 50
+    reference_price: 100.0
+    estimated_value: 5000.0
+    status: PROPOSED_NOT_SUBMITTED
+projected_allocation:
+  FICTA_pct: 25.0
+  FICTB_pct: 30.0
+  FICTC_pct: 30.0
+  cash_pct: 15.0
+manual_execution_required: true

--- a/examples/workflows/core-portfolio-weekly/sample-run/05_weekly_journal_entry.yaml
+++ b/examples/workflows/core-portfolio-weekly/sample-run/05_weekly_journal_entry.yaml
@@ -1,0 +1,19 @@
+schema_version: "1.0"
+journal_type: core_portfolio_weekly
+review_date: "2026-06-27"
+source_snapshot: 01_holdings_snapshot.json
+allocation_decision: REBALANCE_PROPOSED
+dividend_review_status: NOT_RUN
+proposed_actions:
+  - action_id: RA-001
+    symbol: FICTA
+    action: TRIM
+    shares: 50
+    estimated_value: 5000.0
+    broker_status: NOT_SUBMITTED
+projected_cash_pct: 15.0
+human_confirmation:
+  broker_state_verified: false
+  tax_impact_reviewed: false
+  execution_authorized: false
+note: Fictional teaching journal; no broker order was placed.

--- a/examples/workflows/core-portfolio-weekly/sample-run/manifest.yaml
+++ b/examples/workflows/core-portfolio-weekly/sample-run/manifest.yaml
@@ -1,0 +1,43 @@
+workflow_id: core-portfolio-weekly
+sample_type: required-only
+illustrative: true
+prompt: prompt.md
+
+optional_steps_skipped:
+  - step: 3
+    skill: kanchi-dividend-review-monitor
+    reason: required-only canonical sample
+
+artifacts:
+  - step: 1
+    artifact_id: holdings_snapshot
+    skill: portfolio-manager
+    files:
+      canonical: 01_holdings_snapshot.json
+  - step: 2
+    artifact_id: allocation_report
+    skill: portfolio-manager
+    files:
+      canonical: 02_allocation_report.json
+      companion: 02_allocation_report.md
+  - step: 4
+    artifact_id: rebalance_actions
+    skill: portfolio-manager
+    files:
+      canonical: 04_rebalance_actions.yaml
+  - step: 5
+    artifact_id: weekly_journal_entry
+    skill: trader-memory-core
+    files:
+      canonical: 05_weekly_journal_entry.yaml
+
+verification:
+  data_date: "2026-06-27"
+  expected:
+    equity: 100000.0
+    positions_market_value: 90000.0
+    cash: 10000.0
+    allocation_total_pct: 100.0
+    action_symbol: FICTA
+    shares_to_trim: 50
+    projected_cash_pct: 15.0

--- a/examples/workflows/core-portfolio-weekly/sample-run/prompt.md
+++ b/examples/workflows/core-portfolio-weekly/sample-run/prompt.md
@@ -1,0 +1,16 @@
+# Prompt: required-only weekly core portfolio review
+
+Run `core-portfolio-weekly` for the fixed fictional snapshot dated
+`2026-06-27`.
+
+- Treat `01_holdings_snapshot.json` as a sanitized teaching fixture, not a live
+  Alpaca response.
+- Review allocation and concentration.
+- Skip optional step 3 (`kanchi-dividend-review-monitor`) and explicitly record
+  that dividend findings were not provided.
+- Produce a proposed rebalance and a weekly journal entry.
+- Do not place, route, or schedule any broker order. The human must separately
+  confirm the real account state, taxes, timing, and execution.
+
+All symbols and amounts are fictional. This sample is educational and is not
+investment advice.

--- a/examples/workflows/monthly-performance-review/README.md
+++ b/examples/workflows/monthly-performance-review/README.md
@@ -1,0 +1,22 @@
+# Example: `monthly-performance-review`
+
+Two deterministic teaching runs for
+[`monthly-performance-review`](../../../workflows/monthly-performance-review.yaml)
+using three closed fictional trades from May 2026.
+
+> **Illustrative only — not investment advice.** `EXMPL`, `DEMOX`, and `FICTA`
+> are invented symbols. Returns, notes, backtest samples, and review findings
+> are hand-authored fixtures and make no claim about a real strategy.
+
+| Variant | Optional review layers | Result |
+|---|---|---|
+| [`sample-run/`](sample-run/) | skipped | 3 trades, 2 wins, 1 loss, `$300` fictional realized P&L; two evidence-linked operating rules |
+| [`sample-run-full-path/`](sample-run-full-path/) | coaching + backtest + skill review | Same aggregate plus an `INCONCLUSIVE` hypothesis check and one repo-side backlog item |
+
+The required-only sample contains only artifacts marked `required: true`. The
+full path contains all ten workflow artifacts, including the optional
+`skill_improvement_backlog` emitted at the required final step.
+
+Trade-side operating rules and repo-side skill improvements remain separate.
+Every decision and backlog entry points to an upstream evidence ID so tests can
+detect invented or dangling rationales.

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/01_monthly_aggregate.json
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/01_monthly_aggregate.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "review_type": "monthly_aggregate",
+  "trade_id": "monthly_2026_05_fictional",
+  "period": {
+    "start": "2026-05-01",
+    "end": "2026-05-31"
+  },
+  "outcome": "mixed",
+  "planned": {
+    "thesis_recorded_before_entry": true,
+    "setup_confirmed": true,
+    "market_regime": "allowed"
+  },
+  "actual": {
+    "risk_r": 0.5,
+    "portfolio_heat_r": 1.5,
+    "stop_moved": false,
+    "entry_before_confirmation": true,
+    "traded_against_regime": false
+  },
+  "risk_plan": {
+    "max_risk_per_trade_r": 1.0,
+    "max_portfolio_heat_r": 4.0
+  },
+  "monthly": {
+    "trades": ["TRADE-001", "TRADE-002", "TRADE-003"],
+    "consecutive_losses": 1,
+    "rule_violations": 1
+  },
+  "postmortem": {
+    "root_cause": "execution",
+    "notes": [
+      "TRADE-002 entered before its written confirmation condition."
+    ]
+  },
+  "journal": {
+    "reflection": "Keep the confirmation gate explicit after the DEMOX loss.",
+    "emotions": ["impatient"]
+  },
+  "trades": [
+    {
+      "trade_id": "TRADE-001",
+      "symbol": "EXMPL",
+      "outcome": "win",
+      "realized_pnl": 500.0,
+      "root_cause": "thesis_quality",
+      "process_followed": true
+    },
+    {
+      "trade_id": "TRADE-002",
+      "symbol": "DEMOX",
+      "outcome": "loss",
+      "realized_pnl": -300.0,
+      "root_cause": "execution",
+      "process_followed": false
+    },
+    {
+      "trade_id": "TRADE-003",
+      "symbol": "FICTA",
+      "outcome": "win",
+      "realized_pnl": 100.0,
+      "root_cause": "randomness",
+      "process_followed": true
+    }
+  ],
+  "summary": {
+    "closed_trades": 3,
+    "winners": 2,
+    "losers": 1,
+    "realized_pnl": 300.0,
+    "win_rate_pct": 66.67
+  }
+}

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/02_aggregate_postmortem.json
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/02_aggregate_postmortem.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "period": "2026-05",
+  "source_trade_ids": ["TRADE-001", "TRADE-002", "TRADE-003"],
+  "category_counts": {
+    "thesis_quality": 1,
+    "execution": 1,
+    "market_environment": 0,
+    "randomness": 1
+  },
+  "findings": [
+    {
+      "evidence_id": "PM-THESIS-001",
+      "category": "thesis_quality",
+      "trade_ids": ["TRADE-001"],
+      "finding": "The written thesis and planned exit aligned on the larger winner."
+    },
+    {
+      "evidence_id": "PM-EXEC-001",
+      "category": "execution",
+      "trade_ids": ["TRADE-002"],
+      "finding": "The only loss entered before its confirmation condition."
+    },
+    {
+      "evidence_id": "PM-RANDOM-001",
+      "category": "randomness",
+      "trade_ids": ["TRADE-003"],
+      "finding": "The small winner lacks enough evidence for a rule change."
+    }
+  ],
+  "decision": "REVIEW_EXECUTION_RULE",
+  "warnings": [
+    "Three fictional trades are insufficient to infer strategy expectancy."
+  ]
+}

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/03_monthly_behavior_patterns.json
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/03_monthly_behavior_patterns.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0",
+  "period": "2026-05",
+  "source_review_id": "monthly_2026_05_fictional",
+  "patterns": [
+    {
+      "evidence_id": "BEHAVIOR-001",
+      "tag": "fomo_entry",
+      "confidence": "medium",
+      "source_fields": [
+        "actual.entry_before_confirmation",
+        "journal.reflection"
+      ],
+      "scope": "non_diagnostic_process_reflection"
+    },
+    {
+      "evidence_id": "BEHAVIOR-002",
+      "tag": "revenge_trade",
+      "confidence": "medium",
+      "source_fields": [
+        "journal.reflection"
+      ],
+      "scope": "non_diagnostic_process_reflection"
+    }
+  ]
+}

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/03_monthly_performance_coach_report.json
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/03_monthly_performance_coach_report.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": 1,
+  "review_type": "monthly_aggregate",
+  "review_id": "monthly_2026_05_fictional",
+  "generated_at": "2026-06-01T12:00:00+00:00",
+  "source_records": [
+    "examples/workflows/monthly-performance-review/sample-run-full-path/01_monthly_aggregate.json"
+  ],
+  "overall_verdict": "COOL_DOWN",
+  "summary": {
+    "outcome": "mixed",
+    "primary_root_cause": "execution",
+    "secondary_root_causes": [
+      "behavior_pattern"
+    ],
+    "confidence": "high"
+  },
+  "scores": {
+    "process_score": 70,
+    "risk_score": 100,
+    "execution_score": 70,
+    "review_quality_score": 88
+  },
+  "process_adherence_findings": [
+    {
+      "rule": "pre_entry_thesis_record",
+      "status": "met",
+      "evidence": "A pre-entry thesis record is present",
+      "severity": "info"
+    },
+    {
+      "rule": "setup_confirmation",
+      "status": "missed",
+      "evidence": "Entry appears to have occurred before planned setup confirmation",
+      "severity": "critical"
+    }
+  ],
+  "risk_manager_notes": [
+    {
+      "topic": "position_size",
+      "finding": "Actual risk was within the provided risk limit.",
+      "severity": "info",
+      "evidence": "actual.risk_r=0.5, reference_r=1"
+    }
+  ],
+  "execution_quality_assessment": [
+    {
+      "phase": "entry",
+      "finding": "Entry appears to have occurred before planned confirmation.",
+      "evidence": "actual.entry_before_confirmation is true",
+      "severity": "critical"
+    }
+  ],
+  "behavioral_pattern_tags": [
+    {
+      "tag": "fomo_entry",
+      "confidence": "medium",
+      "evidence": "Entry/journal evidence suggests fear of missing a move or entry before confirmation.",
+      "reflection_question": "What evidence did you have before entry that would not have been available after waiting for confirmation?"
+    },
+    {
+      "tag": "revenge_trade",
+      "confidence": "medium",
+      "evidence": "Journal language suggests a possible attempt to recover prior losses.",
+      "reflection_question": "Would you have taken this trade if the prior trade had been a winner?"
+    }
+  ],
+  "next_session_operating_rules": [
+    {
+      "rule": "No new entry without a pre-entry thesis record, invalidation point, and setup-confirmation note.",
+      "duration": "next_week",
+      "trigger": "possible FOMO entry pattern",
+      "reason": "The review found evidence of entry before confirmation or fear of missing a move."
+    },
+    {
+      "rule": "Switch to review-only mode for the next session; do not add new risk until the rule review is journaled.",
+      "duration": "next_session",
+      "trigger": "possible revenge/cool-down condition",
+      "reason": "Repeated losses or revenge-trade evidence can escalate risk-taking."
+    }
+  ],
+  "coach_questions": [
+    "What evidence did you have before entry that would not have been available after waiting for confirmation?",
+    "Would you have taken this trade if the prior trade had been a winner?"
+  ],
+  "human_decision_gate": {
+    "question": "Do you accept these temporary operating rules, modify them, defer the decision, or journal this review only?",
+    "allowed_actions": [
+      "accept_rules",
+      "modify_rules",
+      "defer",
+      "journal_only"
+    ],
+    "default_action": "journal_only"
+  },
+  "disclaimer": "This review is for trading-process improvement only. It is not financial advice, investment advice, therapy, mental-health diagnosis, or a trading signal. The human trader remains responsible for all decisions and risk."
+}

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/03_next_month_operating_rules.yaml
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/03_next_month_operating_rules.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+source_review_id: monthly_2026_05_fictional
+human_gate_action: modify_rules
+rules:
+  - rule_id: COACH-RULE-001
+    rule: No new entry without a pre-entry thesis record, invalidation point, and setup-confirmation note.
+    duration: next_week
+    evidence_ids:
+      - PM-EXEC-001
+      - BEHAVIOR-001
+  - rule_id: COACH-RULE-002
+    rule: Use review-only mode for the first June session and journal the rule review before adding risk.
+    duration: next_session
+    evidence_ids:
+      - BEHAVIOR-002

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/04_hypothesis_revalidation.json
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/04_hypothesis_revalidation.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "1.0",
+  "hypothesis_id": "HYP-001",
+  "hypothesis": "The fictional confirmation rule has positive expectancy.",
+  "sample_returns_r": [1.0, -1.0, 1.0, 1.0, -1.0, 1.0, 1.0, -1.0, 1.0, -1.0],
+  "metrics": {
+    "trade_count": 10,
+    "wins": 6,
+    "losses": 4,
+    "win_rate_pct": 60.0,
+    "total_return_r": 2.0,
+    "average_return_r": 0.2
+  },
+  "verdict": "INCONCLUSIVE",
+  "limitations": [
+    "The fixed ten-trade teaching sample is too small for validation.",
+    "No fees, slippage, or out-of-sample period are represented."
+  ]
+}

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/05_skill_review_findings.json
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/05_skill_review_findings.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "1.0",
+  "period": "2026-05",
+  "reviews": [
+    {
+      "evidence_id": "SKILL-REVIEW-001",
+      "skill": "vcp-screener",
+      "assessment": "HELPFUL_WITH_GAP",
+      "trade_ids": ["TRADE-001", "TRADE-002"],
+      "finding": "Candidate context was useful, but the hand-off did not require a recorded confirmation timestamp.",
+      "repo_action": "BACKLOG"
+    },
+    {
+      "evidence_id": "SKILL-REVIEW-002",
+      "skill": "pre-trade-discipline-gate",
+      "assessment": "HELPFUL",
+      "trade_ids": ["TRADE-003"],
+      "finding": "The written-plan gate kept risk within the configured cap.",
+      "repo_action": "NONE"
+    }
+  ],
+  "warnings": [
+    "Fictional review evidence; no production skill score is asserted."
+  ]
+}

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/06_monthly_decision_log.json
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/06_monthly_decision_log.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0",
+  "period": "2026-05",
+  "review_mode": "full-path",
+  "decisions": [
+    {
+      "decision_id": "DEC-001",
+      "scope": "trade_process",
+      "decision": "REQUIRE_ENTRY_CONFIRMATION",
+      "evidence_ids": [
+        "TRADE-002",
+        "PM-EXEC-001",
+        "BEHAVIOR-001",
+        "COACH-RULE-001"
+      ],
+      "status": "ACCEPTED_FOR_JUNE"
+    },
+    {
+      "decision_id": "DEC-002",
+      "scope": "risk",
+      "decision": "START_JUNE_IN_REVIEW_ONLY_MODE",
+      "evidence_ids": [
+        "BEHAVIOR-002",
+        "COACH-RULE-002"
+      ],
+      "status": "ACCEPTED_FOR_FIRST_SESSION"
+    }
+  ],
+  "hypothesis_decision": {
+    "hypothesis_id": "HYP-001",
+    "verdict": "INCONCLUSIVE",
+    "action": "NO_STRATEGY_CLAIM"
+  },
+  "repo_improvements": [
+    {
+      "backlog_id": "IMP-001",
+      "evidence_ids": ["SKILL-REVIEW-001"]
+    }
+  ],
+  "human_review_completed": true
+}

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/06_rule_changes_for_next_month.yaml
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/06_rule_changes_for_next_month.yaml
@@ -1,0 +1,18 @@
+schema_version: "1.0"
+effective_month: "2026-06"
+rules:
+  - rule_id: RULE-001
+    rule: Require the written confirmation condition before entry.
+    source_rule_id: COACH-RULE-001
+    evidence_ids:
+      - TRADE-002
+      - PM-EXEC-001
+      - BEHAVIOR-001
+    status: ACCEPTED
+  - rule_id: RULE-002
+    rule: Use review-only mode for the first June session and journal the review before adding risk.
+    source_rule_id: COACH-RULE-002
+    evidence_ids:
+      - BEHAVIOR-002
+    status: ACCEPTED
+review_after: "2026-06-30"

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/06_skill_improvement_backlog.yaml
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/06_skill_improvement_backlog.yaml
@@ -1,0 +1,12 @@
+schema_version: "1.0"
+period: "2026-05"
+items:
+  - backlog_id: IMP-001
+    scope: repository
+    skill: vcp-screener
+    title: Require a confirmation timestamp in the candidate hand-off contract.
+    evidence_ids:
+      - SKILL-REVIEW-001
+    priority: medium
+    status: proposed
+trade_rules_included: false

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/manifest.yaml
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/manifest.yaml
@@ -1,0 +1,72 @@
+workflow_id: monthly-performance-review
+sample_type: full-path
+illustrative: true
+prompt: prompt.md
+
+optional_steps_skipped: []
+
+artifacts:
+  - step: 1
+    artifact_id: monthly_aggregate
+    skill: trader-memory-core
+    files:
+      canonical: 01_monthly_aggregate.json
+  - step: 2
+    artifact_id: aggregate_postmortem
+    skill: signal-postmortem
+    files:
+      canonical: 02_aggregate_postmortem.json
+  - step: 3
+    artifact_id: monthly_performance_coach_report
+    skill: trade-performance-coach
+    files:
+      canonical: 03_monthly_performance_coach_report.json
+  - step: 3
+    artifact_id: monthly_behavior_patterns
+    skill: trade-performance-coach
+    files:
+      canonical: 03_monthly_behavior_patterns.json
+  - step: 3
+    artifact_id: next_month_operating_rules
+    skill: trade-performance-coach
+    files:
+      canonical: 03_next_month_operating_rules.yaml
+  - step: 4
+    artifact_id: hypothesis_revalidation
+    skill: backtest-expert
+    files:
+      canonical: 04_hypothesis_revalidation.json
+  - step: 5
+    artifact_id: skill_review_findings
+    skill: dual-axis-skill-reviewer
+    files:
+      canonical: 05_skill_review_findings.json
+  - step: 6
+    artifact_id: monthly_decision_log
+    skill: trader-memory-core
+    files:
+      canonical: 06_monthly_decision_log.json
+  - step: 6
+    artifact_id: rule_changes_for_next_month
+    skill: trader-memory-core
+    files:
+      canonical: 06_rule_changes_for_next_month.yaml
+  - step: 6
+    artifact_id: skill_improvement_backlog
+    skill: trader-memory-core
+    files:
+      canonical: 06_skill_improvement_backlog.yaml
+
+verification:
+  data_month: "2026-05"
+  expected:
+    closed_trades: 3
+    winners: 2
+    losers: 1
+    realized_pnl: 300.0
+    win_rate_pct: 66.67
+    backtest_trades: 10
+    backtest_average_r: 0.2
+    backtest_verdict: INCONCLUSIVE
+    accepted_rule_count: 2
+    repo_backlog_count: 1

--- a/examples/workflows/monthly-performance-review/sample-run-full-path/prompt.md
+++ b/examples/workflows/monthly-performance-review/sample-run-full-path/prompt.md
@@ -1,0 +1,15 @@
+# Prompt: full-path monthly performance review
+
+Run every step of `monthly-performance-review` for May 2026.
+
+- Preserve the three fictional closed trades and recompute their aggregate.
+- Run process coaching, hypothesis revalidation, and the skill-helpfulness
+  review before the final decision.
+- Treat the ten-return backtest fixture as `INCONCLUSIVE`; do not upgrade it to
+  validation.
+- Accept or modify trade-side rules only through the human decision gate.
+- Put repository improvements only in `skill_improvement_backlog`, with
+  evidence IDs that exist in the skill-review artifact.
+
+The symbols, returns, and notes are fictional teaching data. Nothing here is a
+live performance claim. This is not investment advice.

--- a/examples/workflows/monthly-performance-review/sample-run/01_monthly_aggregate.json
+++ b/examples/workflows/monthly-performance-review/sample-run/01_monthly_aggregate.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "review_type": "monthly_aggregate",
+  "trade_id": "monthly_2026_05_fictional",
+  "period": {
+    "start": "2026-05-01",
+    "end": "2026-05-31"
+  },
+  "outcome": "mixed",
+  "planned": {
+    "thesis_recorded_before_entry": true,
+    "setup_confirmed": true,
+    "market_regime": "allowed"
+  },
+  "actual": {
+    "risk_r": 0.5,
+    "portfolio_heat_r": 1.5,
+    "stop_moved": false,
+    "entry_before_confirmation": true,
+    "traded_against_regime": false
+  },
+  "risk_plan": {
+    "max_risk_per_trade_r": 1.0,
+    "max_portfolio_heat_r": 4.0
+  },
+  "monthly": {
+    "trades": ["TRADE-001", "TRADE-002", "TRADE-003"],
+    "consecutive_losses": 1,
+    "rule_violations": 1
+  },
+  "postmortem": {
+    "root_cause": "execution",
+    "notes": [
+      "TRADE-002 entered before its written confirmation condition."
+    ]
+  },
+  "journal": {
+    "reflection": "Keep the confirmation gate explicit after the DEMOX loss.",
+    "emotions": ["impatient"]
+  },
+  "trades": [
+    {
+      "trade_id": "TRADE-001",
+      "symbol": "EXMPL",
+      "outcome": "win",
+      "realized_pnl": 500.0,
+      "root_cause": "thesis_quality",
+      "process_followed": true
+    },
+    {
+      "trade_id": "TRADE-002",
+      "symbol": "DEMOX",
+      "outcome": "loss",
+      "realized_pnl": -300.0,
+      "root_cause": "execution",
+      "process_followed": false
+    },
+    {
+      "trade_id": "TRADE-003",
+      "symbol": "FICTA",
+      "outcome": "win",
+      "realized_pnl": 100.0,
+      "root_cause": "randomness",
+      "process_followed": true
+    }
+  ],
+  "summary": {
+    "closed_trades": 3,
+    "winners": 2,
+    "losers": 1,
+    "realized_pnl": 300.0,
+    "win_rate_pct": 66.67
+  }
+}

--- a/examples/workflows/monthly-performance-review/sample-run/02_aggregate_postmortem.json
+++ b/examples/workflows/monthly-performance-review/sample-run/02_aggregate_postmortem.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0",
+  "period": "2026-05",
+  "source_trade_ids": ["TRADE-001", "TRADE-002", "TRADE-003"],
+  "category_counts": {
+    "thesis_quality": 1,
+    "execution": 1,
+    "market_environment": 0,
+    "randomness": 1
+  },
+  "findings": [
+    {
+      "evidence_id": "PM-THESIS-001",
+      "category": "thesis_quality",
+      "trade_ids": ["TRADE-001"],
+      "finding": "The written thesis and planned exit aligned on the larger winner."
+    },
+    {
+      "evidence_id": "PM-EXEC-001",
+      "category": "execution",
+      "trade_ids": ["TRADE-002"],
+      "finding": "The only loss entered before its confirmation condition."
+    },
+    {
+      "evidence_id": "PM-RANDOM-001",
+      "category": "randomness",
+      "trade_ids": ["TRADE-003"],
+      "finding": "The small winner lacks enough evidence for a rule change."
+    }
+  ],
+  "decision": "REVIEW_EXECUTION_RULE",
+  "warnings": [
+    "Three fictional trades are insufficient to infer strategy expectancy."
+  ]
+}

--- a/examples/workflows/monthly-performance-review/sample-run/06_monthly_decision_log.json
+++ b/examples/workflows/monthly-performance-review/sample-run/06_monthly_decision_log.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0",
+  "period": "2026-05",
+  "review_mode": "required-only",
+  "decisions": [
+    {
+      "decision_id": "DEC-001",
+      "scope": "trade_process",
+      "decision": "REQUIRE_ENTRY_CONFIRMATION",
+      "evidence_ids": ["TRADE-002", "PM-EXEC-001"],
+      "status": "ACCEPTED_FOR_JUNE"
+    },
+    {
+      "decision_id": "DEC-002",
+      "scope": "risk",
+      "decision": "KEEP_RISK_CAP_AT_0_5_PERCENT",
+      "evidence_ids": ["TRADE-001", "TRADE-002", "TRADE-003"],
+      "status": "ACCEPTED_FOR_JUNE"
+    }
+  ],
+  "repo_improvements": [],
+  "human_review_completed": true
+}

--- a/examples/workflows/monthly-performance-review/sample-run/06_rule_changes_for_next_month.yaml
+++ b/examples/workflows/monthly-performance-review/sample-run/06_rule_changes_for_next_month.yaml
@@ -1,0 +1,17 @@
+schema_version: "1.0"
+effective_month: "2026-06"
+rules:
+  - rule_id: RULE-001
+    rule: Require the written confirmation condition before entry.
+    evidence_ids:
+      - TRADE-002
+      - PM-EXEC-001
+    status: ACCEPTED
+  - rule_id: RULE-002
+    rule: Keep planned risk at or below 0.5% of the fictional account per trade.
+    evidence_ids:
+      - TRADE-001
+      - TRADE-002
+      - TRADE-003
+    status: ACCEPTED
+review_after: "2026-06-30"

--- a/examples/workflows/monthly-performance-review/sample-run/manifest.yaml
+++ b/examples/workflows/monthly-performance-review/sample-run/manifest.yaml
@@ -1,0 +1,48 @@
+workflow_id: monthly-performance-review
+sample_type: required-only
+illustrative: true
+prompt: prompt.md
+
+optional_steps_skipped:
+  - step: 3
+    skill: trade-performance-coach
+    reason: required-only canonical sample
+  - step: 4
+    skill: backtest-expert
+    reason: required-only canonical sample
+  - step: 5
+    skill: dual-axis-skill-reviewer
+    reason: required-only canonical sample
+
+artifacts:
+  - step: 1
+    artifact_id: monthly_aggregate
+    skill: trader-memory-core
+    files:
+      canonical: 01_monthly_aggregate.json
+  - step: 2
+    artifact_id: aggregate_postmortem
+    skill: signal-postmortem
+    files:
+      canonical: 02_aggregate_postmortem.json
+  - step: 6
+    artifact_id: monthly_decision_log
+    skill: trader-memory-core
+    files:
+      canonical: 06_monthly_decision_log.json
+  - step: 6
+    artifact_id: rule_changes_for_next_month
+    skill: trader-memory-core
+    files:
+      canonical: 06_rule_changes_for_next_month.yaml
+
+verification:
+  data_month: "2026-05"
+  expected:
+    closed_trades: 3
+    winners: 2
+    losers: 1
+    realized_pnl: 300.0
+    win_rate_pct: 66.67
+    accepted_rule_count: 2
+    repo_backlog_count: 0

--- a/examples/workflows/monthly-performance-review/sample-run/prompt.md
+++ b/examples/workflows/monthly-performance-review/sample-run/prompt.md
@@ -1,0 +1,15 @@
+# Prompt: required-only monthly performance review
+
+Run only the required steps of `monthly-performance-review` for May 2026.
+
+- Aggregate the three closed fictional trades in
+  `01_monthly_aggregate.json`.
+- Classify recurring outcomes without changing the recorded P&L.
+- Skip optional coaching, backtest, and skill-review steps.
+- Produce a monthly decision log and next-month operating rules, with every
+  change tied to an upstream trade or postmortem evidence ID.
+- Keep trade-side behavior changes separate from repository improvements; the
+  required-only path produces no skill-improvement backlog.
+
+The symbols, returns, and notes are fictional teaching data. This is not
+investment advice.

--- a/examples/workflows/swing-opportunity-daily/README.md
+++ b/examples/workflows/swing-opportunity-daily/README.md
@@ -1,0 +1,26 @@
+# Example: `swing-opportunity-daily`
+
+Two deterministic teaching runs for
+[`swing-opportunity-daily`](../../../workflows/swing-opportunity-daily.yaml).
+Both begin with a self-contained, non-restrictive
+`market-regime-daily/exposure_decision` fixture and stop at the manual
+pre-trade discipline gate.
+
+> **Illustrative only — not investment advice.** `EXMPL` is an invented
+> symbol. Prices, chart findings, and account values are hand-authored
+> fixtures. No order is submitted or represented as submitted.
+
+| Variant | Optional steps | Final gate |
+|---|---|---|
+| [`sample-run/`](sample-run/) | skipped | `GO` for a fictional, not-submitted 200-share plan |
+| [`sample-run-full-path/`](sample-run-full-path/) | all included | `GO` after four optional screens and an optional trade plan |
+
+The required-only variant includes only artifacts marked `required: true`.
+The full path includes all eleven artifacts in the workflow manifest. The
+upstream exposure fixture is recorded separately as a prerequisite input, not
+as an artifact produced by this workflow.
+
+The position-sizer output uses an entry of `$50.00`, stop of `$47.50`, a
+`$100,000` fictional account, and `0.5%` planned risk. The deterministic result
+is 200 whole shares and `$500` risk. The same values flow through the thesis
+and discipline decision, which makes cross-artifact drift testable.

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/00_exposure_decision.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/00_exposure_decision.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-29T12:00:00+00:00",
+  "exposure_ceiling_pct": 61,
+  "bias": "NEUTRAL",
+  "participation": "BROAD",
+  "recommendation": "NEW_ENTRY_ALLOWED",
+  "confidence": "MEDIUM",
+  "composite_score": 59.2,
+  "component_scores": {
+    "breadth_score": 70,
+    "uptrend_score": 74,
+    "top_risk_score": 65
+  },
+  "inputs_provided": ["top_risk", "breadth", "uptrend"],
+  "inputs_missing": ["regime", "institutional", "sector", "theme", "ftd"],
+  "rationale": "Broad participation indicates healthy market internals. Missing critical inputs (regime) reduce confidence. New positions allowed within the 59% ceiling."
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/01_circuit_breaker_decision.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/01_circuit_breaker_decision.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-29T12:05:00+00:00",
+  "as_of_date": "2026-06-29",
+  "recommendation": "TRADING_ALLOWED",
+  "triggered_rules": [],
+  "metrics": {
+    "realized_pnl_today": 0.0,
+    "realized_pnl_wtd": 0.0,
+    "realized_pnl_mtd": 0.0,
+    "consecutive_losses": 0,
+    "last_loss_exit_at": null,
+    "theses_scanned": 0
+  },
+  "account_size": 100000.0,
+  "config": {
+    "max_daily_loss_pct": 2.0,
+    "losing_streak_n": 2,
+    "cooldown_hours": 24.0,
+    "weekly_drawdown_pct": 5.0,
+    "monthly_drawdown_pct": 8.0
+  },
+  "data_quality": "OK",
+  "warnings": [],
+  "rationale": "No account-level circuit breaker rules are active; new trade risk may proceed."
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/02_vcp_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/02_vcp_candidates.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "universe": "fictional_teaching_universe",
+  "candidates": [
+    {
+      "symbol": "EXMPL",
+      "pattern": "VCP",
+      "score": 88,
+      "pivot_price": 50.0,
+      "suggested_stop": 47.5,
+      "contractions_pct": [18.0, 10.0, 5.0],
+      "volume_dry_up": true,
+      "status": "CANDIDATE_NOT_SIGNAL"
+    }
+  ],
+  "warnings": [
+    "EXMPL is fictional; candidate generation is not a buy recommendation."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/03_momentum_burst_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/03_momentum_burst_candidates.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "candidates": [
+    {
+      "symbol": "EXMPL",
+      "setup": "MOMENTUM_BURST",
+      "score": 81,
+      "range_expansion_pct": 4.8,
+      "volume_ratio": 1.9,
+      "status": "CANDIDATE_NOT_SIGNAL"
+    }
+  ],
+  "warnings": [
+    "Fictional output; chart and risk validation remain required."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/04_exhaustion_hammer_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/04_exhaustion_hammer_candidates.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "candidates": [],
+  "screen_status": "COMPLETE_NO_MATCHES",
+  "warnings": [
+    "An empty optional screen is preserved; no candidate is invented."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/05_canslim_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/05_canslim_candidates.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "candidates": [
+    {
+      "symbol": "EXMPL",
+      "grade": "B",
+      "score": 78,
+      "current_quarter_eps_growth_pct": 32.0,
+      "annual_eps_growth_pct": 24.0,
+      "status": "CANDIDATE_NOT_SIGNAL"
+    }
+  ],
+  "warnings": [
+    "Fictional fundamentals; not sourced from a real filing."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/06_theme_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/06_theme_candidates.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "themes": [
+    {
+      "theme": "Fictional Cloud Efficiency",
+      "strength": "EMERGING",
+      "symbols": ["EXMPL"],
+      "evidence": [
+        "Hand-authored teaching evidence only."
+      ]
+    }
+  ],
+  "warnings": [
+    "Fictional theme; not a market claim."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/07_validated_setups.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/07_validated_setups.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "inputs_provided": [
+    "vcp_candidates",
+    "momentum_burst_candidates",
+    "exhaustion_hammer_candidates",
+    "canslim_candidates",
+    "theme_candidates"
+  ],
+  "inputs_missing": [],
+  "setups": [
+    {
+      "symbol": "EXMPL",
+      "source_artifacts": [
+        "vcp_candidates",
+        "momentum_burst_candidates",
+        "canslim_candidates",
+        "theme_candidates"
+      ],
+      "weekly_trend": "STAGE_2",
+      "base_quality": "TIGHT",
+      "entry_price": 50.0,
+      "stop_price": 47.5,
+      "target_price": 55.0,
+      "risk_per_share": 2.5,
+      "manual_chart_review": "PASS",
+      "decision": "VALIDATED"
+    }
+  ],
+  "rejected": []
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/08_position_sizing.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/08_position_sizing.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "parameters": {
+    "entry_price": 50.0,
+    "account_size": 100000.0,
+    "stop_price": 47.5,
+    "risk_pct": 0.5
+  },
+  "mode": "shares",
+  "calculations": {
+    "fixed_fractional": {
+      "method": "fixed_fractional",
+      "shares": 200,
+      "risk_per_share": 2.5,
+      "dollar_risk": 500.0,
+      "stop_price": 47.5
+    },
+    "atr_based": null,
+    "kelly": null
+  },
+  "constraints_applied": [],
+  "final_recommended_shares": 200,
+  "final_position_value": 10000.0,
+  "final_risk_dollars": 500.0,
+  "final_risk_pct": 0.5,
+  "binding_constraint": null
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/09_trade_plans.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/09_trade_plans.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "plans": [
+    {
+      "symbol": "EXMPL",
+      "side": "BUY",
+      "entry_type": "STOP_LIMIT",
+      "entry_price": 50.0,
+      "limit_price": 50.25,
+      "stop_price": 47.5,
+      "target_price": 55.0,
+      "shares": 200,
+      "position_value": 10000.0,
+      "planned_risk_dollars": 500.0,
+      "risk_reward_ratio": 2.0,
+      "order_status": "PROPOSED_NOT_SUBMITTED"
+    }
+  ],
+  "manual_execution_required": true
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/10_candidate_journal_entry.yaml
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/10_candidate_journal_entry.yaml
@@ -1,0 +1,82 @@
+thesis_id: th_EXMPL_gro_20260629_cd34
+ticker: EXMPL
+created_at: "2026-06-29T12:20:00+00:00"
+updated_at: "2026-06-29T12:25:00+00:00"
+thesis_type: growth_momentum
+setup_type: fictional_vcp
+catalyst: null
+status: ENTRY_READY
+status_history:
+  - status: IDEA
+    at: "2026-06-29T12:20:00+00:00"
+    reason: Registered from the fictional multi-screen sample.
+  - status: ENTRY_READY
+    at: "2026-06-29T12:25:00+00:00"
+    reason: Weekly setup, position size, and optional trade plan were reviewed.
+thesis_statement: EXMPL holds the fictional 50.00 pivot after a tightening VCP base.
+mechanism_tag: behavior
+evidence:
+  - VCP contractions narrowed from 18% to 10% to 5%.
+  - Momentum, CANSLIM, and fictional-theme screens corroborated the candidate.
+  - Manual weekly-chart review passed.
+kill_criteria:
+  - Close below the planned 47.50 stop invalidates the setup.
+confidence: medium
+confidence_score: 0.7
+entry:
+  target_price: 50.0
+  conditions:
+    - Entry must remain in the written plan.
+  actual_price: null
+  actual_date: null
+exit:
+  stop_loss: 47.5
+  stop_loss_pct: 5.0
+  take_profit: 55.0
+  take_profit_rr: 2.0
+  time_stop_days: 10
+  actual_price: null
+  actual_date: null
+  exit_reason: null
+position:
+  shares: 200
+  shares_remaining: 200
+  position_value: 10000.0
+  risk_dollars: 500.0
+  risk_pct_of_account: 0.5
+  account_type: fictional_cash
+  sizing_method: fixed_fractional
+  raw_source:
+    skill: position-sizer
+    file: 08_position_sizing.json
+    fields:
+      final_recommended_shares: 200
+      final_risk_dollars: 500.0
+market_context:
+  regime: NEW_ENTRY_ALLOWED
+  breadth_score: 70
+  top_detector_score: 35
+  sector: Fictional Technology
+monitoring:
+  review_interval_days: 1
+  next_review_date: "2026-06-30"
+  last_review_date: null
+  review_status: OK
+  triggers_config: []
+  alerts: []
+origin:
+  skill: breakout-trade-planner
+  output_file: 09_trade_plans.json
+  screening_grade: A
+  screening_score: 88
+  raw_provenance:
+    fixture: fictional
+linked_reports: []
+outcome:
+  pnl_dollars: null
+  pnl_pct: null
+  holding_days: null
+  mae_pct: null
+  mfe_pct: null
+  mae_mfe_source: null
+  lessons_learned: null

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/11_pre_trade_discipline_decision.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/11_pre_trade_discipline_decision.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-29T12:30:00+00:00",
+  "as_of": "2026-06-29T08:30:00-04:00",
+  "overall_decision": "GO",
+  "candidate_results": [
+    {
+      "symbol": "EXMPL",
+      "thesis_id": "th_EXMPL_gro_20260629_cd34",
+      "order_intent": "MANUAL_ORDER",
+      "actionable": true,
+      "decision": "GO",
+      "reasons": [],
+      "checklist_answers": {
+        "entry_in_written_plan": true,
+        "stop_predefined": true,
+        "size_within_plan": true,
+        "planned_risk_dollars": 500.0,
+        "actual_risk_dollars": 500.0,
+        "notes": "Fictional 200-share plan; no order submitted."
+      },
+      "link_status": "skipped_no_state_dir"
+    }
+  ],
+  "metrics": {
+    "candidates_total": 1,
+    "actionable_candidates": 1,
+    "theses_scanned": 0,
+    "revenge_window_hours": 24.0
+  },
+  "inputs": {
+    "state_dir": null,
+    "market_regime_decision": "00_exposure_decision.json",
+    "circuit_breaker_decision": "01_circuit_breaker_decision.json"
+  },
+  "artifact_paths": {
+    "json": "11_pre_trade_discipline_decision.json",
+    "markdown": "11_pre_trade_discipline_decision.md"
+  },
+  "warnings": [],
+  "rationale": "All actionable manual-order candidates passed the pre-trade discipline gate."
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/11_pre_trade_discipline_decision.md
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/11_pre_trade_discipline_decision.md
@@ -1,0 +1,15 @@
+# Fictional Pre-Trade Discipline Decision
+
+- Symbol: **EXMPL**
+- Planned quantity: **200 shares**
+- Entry: **$50.00**
+- Stop: **$47.50**
+- Planned and actual risk: **$500.00**
+- Market regime: **NEW_ENTRY_ALLOWED**
+- Circuit breaker: **TRADING_ALLOWED**
+- Optional sources run: **5**
+- Final decision: **GO**
+- Broker status: **NOT_SUBMITTED**
+
+`GO` only means the fictional checklist is internally consistent. It does not
+submit or authorize an order.

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/manifest.yaml
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/manifest.yaml
@@ -1,0 +1,85 @@
+workflow_id: swing-opportunity-daily
+sample_type: full-path
+illustrative: true
+prompt: prompt.md
+
+prerequisite_inputs:
+  - workflow_id: market-regime-daily
+    artifact_id: exposure_decision
+    data_date: "2026-06-29"
+    required_state: NEW_ENTRY_ALLOWED
+    file: 00_exposure_decision.json
+
+optional_steps_skipped: []
+
+artifacts:
+  - step: 1
+    artifact_id: circuit_breaker_decision
+    skill: drawdown-circuit-breaker
+    files:
+      canonical: 01_circuit_breaker_decision.json
+  - step: 2
+    artifact_id: vcp_candidates
+    skill: vcp-screener
+    files:
+      canonical: 02_vcp_candidates.json
+  - step: 3
+    artifact_id: momentum_burst_candidates
+    skill: stockbee-momentum-burst-screener
+    files:
+      canonical: 03_momentum_burst_candidates.json
+  - step: 4
+    artifact_id: exhaustion_hammer_candidates
+    skill: stockbee-exhaustion-hammer-screener
+    files:
+      canonical: 04_exhaustion_hammer_candidates.json
+  - step: 5
+    artifact_id: canslim_candidates
+    skill: canslim-screener
+    files:
+      canonical: 05_canslim_candidates.json
+  - step: 6
+    artifact_id: theme_candidates
+    skill: theme-detector
+    files:
+      canonical: 06_theme_candidates.json
+  - step: 7
+    artifact_id: validated_setups
+    skill: technical-analyst
+    files:
+      canonical: 07_validated_setups.json
+  - step: 8
+    artifact_id: position_sizing
+    skill: position-sizer
+    files:
+      canonical: 08_position_sizing.json
+  - step: 9
+    artifact_id: trade_plans
+    skill: breakout-trade-planner
+    files:
+      canonical: 09_trade_plans.json
+  - step: 10
+    artifact_id: candidate_journal_entry
+    skill: trader-memory-core
+    files:
+      canonical: 10_candidate_journal_entry.yaml
+  - step: 11
+    artifact_id: pre_trade_discipline_decision
+    skill: pre-trade-discipline-gate
+    files:
+      canonical: 11_pre_trade_discipline_decision.json
+      companion: 11_pre_trade_discipline_decision.md
+
+verification:
+  data_date: "2026-06-29"
+  expected:
+    symbol: EXMPL
+    entry_price: 50.0
+    stop_price: 47.5
+    account_size: 100000.0
+    risk_pct: 0.5
+    shares: 200
+    risk_dollars: 500.0
+    optional_sources_run: 5
+    final_gate: GO
+    broker_status: NOT_SUBMITTED

--- a/examples/workflows/swing-opportunity-daily/sample-run-full-path/prompt.md
+++ b/examples/workflows/swing-opportunity-daily/sample-run-full-path/prompt.md
@@ -1,0 +1,16 @@
+# Prompt: full-path swing opportunity review
+
+Run every step of `swing-opportunity-daily` for `2026-06-29`.
+
+1. Confirm the fixed upstream exposure decision is `NEW_ENTRY_ALLOWED` and the
+   circuit breaker is `TRADING_ALLOWED`; otherwise stop.
+2. Run all five candidate/plan optional steps. Empty optional results remain
+   valid evidence and must not be converted into a candidate.
+3. Require the fictional `EXMPL` setup to pass the manual weekly-chart review.
+4. Recalculate size from entry `$50.00`, stop `$47.50`, a fictional `$100,000`
+   account, and `0.5%` risk.
+5. Carry the same 200-share / `$500` risk plan through the optional trade plan,
+   `ENTRY_READY` thesis, and manual discipline gate.
+
+Stop at the discipline decision. Do not place, route, or schedule an order.
+`EXMPL` and all values are fictional; this is not investment advice.

--- a/examples/workflows/swing-opportunity-daily/sample-run/00_exposure_decision.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run/00_exposure_decision.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-29T12:00:00+00:00",
+  "exposure_ceiling_pct": 61,
+  "bias": "NEUTRAL",
+  "participation": "BROAD",
+  "recommendation": "NEW_ENTRY_ALLOWED",
+  "confidence": "MEDIUM",
+  "composite_score": 59.2,
+  "component_scores": {
+    "breadth_score": 70,
+    "uptrend_score": 74,
+    "top_risk_score": 65
+  },
+  "inputs_provided": ["top_risk", "breadth", "uptrend"],
+  "inputs_missing": ["regime", "institutional", "sector", "theme", "ftd"],
+  "rationale": "Broad participation indicates healthy market internals. Missing critical inputs (regime) reduce confidence. New positions allowed within the 59% ceiling."
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run/01_circuit_breaker_decision.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run/01_circuit_breaker_decision.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-29T12:05:00+00:00",
+  "as_of_date": "2026-06-29",
+  "recommendation": "TRADING_ALLOWED",
+  "triggered_rules": [],
+  "metrics": {
+    "realized_pnl_today": 0.0,
+    "realized_pnl_wtd": 0.0,
+    "realized_pnl_mtd": 0.0,
+    "consecutive_losses": 0,
+    "last_loss_exit_at": null,
+    "theses_scanned": 0
+  },
+  "account_size": 100000.0,
+  "config": {
+    "max_daily_loss_pct": 2.0,
+    "losing_streak_n": 2,
+    "cooldown_hours": 24.0,
+    "weekly_drawdown_pct": 5.0,
+    "monthly_drawdown_pct": 8.0
+  },
+  "data_quality": "OK",
+  "warnings": [],
+  "rationale": "No account-level circuit breaker rules are active; new trade risk may proceed."
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run/02_vcp_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run/02_vcp_candidates.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "universe": "fictional_teaching_universe",
+  "candidates": [
+    {
+      "symbol": "EXMPL",
+      "pattern": "VCP",
+      "score": 88,
+      "pivot_price": 50.0,
+      "suggested_stop": 47.5,
+      "contractions_pct": [18.0, 10.0, 5.0],
+      "volume_dry_up": true,
+      "status": "CANDIDATE_NOT_SIGNAL"
+    }
+  ],
+  "warnings": [
+    "EXMPL is fictional; candidate generation is not a buy recommendation."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run/07_validated_setups.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run/07_validated_setups.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "inputs_provided": ["vcp_candidates"],
+  "inputs_missing": [
+    "momentum_burst_candidates",
+    "exhaustion_hammer_candidates",
+    "canslim_candidates",
+    "theme_candidates"
+  ],
+  "setups": [
+    {
+      "symbol": "EXMPL",
+      "source_artifacts": ["vcp_candidates"],
+      "weekly_trend": "STAGE_2",
+      "base_quality": "TIGHT",
+      "entry_price": 50.0,
+      "stop_price": 47.5,
+      "target_price": 55.0,
+      "risk_per_share": 2.5,
+      "manual_chart_review": "PASS",
+      "decision": "VALIDATED"
+    }
+  ],
+  "rejected": []
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run/08_position_sizing.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run/08_position_sizing.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "parameters": {
+    "entry_price": 50.0,
+    "account_size": 100000.0,
+    "stop_price": 47.5,
+    "risk_pct": 0.5
+  },
+  "mode": "shares",
+  "calculations": {
+    "fixed_fractional": {
+      "method": "fixed_fractional",
+      "shares": 200,
+      "risk_per_share": 2.5,
+      "dollar_risk": 500.0,
+      "stop_price": 47.5
+    },
+    "atr_based": null,
+    "kelly": null
+  },
+  "constraints_applied": [],
+  "final_recommended_shares": 200,
+  "final_position_value": 10000.0,
+  "final_risk_dollars": 500.0,
+  "final_risk_pct": 0.5,
+  "binding_constraint": null
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run/10_candidate_journal_entry.yaml
+++ b/examples/workflows/swing-opportunity-daily/sample-run/10_candidate_journal_entry.yaml
@@ -1,0 +1,81 @@
+thesis_id: th_EXMPL_gro_20260629_ab12
+ticker: EXMPL
+created_at: "2026-06-29T12:20:00+00:00"
+updated_at: "2026-06-29T12:25:00+00:00"
+thesis_type: growth_momentum
+setup_type: fictional_vcp
+catalyst: null
+status: ENTRY_READY
+status_history:
+  - status: IDEA
+    at: "2026-06-29T12:20:00+00:00"
+    reason: Registered from the fictional VCP sample.
+  - status: ENTRY_READY
+    at: "2026-06-29T12:25:00+00:00"
+    reason: Weekly setup and position size were reviewed.
+thesis_statement: EXMPL holds the fictional 50.00 pivot after a tightening VCP base.
+mechanism_tag: behavior
+evidence:
+  - VCP contractions narrowed from 18% to 10% to 5%.
+  - Manual weekly-chart review passed.
+kill_criteria:
+  - Close below the planned 47.50 stop invalidates the setup.
+confidence: medium
+confidence_score: 0.7
+entry:
+  target_price: 50.0
+  conditions:
+    - Entry must remain in the written plan.
+  actual_price: null
+  actual_date: null
+exit:
+  stop_loss: 47.5
+  stop_loss_pct: 5.0
+  take_profit: 55.0
+  take_profit_rr: 2.0
+  time_stop_days: 10
+  actual_price: null
+  actual_date: null
+  exit_reason: null
+position:
+  shares: 200
+  shares_remaining: 200
+  position_value: 10000.0
+  risk_dollars: 500.0
+  risk_pct_of_account: 0.5
+  account_type: fictional_cash
+  sizing_method: fixed_fractional
+  raw_source:
+    skill: position-sizer
+    file: 08_position_sizing.json
+    fields:
+      final_recommended_shares: 200
+      final_risk_dollars: 500.0
+market_context:
+  regime: NEW_ENTRY_ALLOWED
+  breadth_score: 70
+  top_detector_score: 35
+  sector: Fictional Technology
+monitoring:
+  review_interval_days: 1
+  next_review_date: "2026-06-30"
+  last_review_date: null
+  review_status: OK
+  triggers_config: []
+  alerts: []
+origin:
+  skill: vcp-screener
+  output_file: 02_vcp_candidates.json
+  screening_grade: A
+  screening_score: 88
+  raw_provenance:
+    fixture: fictional
+linked_reports: []
+outcome:
+  pnl_dollars: null
+  pnl_pct: null
+  holding_days: null
+  mae_pct: null
+  mfe_pct: null
+  mae_mfe_source: null
+  lessons_learned: null

--- a/examples/workflows/swing-opportunity-daily/sample-run/11_pre_trade_discipline_decision.json
+++ b/examples/workflows/swing-opportunity-daily/sample-run/11_pre_trade_discipline_decision.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-29T12:30:00+00:00",
+  "as_of": "2026-06-29T08:30:00-04:00",
+  "overall_decision": "GO",
+  "candidate_results": [
+    {
+      "symbol": "EXMPL",
+      "thesis_id": "th_EXMPL_gro_20260629_ab12",
+      "order_intent": "MANUAL_ORDER",
+      "actionable": true,
+      "decision": "GO",
+      "reasons": [],
+      "checklist_answers": {
+        "entry_in_written_plan": true,
+        "stop_predefined": true,
+        "size_within_plan": true,
+        "planned_risk_dollars": 500.0,
+        "actual_risk_dollars": 500.0,
+        "notes": "Fictional 200-share plan; no order submitted."
+      },
+      "link_status": "skipped_no_state_dir"
+    }
+  ],
+  "metrics": {
+    "candidates_total": 1,
+    "actionable_candidates": 1,
+    "theses_scanned": 0,
+    "revenge_window_hours": 24.0
+  },
+  "inputs": {
+    "state_dir": null,
+    "market_regime_decision": "00_exposure_decision.json",
+    "circuit_breaker_decision": "01_circuit_breaker_decision.json"
+  },
+  "artifact_paths": {
+    "json": "11_pre_trade_discipline_decision.json",
+    "markdown": "11_pre_trade_discipline_decision.md"
+  },
+  "warnings": [],
+  "rationale": "All actionable manual-order candidates passed the pre-trade discipline gate."
+}

--- a/examples/workflows/swing-opportunity-daily/sample-run/11_pre_trade_discipline_decision.md
+++ b/examples/workflows/swing-opportunity-daily/sample-run/11_pre_trade_discipline_decision.md
@@ -1,0 +1,14 @@
+# Fictional Pre-Trade Discipline Decision
+
+- Symbol: **EXMPL**
+- Planned quantity: **200 shares**
+- Entry: **$50.00**
+- Stop: **$47.50**
+- Planned and actual risk: **$500.00**
+- Market regime: **NEW_ENTRY_ALLOWED**
+- Circuit breaker: **TRADING_ALLOWED**
+- Final decision: **GO**
+- Broker status: **NOT_SUBMITTED**
+
+`GO` only means the fictional checklist is internally consistent. It does not
+submit or authorize an order.

--- a/examples/workflows/swing-opportunity-daily/sample-run/manifest.yaml
+++ b/examples/workflows/swing-opportunity-daily/sample-run/manifest.yaml
@@ -1,0 +1,74 @@
+workflow_id: swing-opportunity-daily
+sample_type: required-only
+illustrative: true
+prompt: prompt.md
+
+prerequisite_inputs:
+  - workflow_id: market-regime-daily
+    artifact_id: exposure_decision
+    data_date: "2026-06-29"
+    required_state: NEW_ENTRY_ALLOWED
+    file: 00_exposure_decision.json
+
+optional_steps_skipped:
+  - step: 3
+    skill: stockbee-momentum-burst-screener
+    reason: required-only canonical sample
+  - step: 4
+    skill: stockbee-exhaustion-hammer-screener
+    reason: required-only canonical sample
+  - step: 5
+    skill: canslim-screener
+    reason: required-only canonical sample
+  - step: 6
+    skill: theme-detector
+    reason: required-only canonical sample
+  - step: 9
+    skill: breakout-trade-planner
+    reason: required-only canonical sample
+
+artifacts:
+  - step: 1
+    artifact_id: circuit_breaker_decision
+    skill: drawdown-circuit-breaker
+    files:
+      canonical: 01_circuit_breaker_decision.json
+  - step: 2
+    artifact_id: vcp_candidates
+    skill: vcp-screener
+    files:
+      canonical: 02_vcp_candidates.json
+  - step: 7
+    artifact_id: validated_setups
+    skill: technical-analyst
+    files:
+      canonical: 07_validated_setups.json
+  - step: 8
+    artifact_id: position_sizing
+    skill: position-sizer
+    files:
+      canonical: 08_position_sizing.json
+  - step: 10
+    artifact_id: candidate_journal_entry
+    skill: trader-memory-core
+    files:
+      canonical: 10_candidate_journal_entry.yaml
+  - step: 11
+    artifact_id: pre_trade_discipline_decision
+    skill: pre-trade-discipline-gate
+    files:
+      canonical: 11_pre_trade_discipline_decision.json
+      companion: 11_pre_trade_discipline_decision.md
+
+verification:
+  data_date: "2026-06-29"
+  expected:
+    symbol: EXMPL
+    entry_price: 50.0
+    stop_price: 47.5
+    account_size: 100000.0
+    risk_pct: 0.5
+    shares: 200
+    risk_dollars: 500.0
+    final_gate: GO
+    broker_status: NOT_SUBMITTED

--- a/examples/workflows/swing-opportunity-daily/sample-run/prompt.md
+++ b/examples/workflows/swing-opportunity-daily/sample-run/prompt.md
@@ -1,0 +1,16 @@
+# Prompt: required-only swing opportunity review
+
+Run only the required steps of `swing-opportunity-daily` for `2026-06-29`.
+
+1. Confirm `00_exposure_decision.json` is `NEW_ENTRY_ALLOWED`; otherwise stop.
+2. Confirm the account circuit breaker allows new risk.
+3. Use only the fictional VCP candidate and require a clean weekly-chart
+   validation.
+4. Calculate size from the fixed entry, stop, account, and risk inputs.
+5. Register an `ENTRY_READY` thesis and run the manual execution discipline
+   gate.
+6. Skip optional steps 3, 4, 5, 6, and 9. Do not invent their artifacts.
+
+Stop at the `GO`/`NO_GO` decision. A `GO` means the written fictional checklist
+is internally consistent; it is not an instruction or authorization to place
+an order. `EXMPL` and all values are fictional. This is not investment advice.

--- a/scripts/tests/test_workflow_examples_issue208.py
+++ b/scripts/tests/test_workflow_examples_issue208.py
@@ -1,0 +1,581 @@
+"""Contract tests for the strict workflow samples added for Issue #208."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+import yaml
+from jsonschema import Draft7Validator, FormatChecker, validators
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES = ROOT / "examples" / "workflows"
+STRICT_WORKFLOWS = (
+    "core-portfolio-weekly",
+    "swing-opportunity-daily",
+    "monthly-performance-review",
+)
+VARIANTS = ("sample-run", "sample-run-full-path")
+
+
+def _load(path: Path) -> Any:
+    if path.suffix == ".json":
+        return json.loads(path.read_text(encoding="utf-8"))
+    if path.suffix in {".yaml", ".yml"}:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    return path.read_text(encoding="utf-8")
+
+
+def _module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sample_dir(workflow_id: str, variant: str) -> Path:
+    return EXAMPLES / workflow_id / variant
+
+
+def _manifest(workflow_id: str, variant: str) -> dict[str, Any]:
+    return _load(_sample_dir(workflow_id, variant) / "manifest.yaml")
+
+
+@pytest.mark.parametrize("workflow_id", STRICT_WORKFLOWS)
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_manifest_matches_workflow_and_directory_is_complete(
+    workflow_id: str,
+    variant: str,
+) -> None:
+    sample_dir = _sample_dir(workflow_id, variant)
+    manifest = _manifest(workflow_id, variant)
+    workflow = _load(ROOT / "workflows" / f"{workflow_id}.yaml")
+
+    assert manifest["workflow_id"] == workflow_id
+    assert manifest["sample_type"] == ("required-only" if variant == "sample-run" else "full-path")
+    assert manifest["illustrative"] is True
+
+    prompt = sample_dir / manifest["prompt"]
+    prompt_text = " ".join(prompt.read_text(encoding="utf-8").lower().split())
+    assert "fictional" in prompt_text
+    assert "not investment advice" in prompt_text
+
+    artifact_contract = {item["id"]: item for item in workflow["artifacts"]}
+    step_contract = {item["step"]: item for item in workflow["steps"]}
+    optional_steps = {step["step"]: step for step in workflow["steps"] if step.get("optional")}
+    expected_artifacts = {
+        artifact_id
+        for artifact_id, artifact in artifact_contract.items()
+        if variant == "sample-run-full-path" or artifact["required"]
+    }
+
+    artifact_entries = manifest["artifacts"]
+    actual_artifacts = [item["artifact_id"] for item in artifact_entries]
+    assert len(actual_artifacts) == len(set(actual_artifacts))
+    assert set(actual_artifacts) == expected_artifacts
+
+    for entry in artifact_entries:
+        artifact = artifact_contract[entry["artifact_id"]]
+        assert entry["step"] == artifact["produced_by_step"]
+        step = step_contract[entry["step"]]
+        assert entry["skill"] == step["skill"]
+        assert entry["artifact_id"] in step["produces"]
+
+    skipped = {item["step"]: item for item in manifest["optional_steps_skipped"]}
+    if variant == "sample-run":
+        assert set(skipped) == set(optional_steps)
+        for step_number, item in skipped.items():
+            assert item["skill"] == optional_steps[step_number]["skill"]
+    else:
+        assert skipped == {}
+
+    prerequisite_contract = {
+        (item["id"], item["artifact"])
+        for item in (workflow.get("prerequisite_workflows", []) or [])
+    }
+    prerequisite_inputs = manifest.get("prerequisite_inputs", []) or []
+    prerequisite_pairs = {
+        (item["workflow_id"], item["artifact_id"]) for item in prerequisite_inputs
+    }
+    assert len(prerequisite_inputs) == len(prerequisite_pairs)
+    assert prerequisite_pairs == prerequisite_contract
+    for item in prerequisite_inputs:
+        prerequisite = _load(sample_dir / item["file"])
+        assert prerequisite["recommendation"] == item["required_state"]
+        generated_date = datetime.fromisoformat(prerequisite["generated_at"]).date().isoformat()
+        assert generated_date == item["data_date"] == manifest["verification"]["data_date"]
+
+    declared_files = {"manifest.yaml", manifest["prompt"]}
+    for entry in artifact_entries:
+        declared_files.update(entry["files"].values())
+    for item in prerequisite_inputs:
+        declared_files.add(item["file"])
+    for item in manifest.get("verification_inputs", []):
+        declared_files.add(item["file"])
+
+    for name in declared_files:
+        relative = Path(name)
+        assert not relative.is_absolute()
+        assert ".." not in relative.parts
+        resolved = (sample_dir / relative).resolve()
+        assert resolved.parent == sample_dir.resolve()
+        assert resolved.is_file()
+        if resolved.suffix in {".json", ".yaml", ".yml"}:
+            assert _load(resolved) is not None
+
+    actual_files = {path.name for path in sample_dir.iterdir() if path.is_file()}
+    assert actual_files == declared_files
+
+
+def test_readme_starting_paths_link_the_three_required_samples() -> None:
+    english = (ROOT / "README.md").read_text(encoding="utf-8")
+    japanese = (ROOT / "README.ja.md").read_text(encoding="utf-8")
+    examples_readme = (EXAMPLES / "README.md").read_text(encoding="utf-8")
+
+    for workflow_id in STRICT_WORKFLOWS:
+        sample_path = f"examples/workflows/{workflow_id}/sample-run/"
+        assert f"([sample]({sample_path}))" in english
+        assert f"（[実行例]({sample_path})）" in japanese
+        assert f"[`{workflow_id}/sample-run/`]({workflow_id}/sample-run/)" in examples_readme
+        assert (
+            f"[`{workflow_id}/sample-run-full-path/`]({workflow_id}/sample-run-full-path/)"
+        ) in examples_readme
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_core_portfolio_values_flow_to_rebalance_and_journal(variant: str) -> None:
+    sample_dir = _sample_dir("core-portfolio-weekly", variant)
+    holdings = _load(sample_dir / "01_holdings_snapshot.json")
+    allocation = _load(sample_dir / "02_allocation_report.json")
+    rebalance = _load(sample_dir / "04_rebalance_actions.yaml")
+    journal = _load(sample_dir / "05_weekly_journal_entry.yaml")
+
+    account = holdings["account"]
+    positions_value = sum(item["market_value"] for item in holdings["positions"])
+    assert positions_value == account["long_market_value"] == 90000.0
+    assert positions_value + account["cash"] == account["equity"] == 100000.0
+    for position in holdings["positions"]:
+        expected_weight = position["market_value"] / account["equity"] * 100
+        assert position["portfolio_weight_pct"] == expected_weight
+
+    assert sum(item["current_pct"] for item in allocation["allocation"]) == 100.0
+    assert allocation["allocation_total_pct"] == 100.0
+
+    action = rebalance["actions"][0]
+    assert action["estimated_value"] == action["shares"] * action["reference_price"]
+    projected_cash = (account["cash"] + action["estimated_value"]) / account["equity"] * 100
+    assert rebalance["projected_allocation"]["cash_pct"] == projected_cash == 15.0
+    assert rebalance["manual_execution_required"] is True
+    assert action["status"] == "PROPOSED_NOT_SUBMITTED"
+
+    journal_action = journal["proposed_actions"][0]
+    for field in ("action_id", "symbol", "action", "shares", "estimated_value"):
+        assert journal_action[field] == action[field]
+    assert journal_action["broker_status"] == "NOT_SUBMITTED"
+    assert journal["projected_cash_pct"] == projected_cash
+    assert journal["human_confirmation"]["execution_authorized"] is False
+
+    companion = (sample_dir / "02_allocation_report.md").read_text(encoding="utf-8")
+    for value in ("$100,000.00", "100.0%", "FICTA at 30.0%", "50 FICTA shares"):
+        assert value in companion
+
+
+def test_full_core_dividend_report_is_reproduced_by_rule_engine() -> None:
+    sample_dir = _sample_dir("core-portfolio-weekly", "sample-run-full-path")
+    payload = _load(sample_dir / "03_dividend_monitor_input.json")
+    expected = _load(sample_dir / "03_dividend_review_findings.json")
+    module = _module(
+        "issue208_dividend_review",
+        ROOT / "skills" / "kanchi-dividend-review-monitor" / "scripts" / "build_review_queue.py",
+    )
+
+    actual = module.build_report(payload)
+    actual["generated_at"] = expected["generated_at"]
+    assert actual == expected
+
+    rebalance = _load(sample_dir / "04_rebalance_actions.yaml")
+    journal = _load(sample_dir / "05_weekly_journal_entry.yaml")
+    finding = expected["results"][0]["findings"][0]
+    assert expected["results"][0]["status"] == "WARN"
+    assert rebalance["dividend_review"]["trigger"] == finding["trigger"] == "T2"
+    assert journal["dividend_review"]["trigger"] == finding["trigger"]
+    assert rebalance["dividend_review"]["response"].startswith("PAUSE_OPTIONAL_ADDS")
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_swing_sample_recomputes_risk_and_stops_before_broker(
+    variant: str,
+    tmp_path: Path,
+) -> None:
+    sample_dir = _sample_dir("swing-opportunity-daily", variant)
+    exposure = _load(sample_dir / "00_exposure_decision.json")
+    circuit = _load(sample_dir / "01_circuit_breaker_decision.json")
+    setups = _load(sample_dir / "07_validated_setups.json")
+    sizing = _load(sample_dir / "08_position_sizing.json")
+    thesis = _load(sample_dir / "10_candidate_journal_entry.yaml")
+    discipline = _load(sample_dir / "11_pre_trade_discipline_decision.json")
+
+    assert exposure["recommendation"] == "NEW_ENTRY_ALLOWED"
+    assert circuit["recommendation"] == "TRADING_ALLOWED"
+    setup = setups["setups"][0]
+    parameters = sizing["parameters"]
+    assert setup["entry_price"] == parameters["entry_price"]
+    assert setup["stop_price"] == parameters["stop_price"]
+
+    risk_budget = parameters["account_size"] * parameters["risk_pct"] / 100
+    risk_per_share = parameters["entry_price"] - parameters["stop_price"]
+    shares = math.floor(risk_budget / risk_per_share)
+    assert sizing["final_recommended_shares"] == shares == 200
+    assert sizing["final_risk_dollars"] == shares * risk_per_share == 500.0
+    assert sizing["final_position_value"] == shares * parameters["entry_price"]
+
+    output_dir = tmp_path / f"position-{variant}"
+    subprocess.run(
+        [
+            sys.executable,
+            "skills/position-sizer/scripts/position_sizer.py",
+            "--account-size",
+            str(parameters["account_size"]),
+            "--entry",
+            str(parameters["entry_price"]),
+            "--stop",
+            str(parameters["stop_price"]),
+            "--risk-pct",
+            str(parameters["risk_pct"]),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    generated = _load(next(output_dir.glob("position_sizer_*.json")))
+    assert generated == sizing
+
+    schema = _load(ROOT / "skills" / "trader-memory-core" / "schemas" / "thesis.schema.json")
+    Draft7Validator(schema, format_checker=FormatChecker()).validate(thesis)
+    thesis_store = _module(
+        f"issue208_thesis_store_{variant.replace('-', '_')}",
+        ROOT / "skills" / "trader-memory-core" / "scripts" / "thesis_store.py",
+    )
+    thesis_store._validate_thesis(thesis)
+    assert thesis["ticker"] == setup["symbol"] == "EXMPL"
+    assert thesis["entry"]["target_price"] == parameters["entry_price"]
+    assert thesis["exit"]["stop_loss"] == parameters["stop_price"]
+    assert thesis["position"]["shares"] == shares
+    assert thesis["position"]["risk_dollars"] == sizing["final_risk_dollars"]
+    assert thesis["status"] == "ENTRY_READY"
+
+    result = discipline["candidate_results"][0]
+    assert discipline["overall_decision"] == result["decision"] == "GO"
+    assert result["symbol"] == thesis["ticker"]
+    assert result["thesis_id"] == thesis["thesis_id"]
+    assert result["checklist_answers"]["planned_risk_dollars"] == sizing["final_risk_dollars"]
+    assert result["checklist_answers"]["actual_risk_dollars"] == sizing["final_risk_dollars"]
+    assert "no order submitted" in result["checklist_answers"]["notes"].lower()
+
+    companion = (sample_dir / "11_pre_trade_discipline_decision.md").read_text(encoding="utf-8")
+    for value in ("200 shares", "$50.00", "$47.50", "$500.00", "NOT_SUBMITTED"):
+        assert value in companion
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_swing_decision_engines_reproduce_allowed_gates(
+    variant: str,
+    tmp_path: Path,
+) -> None:
+    sample_dir = _sample_dir("swing-opportunity-daily", variant)
+    exposure_path = sample_dir / "00_exposure_decision.json"
+    circuit_path = sample_dir / "01_circuit_breaker_decision.json"
+    expected_exposure = _load(exposure_path)
+    expected_circuit = _load(circuit_path)
+    thesis = _load(sample_dir / "10_candidate_journal_entry.yaml")
+    expected_gate = _load(sample_dir / "11_pre_trade_discipline_decision.json")
+
+    exposure = _module(
+        f"issue208_exposure_{variant.replace('-', '_')}",
+        ROOT / "skills" / "exposure-coach" / "scripts" / "calculate_exposure.py",
+    )
+    scores = {
+        "regime": None,
+        "top_risk": 65,
+        "breadth": 70,
+        "uptrend": 74,
+        "institutional": None,
+        "sector": None,
+        "theme": None,
+        "ftd": None,
+    }
+    composite, provided, missing = exposure.calculate_composite_score(scores)
+    recommendation = exposure.determine_recommendation(
+        composite,
+        scores["top_risk"],
+        len(set(missing) & exposure.CRITICAL_INPUTS),
+    )
+    participation = exposure.determine_participation(
+        scores["uptrend"],
+        scores["breadth"],
+        None,
+    )
+    bias = exposure.determine_bias("unknown", None, None, None)
+    actual_exposure = {
+        "schema_version": "1.0",
+        "generated_at": expected_exposure["generated_at"],
+        "exposure_ceiling_pct": exposure.determine_exposure_ceiling(composite),
+        "bias": bias,
+        "participation": participation,
+        "recommendation": recommendation,
+        "confidence": exposure.determine_confidence(provided, missing),
+        "composite_score": round(composite, 1),
+        "component_scores": {
+            "breadth_score": scores["breadth"],
+            "uptrend_score": scores["uptrend"],
+            "top_risk_score": scores["top_risk"],
+        },
+        "inputs_provided": provided,
+        "inputs_missing": missing,
+        "rationale": exposure.generate_rationale(
+            composite,
+            recommendation,
+            participation,
+            bias,
+            scores,
+            missing,
+        ),
+    }
+    assert actual_exposure == expected_exposure
+
+    breaker = _module(
+        f"issue208_breaker_{variant.replace('-', '_')}",
+        ROOT / "skills" / "drawdown-circuit-breaker" / "scripts" / "check_circuit_breaker.py",
+    )
+    actual_circuit = breaker.evaluate_circuit_breaker(
+        [],
+        account_size=100000.0,
+        as_of=datetime.fromisoformat("2026-06-29T08:05:00-04:00"),
+        config=breaker.CircuitConfig(),
+    )
+    actual_circuit["generated_at"] = expected_circuit["generated_at"]
+    assert actual_circuit == expected_circuit
+
+    gate = _module(
+        f"issue208_gate_{variant.replace('-', '_')}",
+        ROOT / "skills" / "pre-trade-discipline-gate" / "scripts" / "check_pre_trade_discipline.py",
+    )
+    candidate = {
+        "symbol": thesis["ticker"],
+        "thesis_id": thesis["thesis_id"],
+        "order_intent": "MANUAL_ORDER",
+        "entry_in_written_plan": True,
+        "stop_predefined": True,
+        "size_within_plan": True,
+        "planned_risk_dollars": 500.0,
+        "actual_risk_dollars": 500.0,
+        "notes": "Fictional 200-share plan; no order submitted.",
+    }
+    actual_gate = gate.evaluate_pre_trade_gate(
+        [candidate],
+        as_of=datetime.fromisoformat("2026-06-29T08:30:00-04:00"),
+        state_dir=None,
+        revenge_window_hours=24.0,
+        market_regime_decision=exposure_path,
+        circuit_breaker_decision=circuit_path,
+        output_dir=tmp_path / f"gate-{variant}",
+        json_only=False,
+    )
+    gate.finalize_links(
+        actual_gate,
+        state_dir=None,
+        as_of=datetime.fromisoformat("2026-06-29T08:30:00-04:00"),
+    )
+    actual_gate["generated_at"] = expected_gate["generated_at"]
+    actual_gate["inputs"]["market_regime_decision"] = Path(
+        actual_gate["inputs"]["market_regime_decision"]
+    ).name
+    actual_gate["inputs"]["circuit_breaker_decision"] = Path(
+        actual_gate["inputs"]["circuit_breaker_decision"]
+    ).name
+    actual_gate["artifact_paths"] = expected_gate["artifact_paths"]
+    assert actual_gate == expected_gate
+
+
+def test_full_swing_optional_handoffs_are_complete_and_consistent() -> None:
+    sample_dir = _sample_dir("swing-opportunity-daily", "sample-run-full-path")
+    setups = _load(sample_dir / "07_validated_setups.json")
+    sizing = _load(sample_dir / "08_position_sizing.json")
+    plans = _load(sample_dir / "09_trade_plans.json")
+    thesis = _load(sample_dir / "10_candidate_journal_entry.yaml")
+
+    assert len(setups["inputs_provided"]) == 5
+    assert setups["inputs_missing"] == []
+    assert _load(sample_dir / "04_exhaustion_hammer_candidates.json")["candidates"] == []
+
+    plan = plans["plans"][0]
+    assert plan["symbol"] == thesis["ticker"]
+    assert plan["shares"] == sizing["final_recommended_shares"]
+    assert plan["planned_risk_dollars"] == sizing["final_risk_dollars"]
+    assert plan["entry_price"] == thesis["entry"]["target_price"]
+    assert plan["stop_price"] == thesis["exit"]["stop_loss"]
+    assert plan["order_status"] == "PROPOSED_NOT_SUBMITTED"
+    assert plans["manual_execution_required"] is True
+
+
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_monthly_aggregate_and_evidence_graph_are_consistent(variant: str) -> None:
+    sample_dir = _sample_dir("monthly-performance-review", variant)
+    aggregate = _load(sample_dir / "01_monthly_aggregate.json")
+    postmortem = _load(sample_dir / "02_aggregate_postmortem.json")
+    decisions = _load(sample_dir / "06_monthly_decision_log.json")
+    rules = _load(sample_dir / "06_rule_changes_for_next_month.yaml")
+
+    trades = aggregate["trades"]
+    summary = aggregate["summary"]
+    assert summary["closed_trades"] == len(trades) == 3
+    assert summary["winners"] == sum(item["realized_pnl"] > 0 for item in trades) == 2
+    assert summary["losers"] == sum(item["realized_pnl"] < 0 for item in trades) == 1
+    assert summary["realized_pnl"] == sum(item["realized_pnl"] for item in trades) == 300.0
+    assert summary["win_rate_pct"] == round(summary["winners"] / len(trades) * 100, 2)
+
+    category_counts = Counter(item["root_cause"] for item in trades)
+    assert sum(postmortem["category_counts"].values()) == len(trades)
+    for category, count in postmortem["category_counts"].items():
+        assert count == category_counts.get(category, 0)
+
+    trade_ids = {item["trade_id"] for item in trades}
+    postmortem_ids = {item["evidence_id"] for item in postmortem["findings"]}
+    assert set(postmortem["source_trade_ids"]) == trade_ids
+    for finding in postmortem["findings"]:
+        assert set(finding["trade_ids"]) <= trade_ids
+
+    behavior_ids: set[str] = set()
+    operating_rule_ids: set[str] = set()
+    if variant == "sample-run-full-path":
+        coach = _load(sample_dir / "03_monthly_performance_coach_report.json")
+        behavior = _load(sample_dir / "03_monthly_behavior_patterns.json")
+        operating_rules = _load(sample_dir / "03_next_month_operating_rules.yaml")
+        skill_review = _load(sample_dir / "05_skill_review_findings.json")
+        assert behavior["source_review_id"] == coach["review_id"]
+        assert operating_rules["source_review_id"] == coach["review_id"]
+        for pattern in behavior["patterns"]:
+            for source_field in pattern["source_fields"]:
+                source_value: Any = aggregate
+                for field_part in source_field.split("."):
+                    assert isinstance(source_value, dict)
+                    assert field_part in source_value
+                    source_value = source_value[field_part]
+        behavior_ids = {item["evidence_id"] for item in behavior["patterns"]}
+        operating_rule_ids = {item["rule_id"] for item in operating_rules["rules"]}
+        source_evidence_ids = trade_ids | postmortem_ids | behavior_ids
+        for operating_rule in operating_rules["rules"]:
+            assert set(operating_rule["evidence_ids"]) <= source_evidence_ids
+        for review in skill_review["reviews"]:
+            assert set(review["trade_ids"]) <= trade_ids
+
+    source_evidence_ids = trade_ids | postmortem_ids | behavior_ids
+    decision_evidence_ids = source_evidence_ids | operating_rule_ids
+    for decision in decisions["decisions"]:
+        assert set(decision["evidence_ids"]) <= decision_evidence_ids
+
+    for rule in rules["rules"]:
+        assert set(rule["evidence_ids"]) <= source_evidence_ids
+        if variant == "sample-run-full-path":
+            assert rule["source_rule_id"] in operating_rule_ids
+
+
+def test_full_monthly_optional_outputs_are_reproducible_and_schema_valid() -> None:
+    sample_dir = _sample_dir("monthly-performance-review", "sample-run-full-path")
+    aggregate_path = sample_dir / "01_monthly_aggregate.json"
+    coach = _load(sample_dir / "03_monthly_performance_coach_report.json")
+    behavior = _load(sample_dir / "03_monthly_behavior_patterns.json")
+    operating_rules = _load(sample_dir / "03_next_month_operating_rules.yaml")
+    hypothesis = _load(sample_dir / "04_hypothesis_revalidation.json")
+    skill_review = _load(sample_dir / "05_skill_review_findings.json")
+    decisions = _load(sample_dir / "06_monthly_decision_log.json")
+    backlog = _load(sample_dir / "06_skill_improvement_backlog.yaml")
+
+    schema = _load(
+        ROOT
+        / "skills"
+        / "trade-performance-coach"
+        / "assets"
+        / "performance_coach_report.schema.json"
+    )
+    validator_class = validators.validator_for(schema)
+    validator_class.check_schema(schema)
+    validator_class(schema).validate(coach)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "skills/trade-performance-coach/scripts/review_trade_performance.py",
+            "--input",
+            str(aggregate_path.relative_to(ROOT)),
+            "--stdout",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    generated = json.loads(completed.stdout)
+    for field in (
+        "schema_version",
+        "review_type",
+        "review_id",
+        "source_records",
+        "overall_verdict",
+        "summary",
+        "scores",
+        "process_adherence_findings",
+        "risk_manager_notes",
+        "execution_quality_assessment",
+        "behavioral_pattern_tags",
+        "next_session_operating_rules",
+        "coach_questions",
+        "human_decision_gate",
+        "disclaimer",
+    ):
+        assert generated[field] == coach[field]
+
+    coach_patterns = {
+        (item["tag"], item["confidence"]) for item in coach["behavioral_pattern_tags"]
+    }
+    artifact_patterns = {(item["tag"], item["confidence"]) for item in behavior["patterns"]}
+    assert artifact_patterns == coach_patterns
+    assert len(operating_rules["rules"]) == len(coach["next_session_operating_rules"])
+
+    returns = hypothesis["sample_returns_r"]
+    metrics = hypothesis["metrics"]
+    assert metrics["trade_count"] == len(returns) == 10
+    assert metrics["wins"] == sum(value > 0 for value in returns) == 6
+    assert metrics["losses"] == sum(value < 0 for value in returns) == 4
+    assert metrics["total_return_r"] == sum(returns) == 2.0
+    assert metrics["average_return_r"] == sum(returns) / len(returns) == 0.2
+    assert metrics["win_rate_pct"] == metrics["wins"] / len(returns) * 100 == 60.0
+    assert hypothesis["hypothesis_id"] == decisions["hypothesis_decision"]["hypothesis_id"]
+    assert hypothesis["verdict"] == decisions["hypothesis_decision"]["verdict"]
+    assert decisions["hypothesis_decision"]["action"] == "NO_STRATEGY_CLAIM"
+
+    review_ids = {item["evidence_id"] for item in skill_review["reviews"]}
+    backlog_by_id = {item["backlog_id"]: item for item in backlog["items"]}
+    assert set(backlog_by_id) == {"IMP-001"}
+    for item in backlog["items"]:
+        assert set(item["evidence_ids"]) <= review_ids
+    assert backlog["trade_rules_included"] is False
+    repo_improvements = {item["backlog_id"]: item for item in decisions["repo_improvements"]}
+    assert set(repo_improvements) == set(backlog_by_id)
+    for backlog_id, improvement in repo_improvements.items():
+        assert set(improvement["evidence_ids"]) == set(backlog_by_id[backlog_id]["evidence_ids"])
+        assert set(improvement["evidence_ids"]) <= review_ids


### PR DESCRIPTION
## Summary

- add deterministic fictional `sample-run/` and `sample-run-full-path/` examples for `core-portfolio-weekly`, `swing-opportunity-daily`, and `monthly-performance-review`
- link the required samples from the English and Japanese README starting paths
- add strict contract tests for manifest/workflow parity, artifact completeness, executable output reproduction, cross-artifact invariants, prerequisite safety state, and monthly evidence provenance

## Review loops

- plan review: 2 rounds; all findings addressed
- implementation review: 3 rounds; all findings addressed

## Validation

- `python3 -m pytest scripts/tests/test_workflow_examples_issue208.py -q` — 18 passed
- `python3 -m pytest scripts/tests -q` — 444 passed
- `bash scripts/run_all_tests.sh` with the existing project environment — 69/69 suites passed
- `pre-commit run --all-files` — passed
- pre-push strict validation and all skill tests — passed

The full matrix retains the existing covered exclusion for `pair-trade-screener` because its optional `statsmodels` dependency is not installed.

Closes #208
