### PR TITLE
ci: require tests for executable skills

### DIFF
--- a/scripts/ci_test_matrix.py
+++ b/scripts/ci_test_matrix.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+POLICY_GATE_ID = "executable-test-policy"
 
 
 @dataclass(frozen=True)
@@ -59,7 +60,42 @@ class MatrixError(ValueError):
 
 
 def _has_tests(path: Path) -> bool:
-    return path.is_dir() and any(path.glob("test_*.py"))
+    return path.is_dir() and any(candidate.is_file() for candidate in path.glob("test_*.py"))
+
+
+def executable_test_inventory(root: Path = ROOT) -> dict[str, bool]:
+    """Return canonical-test presence for every skill with executable Python scripts."""
+    skills_dir = root / "skills"
+    if not skills_dir.is_dir():
+        raise MatrixError(f"skills directory is missing: {skills_dir}")
+    inventory: dict[str, bool] = {}
+    for skill_dir in sorted(path for path in skills_dir.iterdir() if path.is_dir()):
+        skill_id = skill_dir.name
+        if not ID_RE.fullmatch(skill_id):
+            raise MatrixError(f"unsafe skill id: {skill_id!r}")
+        scripts_dir = skill_dir / "scripts"
+        executable_scripts = tuple(
+            path
+            for path in sorted(scripts_dir.glob("*.py"))
+            if path.is_file() and path.name != "__init__.py"
+        )
+        if not executable_scripts:
+            continue
+        inventory[skill_id] = any(
+            _has_tests(skill_dir / relative) for relative in (Path("scripts/tests"), Path("tests"))
+        )
+    return inventory
+
+
+def validate_executable_test_coverage(root: Path = ROOT) -> None:
+    """Fail when any skill has Python scripts but no canonical tests."""
+    missing = sorted(
+        skill_id for skill_id, has_tests in executable_test_inventory(root).items() if not has_tests
+    )
+    if missing:
+        raise MatrixError(
+            "skills with executable scripts lack canonical tests: " + ", ".join(missing)
+        )
 
 
 def discover(root: Path = ROOT) -> dict[str, TestEntry]:
@@ -304,11 +340,28 @@ def main(argv: list[str] | None = None) -> int:
     aggregate_parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
 
-    try:
-        entries = build_entries()
-        if args.command == "matrix":
+    if args.command == "matrix":
+        try:
+            validate_executable_test_coverage(ROOT)
+            entries = build_entries()
             print(json.dumps(matrix(entries), separators=(",", ":")))
-        elif args.command == "list":
+        except (MatrixError, OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            # ci.yml captures this command inside echo, which masks its exit status.
+            # Emit a blocking row so the next direct CLI invocation fails visibly.
+            print(
+                json.dumps(
+                    {"include": [{"id": POLICY_GATE_ID, "allowed_failure": False}]},
+                    separators=(",", ":"),
+                )
+            )
+            return 1
+        return 0
+
+    try:
+        validate_executable_test_coverage(ROOT)
+        entries = build_entries()
+        if args.command == "list":
             for entry in entries.values():
                 if not entry.excluded:
                     print(entry.id)

--- a/scripts/tests/test_ci_test_matrix.py
+++ b/scripts/tests/test_ci_test_matrix.py
@@ -8,15 +8,18 @@ from types import SimpleNamespace
 import pytest
 
 from scripts.ci_test_matrix import (
+    POLICY_GATE_ID,
     MatrixError,
     TestEntry,
     aggregate,
     build_entries,
     discover,
+    executable_test_inventory,
     install,
     main,
     matrix,
     run,
+    validate_executable_test_coverage,
 )
 
 
@@ -24,6 +27,72 @@ def _test_file(root: Path, relative: str) -> None:
     path = root / relative
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+
+
+def _script_file(root: Path, skill_id: str, name: str = "run.py") -> None:
+    path = root / "skills" / skill_id / "scripts" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("def main():\n    return 0\n", encoding="utf-8")
+
+
+def test_executable_inventory_requires_canonical_test_files(tmp_path):
+    for skill_id in ("covered", "missing", "empty", "nested-only"):
+        _script_file(tmp_path, skill_id)
+    _test_file(tmp_path, "skills/covered/scripts/tests/test_covered.py")
+    (tmp_path / "skills/empty/scripts/tests").mkdir(parents=True)
+    (tmp_path / "skills/empty/scripts/tests/test_directory.py").mkdir()
+    _test_file(
+        tmp_path,
+        "skills/nested-only/examples/skills/nested/scripts/tests/test_nested.py",
+    )
+
+    assert executable_test_inventory(tmp_path) == {
+        "covered": True,
+        "empty": False,
+        "missing": False,
+        "nested-only": False,
+    }
+    with pytest.raises(
+        MatrixError,
+        match="skills with executable scripts lack canonical tests: empty, missing, nested-only",
+    ):
+        validate_executable_test_coverage(tmp_path)
+
+
+def test_executable_inventory_accepts_tests_layout_and_ignores_init_only(tmp_path):
+    _script_file(tmp_path, "direct-tests")
+    _test_file(tmp_path, "skills/direct-tests/tests/test_direct.py")
+    _script_file(tmp_path, "init-only", "__init__.py")
+
+    assert executable_test_inventory(tmp_path) == {"direct-tests": True}
+    validate_executable_test_coverage(tmp_path)
+
+
+def test_executable_inventory_rejects_missing_or_unsafe_skills_directory(tmp_path):
+    with pytest.raises(MatrixError, match="skills directory is missing"):
+        executable_test_inventory(tmp_path)
+
+    _script_file(tmp_path, "Unsafe")
+    with pytest.raises(MatrixError, match="unsafe skill id"):
+        executable_test_inventory(tmp_path)
+
+
+def test_cli_matrix_emits_blocking_policy_row_for_untested_script(monkeypatch, tmp_path, capsys):
+    _script_file(tmp_path, "untested")
+    monkeypatch.setattr("scripts.ci_test_matrix.ROOT", tmp_path)
+    monkeypatch.setattr("scripts.ci_test_matrix.POLICY", {})
+
+    assert main(["matrix"]) == 1
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "include": [{"id": POLICY_GATE_ID, "allowed_failure": False}]
+    }
+    assert "skills with executable scripts lack canonical tests: untested" in captured.err
+
+    assert main(["install", POLICY_GATE_ID]) == 1
+    assert (
+        "skills with executable scripts lack canonical tests: untested" in capsys.readouterr().err
+    )
 
 
 def test_discover_supports_both_direct_skill_layouts_and_repo_tests(tmp_path):


### PR DESCRIPTION
## Summary

- inventory every skill with top-level executable Python scripts before building the CI test matrix
- require at least one real canonical test file under `scripts/tests/` or `tests/`
- emit a blocking policy row when matrix validation fails so GitHub Actions still fails clearly even though the current workflow wraps matrix generation in `echo`
- cover empty, nested-only, directory-only, unsafe-id, alternate canonical layout, and direct CLI failure cases

## Why

The existing matrix starts from test directories, so a skill with executable scripts but no tests is invisible. This lands the first ratchet slice from Issue #293. It applies the gate to all 68 currently executable skills, which is stricter than the production-only minimum and avoids a dependency on YAML parsing before CI installs project packages.

## Validation

- `python3.9 -m pytest scripts/tests/test_ci_test_matrix.py -q` — 18 passed
- `ruff check scripts/ci_test_matrix.py scripts/tests/test_ci_test_matrix.py`
- `ruff format --check scripts/ci_test_matrix.py scripts/tests/test_ci_test_matrix.py`
- `python3 scripts/ci_test_matrix.py matrix`
- catalog, skill-doc, workflow-doc, skillset-doc, strict metadata/workflow, skillset, and navigator snapshot drift checks
- `bash scripts/run_all_tests.sh` — 72/72 suites passed
- `pre-commit run --all-files` — all hooks passed
- `git diff --check`

The first sandboxed full-test attempt could not read `~/.cache/uv`; the same command was rerun with cache access and passed.

## Review loops

- Plan review: 2 rounds (round 1 revised; round 2 approved)
- Implementation review: 3 rounds (rounds 1-2 revised; round 3 approved)

## Issue state

Refs #293

Keep Issue #293 open. This PR lands only the missing-test inventory/hard-fail ratchet. Per-skill coverage floors, expiry/Issue linkage for allowed failures, and versioned exemption/knowledge-only policy remain follow-up acceptance criteria.
