### PR TITLE
docs(dev): redact personal gh username from maintenance runbook

### DIFF
--- a/docs/dev/maintenance-runbook.md
+++ b/docs/dev/maintenance-runbook.md
@@ -230,19 +230,18 @@ Common outcomes and where they come from (grep the `*.log`):
 ## 6. The `gh` account gotcha
 
 PR / issue creation on `tradermonty/claude-trading-skills` requires the
-**`tradermonty`** `gh` account to be active. Both `tradermonty` and
-`takusaotome` are logged in; the active one is global `gh` state and may be
-either at session start. Before any `gh pr create` / `gh issue` / scheduled
-job that opens a PR:
+**`tradermonty`** `gh` account to be active. If more than one account is logged
+in, the active one is global `gh` state and may be any of them at session
+start. Before any `gh pr create` / `gh issue` / scheduled job that opens a PR:
 
 ```bash
 gh auth switch --hostname github.com --user tradermonty
 gh auth status | grep -A1 'Active account: true'
 ```
 
-With the wrong account, PR creation fails with
-`GraphQL: must be a collaborator (createPullRequest)` (`takusaotome` is not a
-collaborator). Reverting afterward is optional (local preference only).
+With a non-collaborator account active, PR creation fails with
+`GraphQL: must be a collaborator (createPullRequest)`. Reverting afterward is
+optional (local preference only).
 
 ---
 


### PR DESCRIPTION
## Summary

`docs/dev/maintenance-runbook.md` §6 named a personal GitHub account
(`takusaotome`) in two places to explain why `gh pr create` can fail with
`GraphQL: must be a collaborator`. This is a public repository, so the wording
is generalized.

## Changes

| Before | After |
|---|---|
| ``Both `tradermonty` and `takusaotome` are logged in`` | `If more than one account is logged in` |
| ``(`takusaotome` is not a collaborator)`` | `With a non-collaborator account active, ...` |

The actionable content is unchanged: switch to `tradermonty` before opening a
PR, and the exact error string to grep for on failure.

## Verification

- `grep -rn "takusaotome"` over the tracked tree returns no hits. The only
  remaining occurrences are in `logs/*.log`, which are excluded by `.gitignore`.
- Full pre-push suite (pre-commit hooks + `Run all skill tests`) passed.

## Note

The string still exists in the history of commit `6da55c7`. Purging it from
git history would require a rewrite + force push, which is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsJQBiW1xXWFRpyVqw1g56
