### PR TITLE
ci: enforce executable skill coverage ratchets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"
+      - name: Install policy dependency
+        run: pip install "packaging>=24.0" "pyyaml>=6.0"
       - name: Discover and validate test coverage
         id: discover
         run: echo "matrix=$(python3 scripts/ci_test_matrix.py matrix)" >> "$GITHUB_OUTPUT"
@@ -74,7 +76,7 @@ jobs:
         with:
           name: coverage-${{ matrix.id }}
           path: coverage-data/
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 1
 
   coverage:
@@ -100,6 +102,14 @@ jobs:
           python scripts/ci_test_matrix.py aggregate
           --artifacts coverage-artifacts
           --output combined-coverage
+      - name: Upload executable-code coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: executable-code-coverage-report
+          path: combined-coverage/
+          if-no-files-found: error
+          retention-days: 14
 
   metadata:
     name: Metadata + Workflow checks

--- a/config/ci-test-policy.yaml
+++ b/config/ci-test-policy.yaml
@@ -1,0 +1,205 @@
+schema_version: 1
+
+# Coverage is measured on executable code only. Test modules under */tests/*
+# are excluded from both per-skill and repository aggregates.
+aggregate_coverage:
+  target: 75
+  waiver:
+    floor: 73
+    target: 75
+    expires_on: "2026-10-31"
+    issue: 293
+    reason: Current executable-code repository coverage is below the 75% target.
+
+coverage:
+  default_target: 70
+  tiers:
+    core-risk-math-state:
+      target: 85
+      skills:
+      - drawdown-circuit-breaker
+      - futures-position-sizer
+      - position-sizer
+      - trader-memory-core
+  waivers:
+    breadth-chart-analyst:
+      floor: 25
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    canslim-screener:
+      floor: 48
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    dividend-growth-pullback-screener:
+      floor: 39
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    downtrend-duration-analyzer:
+      floor: 46
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    earnings-calendar:
+      floor: 48
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    earnings-trade-analyzer:
+      floor: 67
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    economic-calendar-fetcher:
+      floor: 69
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    edge-candidate-agent:
+      floor: 40
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    edge-strategy-designer:
+      floor: 47
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    ftd-detector:
+      floor: 65
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    ibd-distribution-day-monitor:
+      floor: 38
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    institutional-flow-tracker:
+      floor: 65
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    market-breadth-analyzer:
+      floor: 69
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    pair-trade-screener:
+      floor: 56
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    pead-screener:
+      floor: 69
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    position-sizer:
+      floor: 71
+      target: 85
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet core financial-math coverage toward the 85% target.
+    signal-postmortem:
+      floor: 40
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    skill-designer:
+      floor: 47
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    skill-idea-miner:
+      floor: 60
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    stockbee-20pct-study:
+      floor: 69
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    stockbee-episodic-pivot-analyzer:
+      floor: 59
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    stockbee-exhaustion-hammer-screener:
+      floor: 59
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    stockbee-momentum-burst-screener:
+      floor: 57
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    stockbee-setup-fluency-trainer:
+      floor: 53
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    strategy-pivot-designer:
+      floor: 63
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    us-market-bubble-detector:
+      floor: 43
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+    value-dividend-screener:
+      floor: 34
+      target: 70
+      expires_on: "2026-10-31"
+      issue: 293
+      reason: Ratchet from the 2026-08-10 executable-code baseline.
+
+# Runtime exceptions are data, not code. Every entry must carry a future
+# expiry, linked issue, and reason. There are currently no allowed failures.
+allowed_failures: {}
+
+matrix:
+  canslim-screener:
+    test_paths:
+    - skills/canslim-screener/scripts/tests/test_fmp_fallback.py
+    - skills/canslim-screener/scripts/tests/test_fmp_stable_migration.py
+    - skills/canslim-screener/scripts/tests/test_institutional_fallback.py
+    requirements:
+    - beautifulsoup4
+    - lxml
+    reason: Preserve the focused FMP contract suite and optional dependencies.
+  pair-trade-screener:
+    requirements:
+    - statsmodels>=0.14,<0.15
+    reason: Install the statistical runtime only for this dedicated CI row.

--- a/config/ci-test-policy.yaml
+++ b/config/ci-test-policy.yaml
@@ -5,11 +5,11 @@ schema_version: 1
 aggregate_coverage:
   target: 75
   waiver:
-    floor: 73
+    floor: 72
     target: 75
     expires_on: "2026-10-31"
     issue: 293
-    reason: Current executable-code repository coverage is below the 75% target.
+    reason: Cross-platform executable-code coverage is below the 75% target.
 
 coverage:
   default_target: 70

--- a/docs/dev/ci-test-coverage-policy.md
+++ b/docs/dev/ci-test-coverage-policy.md
@@ -52,11 +52,12 @@ CI maintenance. Once a skill reaches its target, remove its waiver instead of
 resetting the baseline.
 
 The 2026-08-10 baseline uses executable code only. Across the current 69
-executable skills plus root repository scripts, the implementation validation
-measured 35,429 covered statements out of 48,073 (73.698%). The temporary
-repository effective floor is therefore 73%, with a 75% target. Per-skill
-floors use the cross-platform CI baseline when it is lower than the local
-measurement. All current waivers expire on 2026-10-31 and link to Issue #293.
+executable skills plus root repository scripts, Linux CI measured 35,031
+covered statements out of 48,073 (72.870%); local Python 3.9 validation
+measured 35,429 out of 48,073 (73.698%). The temporary repository effective
+floor is therefore the lower cross-platform baseline rounded down to 72%, with
+a 75% target. Per-skill floors follow the same cross-platform rule. All current
+waivers expire on 2026-10-31 and link to Issue #293.
 
 ### Burn-down schedule
 

--- a/docs/dev/ci-test-coverage-policy.md
+++ b/docs/dev/ci-test-coverage-policy.md
@@ -1,0 +1,74 @@
+# CI test and executable-code coverage policy
+
+`config/ci-test-policy.yaml` is the single source of truth for the dynamic
+pytest matrix, temporary allowed failures, and coverage floors. The CI runner
+rejects unknown fields, unsafe paths or dependency strings, stale skill IDs,
+expired exceptions, and policy/artifact mismatches.
+
+## Test-presence gate
+
+Every skill with executable `skills/<id>/scripts/**/*.py` code must have at
+least one canonical `test_*.py` file in `scripts/tests/` or `tests/`.
+Files under a `tests/` directory and `__init__.py` are not executables.
+This applies to production, beta, experimental, and deprecated skills so that a
+status change cannot make an untested executable disappear from CI. An empty
+test directory does not satisfy the gate.
+
+Script-free production skills must declare `knowledge_only: true` in
+`skills-index.yaml`. The marker is invalid for non-production skills and for a
+skill that contains executable Python scripts at any depth under `scripts/`.
+
+## Coverage measurement
+
+Coverage percentages include executable code and exclude all files matching
+`*/tests/*`:
+
+- Core risk, financial-math, and state-management skills have an 85% target:
+  `position-sizer`, `futures-position-sizer`, `trader-memory-core`, and
+  `drawdown-circuit-breaker`.
+- Every other executable skill has a 70% target, regardless of status.
+- The repository aggregate includes every executable skill plus code under the
+  root `scripts/` directory and has a 75% target.
+
+The aggregate step publishes `per-skill-coverage.json`,
+`per-skill-coverage.md`, the raw per-row coverage JSON, and the combined
+repository coverage JSON. It writes the reports before returning a failure for
+any floor violation, so failed CI still preserves actionable evidence.
+
+## Ratchet and waiver rules
+
+Coverage that is already at target has no waiver and may not regress below the
+target. A below-target baseline may temporarily declare an effective floor,
+but every waiver must include all of the following in versioned config:
+
+- the final target and a lower current floor;
+- an ISO `expires_on` date;
+- a linked GitHub issue number;
+- a non-empty reason.
+
+The loader fails closed after the expiry date. Lowering a floor or extending an
+expiry requires fresh measured evidence and explicit review; it is not routine
+CI maintenance. Once a skill reaches its target, remove its waiver instead of
+resetting the baseline.
+
+The 2026-08-10 baseline uses executable code only. Across the current 69
+executable skills plus root repository scripts, the implementation validation
+measured 35,429 covered statements out of 48,073 (73.698%). The temporary
+repository effective floor is therefore 73%, with a 75% target. Per-skill
+floors use the cross-platform CI baseline when it is lower than the local
+measurement. All current waivers expire on 2026-10-31 and link to Issue #293.
+
+### Burn-down schedule
+
+1. By 2026-08-31, prioritize skills below 50% and add happy-path, boundary,
+   error-path, and fail-closed tests around production code.
+2. By 2026-09-30, bring every remaining non-core executable to at least 70%
+   and remove its waiver as soon as it passes.
+3. By 2026-10-31, bring the four core skills to at least 85%, raise the
+   executable-code repository aggregate to at least 75%, and remove all
+   coverage waivers.
+
+`allowed_failures` are separate from coverage waivers. They permit a matrix row
+to be non-blocking only when the entry has its own future expiry, linked issue,
+and reason. There are currently no allowed-failure rows; `theme-detector` is a
+blocking suite.

--- a/docs/dev/metadata-and-workflow-schema.md
+++ b/docs/dev/metadata-and-workflow-schema.md
@@ -35,6 +35,7 @@ skills:
     display_name: <Human Title>
     category: <one of categories>
     status: production | beta | experimental | deprecated
+    knowledge_only: true  # required only for script-free production skills
     verification:
       instruction_contract: passed | not_verified | not_applicable
       unit_tests: passed | not_verified | not_applicable
@@ -72,6 +73,13 @@ skills:
 | `category` | One of the 8 enum values above. | `IDX005` |
 | `status` | One of `production` / `beta` / `experimental` / `deprecated`. | `IDX006` |
 | `summary` | Non-empty string. | `IDX009` |
+
+`knowledge_only: true` is the explicit CI exemption marker for a production
+skill that has no executable Python files at any depth under `scripts/`. The field
+must be boolean, may only be true on a production skill, and conflicts with any
+`scripts/**/*.py` file outside `tests/`, other than `__init__.py` (`IDX014`).
+Executable skills must ship canonical tests and cannot use this marker to
+bypass the test gate.
 
 **Best-effort** (warn-only by default; required under `--strict-metadata`):
 
@@ -444,6 +452,7 @@ python3 scripts/validate_skills_index.py --strict-metadata
 |---|---|
 | `IDX012` | Integration uses an `unknown` marker (`id` / `type` / `requirement`); flagged for owner review. Warning by default; error under `--strict-metadata`. |
 | `IDX013` | Missing production `verification` block, or a present block has the wrong type, missing/unknown axes, or invalid enum values. Missing block warns by default and errors under `--strict-metadata`; malformed present blocks always error. |
+| `IDX014` | Invalid `knowledge_only` type, non-production use, or conflict with executable Python scripts. |
 
 ### Workflow-level (strict-workflows)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ description = "Claude Skills for equity investors and traders"
 requires-python = ">=3.9"
 dependencies = [
     "jsonschema>=4.25.1",
+    "packaging>=24.0",
     "pyyaml>=6.0",
     "requests>=2.31.0",
     "scipy>=1.13.1",
@@ -67,7 +68,7 @@ testpaths = [
     "skills/stockbee-20pct-study/scripts/tests",
     "skills/stockbee-exhaustion-hammer-screener/scripts/tests",
     "skills/stockbee-momentum-burst-screener/scripts/tests",
-    # theme-detector excluded: 27+ pre-existing failures + duplicate basenames
+    "skills/theme-detector/scripts/tests",
     "skills/uptrend-analyzer/scripts/tests",
     "skills/vcp-screener/scripts/tests",
     "skills/earnings-trade-analyzer/scripts/tests",
@@ -142,7 +143,6 @@ ignore-regex = "(Depósito|Deposito) inicial"  # codespell:ignore inicial
 source = ["skills"]
 
 [tool.coverage.report]
-fail_under = 40
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/scripts/ci_test_matrix.py
+++ b/scripts/ci_test_matrix.py
@@ -1,22 +1,105 @@
 #!/usr/bin/env python3
-"""Discover and run skill tests without hand-maintained CI test steps."""
+"""Discover skill tests and enforce the versioned CI test/coverage policy."""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Iterable
 from dataclasses import dataclass, replace
+from datetime import date
 from pathlib import Path
 
+import yaml
+from packaging.requirements import InvalidRequirement, Requirement
+from yaml.resolver import BaseResolver
+
 ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = Path("config/ci-test-policy.yaml")
 ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 POLICY_GATE_ID = "executable-test-policy"
+
+
+class MatrixError(ValueError):
+    """Raised when discovery, policy, and artifacts do not form a closed matrix."""
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: UniqueKeyLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[object, object]:
+    loader.flatten_mapping(node)
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise MatrixError(f"unhashable YAML mapping key: {key!r}") from exc
+        if duplicate:
+            raise MatrixError(f"duplicate YAML key: {key!r}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(BaseResolver.DEFAULT_MAPPING_TAG, _construct_unique_mapping)
+
+
+@dataclass(frozen=True)
+class SkillMetadata:
+    status: str
+    knowledge_only: bool = False
+
+
+@dataclass(frozen=True)
+class DatedException:
+    expires_on: date
+    issue: int
+    reason: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "expires_on": self.expires_on.isoformat(),
+            "issue": self.issue,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class CoverageWaiver(DatedException):
+    floor: int
+    target: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "floor": self.floor,
+            "target": self.target,
+            **super().as_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class TestPolicy:
+    __test__ = False
+
+    aggregate_target: int
+    aggregate_waiver: CoverageWaiver | None
+    default_target: int
+    tier_targets: dict[str, int]
+    coverage_waivers: dict[str, CoverageWaiver]
+    allowed_failures: dict[str, DatedException]
+    matrix_overrides: dict[str, dict[str, object]]
+
+    def target_for(self, skill_id: str) -> int:
+        return self.tier_targets.get(skill_id, self.default_target)
 
 
 @dataclass(frozen=True)
@@ -25,38 +108,246 @@ class TestEntry:
 
     id: str
     test_paths: tuple[str, ...]
-    coverage_target: str
+    coverage_source: str
     requirements: tuple[str, ...] = ()
     allowed_failure: bool = False
-    excluded: bool = False
+    allowed_failure_policy: DatedException | None = None
+    coverage_target: int | None = None
+    coverage_floor: int | None = None
+    coverage_waiver: CoverageWaiver | None = None
     reason: str | None = None
+    policy_signature: str = ""
 
 
-# Only existing exceptions belong here. Newly discovered skills use the default policy.
-POLICY = {
-    "canslim-screener": {
-        "test_paths": (
-            "skills/canslim-screener/scripts/tests/test_fmp_fallback.py",
-            "skills/canslim-screener/scripts/tests/test_fmp_stable_migration.py",
-            "skills/canslim-screener/scripts/tests/test_institutional_fallback.py",
-        ),
-        "requirements": ("beautifulsoup4", "lxml"),
-        "reason": "Preserve the existing CI FMP contract subset and optional dependencies.",
-    },
-    "pair-trade-screener": {
-        "requirements": ("statsmodels>=0.14,<0.15",),
-        "reason": "Install the skill's statistical runtime only for its dedicated CI row.",
-    },
-    "theme-detector": {
-        "requirements": ("pandas", "numpy"),
-        "allowed_failure": True,
-        "reason": "Preserve the existing non-blocking known-failure CI contract.",
-    },
-}
+def _mapping(value: object, context: str) -> dict[object, object]:
+    if not isinstance(value, dict):
+        raise MatrixError(f"{context} must be a mapping")
+    return value
 
 
-class MatrixError(ValueError):
-    """Raised when discovered tests and policy do not form a closed matrix."""
+def _strict_keys(
+    value: dict[object, object],
+    *,
+    required: set[str],
+    optional: set[str] = frozenset(),
+    context: str,
+) -> None:
+    keys = set(value)
+    missing = sorted(required - keys)
+    unknown = sorted(keys - required - optional, key=repr)
+    if missing:
+        raise MatrixError(f"{context} missing keys: {', '.join(missing)}")
+    if unknown:
+        raise MatrixError(f"{context} has unknown keys: {unknown}")
+
+
+def _bounded_int(value: object, context: str, *, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        raise MatrixError(f"{context} must be an integer from {minimum} to {maximum}")
+    return value
+
+
+def _nonempty_string(value: object, context: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise MatrixError(f"{context} must be a non-empty string")
+    return value.strip()
+
+
+def _expiry(value: object, context: str, today: date) -> date:
+    raw = _nonempty_string(value, context)
+    try:
+        parsed = date.fromisoformat(raw)
+    except ValueError as exc:
+        raise MatrixError(f"{context} must use YYYY-MM-DD") from exc
+    if parsed < today:
+        raise MatrixError(f"{context} expired on {parsed.isoformat()}")
+    return parsed
+
+
+def _dated_exception(value: object, context: str, today: date) -> DatedException:
+    payload = _mapping(value, context)
+    _strict_keys(
+        payload,
+        required={"expires_on", "issue", "reason"},
+        context=context,
+    )
+    return DatedException(
+        expires_on=_expiry(payload["expires_on"], f"{context}.expires_on", today),
+        issue=_bounded_int(payload["issue"], f"{context}.issue", minimum=1, maximum=10**9),
+        reason=_nonempty_string(payload["reason"], f"{context}.reason"),
+    )
+
+
+def _coverage_waiver(value: object, context: str, today: date) -> CoverageWaiver:
+    payload = _mapping(value, context)
+    _strict_keys(
+        payload,
+        required={"floor", "target", "expires_on", "issue", "reason"},
+        context=context,
+    )
+    dated = _dated_exception(
+        {key: payload[key] for key in ("expires_on", "issue", "reason")}, context, today
+    )
+    floor = _bounded_int(payload["floor"], f"{context}.floor", minimum=0, maximum=100)
+    target = _bounded_int(payload["target"], f"{context}.target", minimum=1, maximum=100)
+    if floor >= target:
+        raise MatrixError(f"{context}.floor must be lower than target")
+    return CoverageWaiver(
+        floor=floor,
+        target=target,
+        expires_on=dated.expires_on,
+        issue=dated.issue,
+        reason=dated.reason,
+    )
+
+
+def _string_list(value: object, context: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise MatrixError(f"{context} must be a non-empty list")
+    result = tuple(_nonempty_string(item, f"{context}[]") for item in value)
+    if len(set(result)) != len(result):
+        raise MatrixError(f"{context} contains duplicates")
+    return result
+
+
+def _load_yaml(path: Path, context: str) -> object:
+    try:
+        return yaml.load(path.read_text(encoding="utf-8"), Loader=UniqueKeyLoader)
+    except (OSError, yaml.YAMLError) as exc:
+        raise MatrixError(f"cannot load {context}: {exc}") from exc
+
+
+def load_skill_metadata(root: Path = ROOT) -> dict[str, SkillMetadata]:
+    payload = _mapping(_load_yaml(root / "skills-index.yaml", "skills-index.yaml"), "skills-index")
+    skills = payload.get("skills")
+    if not isinstance(skills, list):
+        raise MatrixError("skills-index.skills must be a list")
+    result: dict[str, SkillMetadata] = {}
+    for index, item in enumerate(skills):
+        entry = _mapping(item, f"skills-index.skills[{index}]")
+        skill_id = entry.get("id")
+        if not isinstance(skill_id, str) or not ID_RE.fullmatch(skill_id):
+            raise MatrixError(f"unsafe skill id in skills-index: {skill_id!r}")
+        if skill_id in result:
+            raise MatrixError(f"duplicate skill id in skills-index: {skill_id}")
+        status = _nonempty_string(entry.get("status"), f"skills-index::{skill_id}.status")
+        knowledge_only = entry.get("knowledge_only", False)
+        if not isinstance(knowledge_only, bool):
+            raise MatrixError(f"skills-index::{skill_id}.knowledge_only must be a boolean")
+        result[skill_id] = SkillMetadata(status=status, knowledge_only=knowledge_only)
+    return result
+
+
+def load_policy(root: Path = ROOT, *, today: date | None = None) -> TestPolicy:
+    today = date.today() if today is None else today
+    payload = _mapping(_load_yaml(root / POLICY_PATH, str(POLICY_PATH)), str(POLICY_PATH))
+    _strict_keys(
+        payload,
+        required={
+            "schema_version",
+            "aggregate_coverage",
+            "coverage",
+            "allowed_failures",
+            "matrix",
+        },
+        context=str(POLICY_PATH),
+    )
+    if payload["schema_version"] != 1:
+        raise MatrixError(f"{POLICY_PATH}.schema_version must be 1")
+
+    aggregate = _mapping(payload["aggregate_coverage"], "aggregate_coverage")
+    _strict_keys(aggregate, required={"target", "waiver"}, context="aggregate_coverage")
+    aggregate_target = _bounded_int(
+        aggregate["target"], "aggregate_coverage.target", minimum=1, maximum=100
+    )
+    aggregate_waiver = (
+        None
+        if aggregate["waiver"] is None
+        else _coverage_waiver(aggregate["waiver"], "aggregate_coverage.waiver", today)
+    )
+    if aggregate_waiver is not None and aggregate_waiver.target != aggregate_target:
+        raise MatrixError("aggregate coverage waiver target does not match aggregate target")
+
+    coverage = _mapping(payload["coverage"], "coverage")
+    _strict_keys(
+        coverage,
+        required={"default_target", "tiers", "waivers"},
+        context="coverage",
+    )
+    default_target = _bounded_int(
+        coverage["default_target"], "coverage.default_target", minimum=1, maximum=100
+    )
+    tier_targets: dict[str, int] = {}
+    tiers = _mapping(coverage["tiers"], "coverage.tiers")
+    for tier_name, raw_tier in tiers.items():
+        if not isinstance(tier_name, str) or not ID_RE.fullmatch(tier_name):
+            raise MatrixError(f"unsafe coverage tier name: {tier_name!r}")
+        tier = _mapping(raw_tier, f"coverage.tiers.{tier_name}")
+        _strict_keys(
+            tier,
+            required={"target", "skills"},
+            context=f"coverage.tiers.{tier_name}",
+        )
+        target = _bounded_int(
+            tier["target"], f"coverage.tiers.{tier_name}.target", minimum=1, maximum=100
+        )
+        for skill_id in _string_list(tier["skills"], f"coverage.tiers.{tier_name}.skills"):
+            if not ID_RE.fullmatch(skill_id):
+                raise MatrixError(f"unsafe skill id in coverage tier: {skill_id!r}")
+            if skill_id in tier_targets:
+                raise MatrixError(f"skill appears in multiple coverage tiers: {skill_id}")
+            tier_targets[skill_id] = target
+
+    coverage_waivers: dict[str, CoverageWaiver] = {}
+    for skill_id, raw_waiver in _mapping(coverage["waivers"], "coverage.waivers").items():
+        if not isinstance(skill_id, str) or not ID_RE.fullmatch(skill_id):
+            raise MatrixError(f"unsafe coverage waiver skill id: {skill_id!r}")
+        coverage_waivers[skill_id] = _coverage_waiver(
+            raw_waiver, f"coverage.waivers.{skill_id}", today
+        )
+
+    allowed_failures: dict[str, DatedException] = {}
+    for skill_id, raw_exception in _mapping(
+        payload["allowed_failures"], "allowed_failures"
+    ).items():
+        if not isinstance(skill_id, str) or not ID_RE.fullmatch(skill_id):
+            raise MatrixError(f"unsafe allowed-failure skill id: {skill_id!r}")
+        allowed_failures[skill_id] = _dated_exception(
+            raw_exception, f"allowed_failures.{skill_id}", today
+        )
+
+    matrix_overrides: dict[str, dict[str, object]] = {}
+    for entry_id, raw_override in _mapping(payload["matrix"], "matrix").items():
+        if not isinstance(entry_id, str) or not ID_RE.fullmatch(entry_id):
+            raise MatrixError(f"unsafe matrix id: {entry_id!r}")
+        override = _mapping(raw_override, f"matrix.{entry_id}")
+        _strict_keys(
+            override,
+            required={"reason"},
+            optional={"test_paths", "requirements"},
+            context=f"matrix.{entry_id}",
+        )
+        parsed: dict[str, object] = {
+            "reason": _nonempty_string(override["reason"], f"matrix.{entry_id}.reason")
+        }
+        for field in ("test_paths", "requirements"):
+            if field in override:
+                parsed[field] = _string_list(override[field], f"matrix.{entry_id}.{field}")
+        matrix_overrides[entry_id] = parsed
+
+    policy = TestPolicy(
+        aggregate_target=aggregate_target,
+        aggregate_waiver=aggregate_waiver,
+        default_target=default_target,
+        tier_targets=tier_targets,
+        coverage_waivers=coverage_waivers,
+        allowed_failures=allowed_failures,
+        matrix_overrides=matrix_overrides,
+    )
+    for skill_id, waiver in coverage_waivers.items():
+        if waiver.target != policy.target_for(skill_id):
+            raise MatrixError(f"coverage waiver target mismatch for {skill_id}")
+    return policy
 
 
 def _has_tests(path: Path) -> bool:
@@ -64,7 +355,7 @@ def _has_tests(path: Path) -> bool:
 
 
 def executable_test_inventory(root: Path = ROOT) -> dict[str, bool]:
-    """Return canonical-test presence for every skill with executable Python scripts."""
+    """Return canonical-test presence for every skill with executable Python code."""
     skills_dir = root / "skills"
     if not skills_dir.is_dir():
         raise MatrixError(f"skills directory is missing: {skills_dir}")
@@ -76,8 +367,10 @@ def executable_test_inventory(root: Path = ROOT) -> dict[str, bool]:
         scripts_dir = skill_dir / "scripts"
         executable_scripts = tuple(
             path
-            for path in sorted(scripts_dir.glob("*.py"))
-            if path.is_file() and path.name != "__init__.py"
+            for path in sorted(scripts_dir.rglob("*.py"))
+            if path.is_file()
+            and path.name != "__init__.py"
+            and "tests" not in path.relative_to(scripts_dir).parts
         )
         if not executable_scripts:
             continue
@@ -87,15 +380,41 @@ def executable_test_inventory(root: Path = ROOT) -> dict[str, bool]:
     return inventory
 
 
-def validate_executable_test_coverage(root: Path = ROOT) -> None:
-    """Fail when any skill has Python scripts but no canonical tests."""
-    missing = sorted(
-        skill_id for skill_id, has_tests in executable_test_inventory(root).items() if not has_tests
-    )
+def validate_executable_test_coverage(
+    root: Path = ROOT, metadata: dict[str, SkillMetadata] | None = None
+) -> dict[str, bool]:
+    """Fail closed on missing tests or inconsistent knowledge-only metadata."""
+    metadata = load_skill_metadata(root) if metadata is None else metadata
+    inventory = executable_test_inventory(root)
+    unknown = sorted(set(inventory) - set(metadata))
+    if unknown:
+        raise MatrixError("executable skills missing from skills-index: " + ", ".join(unknown))
+    missing = sorted(skill_id for skill_id, has_tests in inventory.items() if not has_tests)
     if missing:
         raise MatrixError(
             "skills with executable scripts lack canonical tests: " + ", ".join(missing)
         )
+    invalid_knowledge = sorted(
+        skill_id
+        for skill_id, item in metadata.items()
+        if item.knowledge_only and (item.status != "production" or skill_id in inventory)
+    )
+    if invalid_knowledge:
+        raise MatrixError(
+            "knowledge_only must identify script-free production skills: "
+            + ", ".join(invalid_knowledge)
+        )
+    unclassified = sorted(
+        skill_id
+        for skill_id, item in metadata.items()
+        if item.status == "production" and skill_id not in inventory and not item.knowledge_only
+    )
+    if unclassified:
+        raise MatrixError(
+            "script-free production skills must set knowledge_only: true: "
+            + ", ".join(unclassified)
+        )
+    return inventory
 
 
 def discover(root: Path = ROOT) -> dict[str, TestEntry]:
@@ -114,7 +433,7 @@ def discover(root: Path = ROOT) -> dict[str, TestEntry]:
                 entries[skill_id] = TestEntry(
                     id=skill_id,
                     test_paths=tuple(paths),
-                    coverage_target=f"skills/{skill_id}/scripts",
+                    coverage_source=f"skills/{skill_id}/scripts",
                 )
 
     repo_tests = root / "scripts/tests"
@@ -122,72 +441,105 @@ def discover(root: Path = ROOT) -> dict[str, TestEntry]:
         entries["repo-scripts"] = TestEntry(
             id="repo-scripts",
             test_paths=("scripts/tests",),
-            coverage_target="scripts",
+            coverage_source="scripts",
         )
     return entries
 
 
+def _signature(entry: TestEntry) -> str:
+    payload = {
+        "id": entry.id,
+        "test_paths": entry.test_paths,
+        "coverage_source": entry.coverage_source,
+        "requirements": entry.requirements,
+        "allowed_failure": entry.allowed_failure,
+        "allowed_failure_policy": (
+            entry.allowed_failure_policy.as_dict() if entry.allowed_failure_policy else None
+        ),
+        "coverage_target": entry.coverage_target,
+        "coverage_floor": entry.coverage_floor,
+        "coverage_waiver": entry.coverage_waiver.as_dict() if entry.coverage_waiver else None,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def build_entries(
-    root: Path = ROOT, policy: dict[str, dict[str, object]] | None = None
+    root: Path = ROOT,
+    policy: TestPolicy | None = None,
+    metadata: dict[str, SkillMetadata] | None = None,
 ) -> dict[str, TestEntry]:
-    """Apply the explicit policy and fail if any discovered entry is uncovered."""
+    """Apply the versioned policy and fail if discovery is not fully covered."""
+    policy = load_policy(root) if policy is None else policy
+    metadata = load_skill_metadata(root) if metadata is None else metadata
+    inventory = validate_executable_test_coverage(root, metadata)
     discovered = discover(root)
-    policy = POLICY if policy is None else policy
-    unknown = sorted(set(policy) - set(discovered))
-    if unknown:
-        raise MatrixError(f"policy references undiscovered test ids: {', '.join(unknown)}")
+
+    for label, configured, valid in (
+        ("matrix", set(policy.matrix_overrides), set(discovered)),
+        ("allowed failure", set(policy.allowed_failures), set(discovered)),
+        ("coverage waiver", set(policy.coverage_waivers), set(inventory)),
+        ("coverage tier", set(policy.tier_targets), set(inventory)),
+    ):
+        unknown = sorted(configured - valid)
+        if unknown:
+            raise MatrixError(f"{label} references unknown ids: {', '.join(unknown)}")
+
+    uncovered = sorted(set(inventory) - set(discovered))
+    if uncovered:
+        raise MatrixError(
+            "executable skills are absent from the test matrix: " + ", ".join(uncovered)
+        )
 
     result: dict[str, TestEntry] = {}
     for entry_id, base in discovered.items():
         if not ID_RE.fullmatch(entry_id):
             raise MatrixError(f"unsafe test id: {entry_id!r}")
-        override = policy.get(entry_id, {})
-        allowed_keys = {"test_paths", "requirements", "allowed_failure", "excluded", "reason"}
-        extra = set(override) - allowed_keys
-        if extra:
-            raise MatrixError(f"unknown policy keys for {entry_id}: {sorted(extra)}")
+        override = policy.matrix_overrides.get(entry_id, {})
+        test_paths = tuple(override.get("test_paths", base.test_paths))
+        requirements = tuple(override.get("requirements", ()))
+        for rel_path in test_paths:
+            path = root / rel_path
+            if not path.is_file() and not _has_tests(path):
+                raise MatrixError(f"invalid test path for {entry_id}: {rel_path}")
+            if root.resolve() not in path.resolve().parents:
+                raise MatrixError(f"test path escapes repository for {entry_id}: {rel_path}")
+        for requirement in requirements:
+            try:
+                parsed_requirement = Requirement(requirement)
+            except InvalidRequirement as exc:
+                raise MatrixError(f"unsafe requirement for {entry_id}: {requirement!r}") from exc
+            if parsed_requirement.url is not None:
+                raise MatrixError(f"unsafe requirement for {entry_id}: {requirement!r}")
+
+        target = policy.target_for(entry_id) if entry_id in inventory else None
+        waiver = policy.coverage_waivers.get(entry_id)
+        floor = waiver.floor if waiver is not None else target
+        allowed_policy = policy.allowed_failures.get(entry_id)
         entry = replace(
             base,
-            test_paths=tuple(override.get("test_paths", base.test_paths)),
-            requirements=tuple(override.get("requirements", ())),
-            allowed_failure=bool(override.get("allowed_failure", False)),
-            excluded=bool(override.get("excluded", False)),
+            test_paths=test_paths,
+            requirements=requirements,
+            allowed_failure=allowed_policy is not None,
+            allowed_failure_policy=allowed_policy,
+            coverage_target=target,
+            coverage_floor=floor,
+            coverage_waiver=waiver,
             reason=override.get("reason") if isinstance(override.get("reason"), str) else None,
         )
-        if (
-            entry.allowed_failure or entry.excluded or entry.test_paths != base.test_paths
-        ) and not entry.reason:
-            raise MatrixError(f"exception policy for {entry_id} requires a reason")
-        if entry.allowed_failure and entry.excluded:
-            raise MatrixError(f"{entry_id} cannot be both allowed_failure and excluded")
-        if not entry.test_paths:
-            raise MatrixError(f"{entry_id} has no covered test paths")
-        for rel_path in entry.test_paths:
-            path = root / rel_path
-            if not path.exists() or root not in path.resolve().parents:
-                raise MatrixError(f"invalid test path for {entry_id}: {rel_path}")
-        for requirement in entry.requirements:
-            if not requirement or requirement.startswith("-") or re.search(r"\s", requirement):
-                raise MatrixError(f"unsafe requirement for {entry_id}: {requirement!r}")
-        result[entry_id] = entry
+        result[entry_id] = replace(entry, policy_signature=_signature(entry))
 
     if not result:
         raise MatrixError("no test suites discovered")
-    if set(result) != set(discovered):
-        missing = sorted(set(discovered) - set(result))
-        raise MatrixError(f"discovered tests are not covered: {', '.join(missing)}")
-    if not any(not entry.excluded for entry in result.values()):
-        raise MatrixError("matrix has no runnable test suites")
     return result
 
 
 def matrix(entries: dict[str, TestEntry]) -> dict[str, list[dict[str, object]]]:
-    rows = [
-        {"id": entry.id, "allowed_failure": entry.allowed_failure}
-        for entry in entries.values()
-        if not entry.excluded
-    ]
-    return {"include": rows}
+    return {
+        "include": [
+            {"id": entry.id, "allowed_failure": entry.allowed_failure} for entry in entries.values()
+        ]
+    }
 
 
 def install(entry: TestEntry) -> None:
@@ -204,25 +556,28 @@ def install(entry: TestEntry) -> None:
 def run(entry: TestEntry, root: Path, coverage_dir: Path | None) -> int:
     command = [sys.executable, "-m", "pytest", *entry.test_paths, "--tb=short", "-q"]
     manifest = None
+    coverage_file = None
     if coverage_dir is not None:
         coverage_dir.mkdir(parents=True, exist_ok=True)
         coverage_file = coverage_dir / f"coverage.{entry.id}"
         manifest = coverage_dir / f"manifest.{entry.id}.json"
         env = {**os.environ, "COVERAGE_FILE": str(coverage_file)}
-        command.extend([f"--cov={entry.coverage_target}", "--cov-report=", "--cov-fail-under=0"])
+        command.extend([f"--cov={entry.coverage_source}", "--cov-report=", "--cov-fail-under=0"])
     else:
         env = None
 
     completed = subprocess.run(command, cwd=root, env=env, check=False)
-    if manifest is not None:
-        coverage_file = coverage_dir / f"coverage.{entry.id}"
+    if manifest is not None and coverage_file is not None:
         manifest.write_text(
             json.dumps(
                 {
                     "id": entry.id,
                     "allowed_failure": entry.allowed_failure,
-                    "test_exit": completed.returncode,
                     "coverage_created": coverage_file.is_file(),
+                    "coverage_floor": entry.coverage_floor,
+                    "coverage_target": entry.coverage_target,
+                    "policy_signature": entry.policy_signature,
+                    "test_exit": completed.returncode,
                 },
                 sort_keys=True,
             )
@@ -232,8 +587,121 @@ def run(entry: TestEntry, root: Path, coverage_dir: Path | None) -> int:
     return completed.returncode
 
 
-def aggregate(entries: dict[str, TestEntry], artifacts: Path, output: Path) -> int:
-    expected = {entry.id: entry for entry in entries.values() if not entry.excluded}
+def _coverage_percent(data_file: Path, output_json: Path, root: Path) -> float:
+    env = {**os.environ, "COVERAGE_FILE": str(data_file)}
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "json",
+            "--omit=*/tests/*",
+            "--fail-under=0",
+            "-o",
+            str(output_json),
+        ],
+        cwd=root,
+        env=env,
+        check=True,
+    )
+    try:
+        payload = json.loads(output_json.read_text(encoding="utf-8"))
+        value = payload["totals"]["percent_covered"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise MatrixError(f"invalid coverage JSON: {output_json}") from exc
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise MatrixError(f"invalid coverage percentage: {output_json}")
+    return float(value)
+
+
+def _waiver_payload(waiver: CoverageWaiver | None) -> dict[str, object] | None:
+    return waiver.as_dict() if waiver is not None else None
+
+
+def _write_reports(
+    output: Path,
+    *,
+    today: date,
+    aggregate_row: dict[str, object],
+    skill_rows: list[dict[str, object]],
+    skipped_allowed_failures: list[str],
+    violations: list[str],
+) -> None:
+    summary = {
+        "schema_version": 1,
+        "generated_on": today.isoformat(),
+        "scope": "executable skill and repository scripts, excluding */tests/*",
+        "aggregate": aggregate_row,
+        "skills": skill_rows,
+        "skipped_allowed_failures": skipped_allowed_failures,
+        "violations": violations,
+    }
+    (output / "per-skill-coverage.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    lines = [
+        "# Executable-code coverage policy report",
+        "",
+        f"Generated: {today.isoformat()}",
+        "",
+        "Tests under `*/tests/*` are excluded from every percentage.",
+        "",
+        "## Repository aggregate",
+        "",
+        "| Actual | Effective floor | Target | Status | Waiver |",
+        "|---:|---:|---:|---|---|",
+        f"| {_format_percent(aggregate_row['actual'])} | "
+        f"{aggregate_row['effective_floor']}% | {aggregate_row['target']}% | "
+        f"{aggregate_row['status']} | {_format_exception(aggregate_row.get('waiver'))} |",
+        "",
+        "## Per-skill coverage",
+        "",
+        "| Skill | Actual | Effective floor | Target | Status | Coverage waiver | Test waiver |",
+        "|---|---:|---:|---:|---|---|---|",
+    ]
+    for row in skill_rows:
+        lines.append(
+            f"| {row['id']} | {_format_percent(row['actual'])} | {row['effective_floor']}% | "
+            f"{row['target']}% | {row['status']} | {_format_exception(row.get('waiver'))} | "
+            f"{_format_exception(row.get('allowed_failure'))} |"
+        )
+    if skipped_allowed_failures:
+        lines.extend(
+            [
+                "",
+                "## Skipped allowed failures",
+                "",
+                *[f"- {entry_id}" for entry_id in skipped_allowed_failures],
+            ]
+        )
+    if violations:
+        lines.extend(["", "## Violations", "", *[f"- {item}" for item in violations]])
+    (output / "per-skill-coverage.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _format_percent(value: object) -> str:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "-"
+    return f"{value:.2f}%"
+
+
+def _format_exception(value: object) -> str:
+    if not isinstance(value, dict):
+        return "-"
+    return f"#{value['issue']} until {value['expires_on']}"
+
+
+def aggregate(
+    entries: dict[str, TestEntry],
+    policy: TestPolicy,
+    artifacts: Path,
+    output: Path,
+    *,
+    root: Path = ROOT,
+    today: date | None = None,
+) -> int:
+    today = date.today() if today is None else today
     manifests: dict[str, dict[str, object]] = {}
     for path in artifacts.rglob("manifest.*.json"):
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -244,20 +712,30 @@ def aggregate(entries: dict[str, TestEntry], artifacts: Path, output: Path) -> i
             raise MatrixError(f"manifest filename/id mismatch: {path}")
         manifests[entry_id] = payload
 
-    unexpected = sorted(set(manifests) - set(expected))
+    unexpected = sorted(set(manifests) - set(entries))
     if unexpected:
         raise MatrixError(f"unexpected manifests: {', '.join(unexpected)}")
 
-    coverage_paths = []
-    blocking_errors = []
-    for entry_id, entry in expected.items():
+    coverage_paths: list[Path] = []
+    per_entry_coverage: dict[str, Path] = {}
+    blocking_errors: list[str] = []
+    skipped_allowed_failures: list[str] = []
+    for entry_id, entry in entries.items():
         payload = manifests.get(entry_id)
         matching_coverage = list(artifacts.rglob(f"coverage.{entry_id}"))
         if len(matching_coverage) > 1:
             raise MatrixError(f"duplicate coverage data for {entry_id}")
         coverage_path = matching_coverage[0] if matching_coverage else None
         if payload is not None:
-            required = {"id", "allowed_failure", "test_exit", "coverage_created"}
+            required = {
+                "id",
+                "allowed_failure",
+                "coverage_created",
+                "coverage_floor",
+                "coverage_target",
+                "policy_signature",
+                "test_exit",
+            }
             if set(payload) != required:
                 raise MatrixError(f"invalid manifest fields for {entry_id}")
             if not isinstance(payload["allowed_failure"], bool) or not isinstance(
@@ -266,61 +744,150 @@ def aggregate(entries: dict[str, TestEntry], artifacts: Path, output: Path) -> i
                 raise MatrixError(f"invalid manifest booleans for {entry_id}")
             if not isinstance(payload["test_exit"], int) or isinstance(payload["test_exit"], bool):
                 raise MatrixError(f"invalid test exit for {entry_id}")
-            if payload["allowed_failure"] != entry.allowed_failure:
-                raise MatrixError(f"allowed-failure mismatch for {entry_id}")
+            expected_policy = {
+                "allowed_failure": entry.allowed_failure,
+                "coverage_floor": entry.coverage_floor,
+                "coverage_target": entry.coverage_target,
+                "policy_signature": entry.policy_signature,
+            }
+            for field, expected_value in expected_policy.items():
+                if payload[field] != expected_value:
+                    raise MatrixError(f"{field.replace('_', '-')} mismatch for {entry_id}")
             if payload["coverage_created"] != (coverage_path is not None):
                 raise MatrixError(f"coverage manifest mismatch for {entry_id}")
-            if payload["test_exit"] != 0 and not entry.allowed_failure:
-                blocking_errors.append(f"{entry_id} (tests failed)")
+            if payload["test_exit"] != 0:
+                if entry.allowed_failure:
+                    print(
+                        f"WARNING: skipping failed allowed-failure row {entry_id}", file=sys.stderr
+                    )
+                    skipped_allowed_failures.append(entry_id)
+                else:
+                    blocking_errors.append(f"{entry_id} (tests failed)")
                 continue
 
         missing = payload is None or coverage_path is None
         if missing and entry.allowed_failure:
             print(f"WARNING: allowed-failure row {entry_id} produced no coverage", file=sys.stderr)
+            skipped_allowed_failures.append(entry_id)
             continue
         if missing:
             blocking_errors.append(entry_id)
             continue
         coverage_paths.append(coverage_path)
+        per_entry_coverage[entry_id] = coverage_path
     if blocking_errors:
         raise MatrixError(
             f"blocking rows missing manifests or coverage: {', '.join(blocking_errors)}"
         )
-    if not coverage_paths:
-        raise MatrixError("no coverage data available to combine")
 
     output.mkdir(parents=True, exist_ok=True)
-    env = {**os.environ, "COVERAGE_FILE": str(output / "coverage")}
-    subprocess.run(
-        [sys.executable, "-m", "coverage", "combine", *map(str, coverage_paths)],
-        cwd=ROOT,
-        env=env,
-        check=True,
+    raw_dir = output / "raw"
+    raw_dir.mkdir(exist_ok=True)
+    combined_file = output / "coverage"
+    if coverage_paths:
+        env = {**os.environ, "COVERAGE_FILE": str(combined_file)}
+        subprocess.run(
+            [sys.executable, "-m", "coverage", "combine", "--keep", *map(str, coverage_paths)],
+            cwd=root,
+            env=env,
+            check=True,
+        )
+
+    violations: list[str] = []
+    skill_rows: list[dict[str, object]] = []
+    for entry_id, entry in entries.items():
+        if entry.coverage_target is None:
+            continue
+        if entry_id in skipped_allowed_failures:
+            skill_rows.append(
+                {
+                    "id": entry_id,
+                    "actual": None,
+                    "effective_floor": entry.coverage_floor,
+                    "target": entry.coverage_target,
+                    "status": "allowed_failure",
+                    "waiver": _waiver_payload(entry.coverage_waiver),
+                    "allowed_failure": (
+                        entry.allowed_failure_policy.as_dict()
+                        if entry.allowed_failure_policy is not None
+                        else None
+                    ),
+                }
+            )
+            continue
+        actual = _coverage_percent(per_entry_coverage[entry_id], raw_dir / f"{entry_id}.json", root)
+        if entry.coverage_floor is None:
+            raise MatrixError(f"coverage floor missing for executable skill: {entry_id}")
+        if actual + 1e-9 < entry.coverage_floor:
+            status = "floor_failed"
+            violations.append(
+                f"{entry_id}: {actual:.2f}% is below {entry.coverage_floor}% effective floor"
+            )
+        elif actual + 1e-9 >= entry.coverage_target:
+            status = "target_met"
+        else:
+            status = "waiver_active"
+        skill_rows.append(
+            {
+                "id": entry_id,
+                "actual": actual,
+                "effective_floor": entry.coverage_floor,
+                "target": entry.coverage_target,
+                "status": status,
+                "waiver": _waiver_payload(entry.coverage_waiver),
+                "allowed_failure": (
+                    entry.allowed_failure_policy.as_dict()
+                    if entry.allowed_failure_policy is not None
+                    else None
+                ),
+            }
+        )
+
+    aggregate_waiver = policy.aggregate_waiver
+    aggregate_floor = aggregate_waiver.floor if aggregate_waiver else policy.aggregate_target
+    aggregate_actual = (
+        _coverage_percent(combined_file, output / "repository-coverage.json", root)
+        if coverage_paths
+        else None
     )
-    return subprocess.run(
-        [sys.executable, "-m", "coverage", "report", "--fail-under=40"],
-        cwd=ROOT,
-        env=env,
-        check=False,
-    ).returncode
+    if skipped_allowed_failures:
+        aggregate_status = "partial_allowed_failure" if coverage_paths else "not_measured"
+    elif aggregate_actual is None:
+        raise MatrixError("no coverage data available to combine")
+    elif aggregate_actual + 1e-9 < aggregate_floor:
+        aggregate_status = "floor_failed"
+        violations.append(
+            f"repository: {aggregate_actual:.2f}% is below {aggregate_floor}% effective floor"
+        )
+    elif aggregate_actual + 1e-9 >= policy.aggregate_target:
+        aggregate_status = "target_met"
+    else:
+        aggregate_status = "waiver_active"
+    aggregate_row: dict[str, object] = {
+        "actual": aggregate_actual,
+        "effective_floor": aggregate_floor,
+        "target": policy.aggregate_target,
+        "status": aggregate_status,
+        "waiver": _waiver_payload(aggregate_waiver),
+    }
+    _write_reports(
+        output,
+        today=today,
+        aggregate_row=aggregate_row,
+        skill_rows=skill_rows,
+        skipped_allowed_failures=skipped_allowed_failures,
+        violations=violations,
+    )
+    for violation in violations:
+        print(f"ERROR: {violation}", file=sys.stderr)
+    return 1 if violations else 0
 
 
 def _entry(entries: dict[str, TestEntry], entry_id: str) -> TestEntry:
     try:
-        entry = entries[entry_id]
+        return entries[entry_id]
     except KeyError as exc:
         raise MatrixError(f"unknown test id: {entry_id}") from exc
-    if entry.excluded:
-        raise MatrixError(f"test id is a covered exclusion: {entry_id} ({entry.reason})")
-    return entry
-
-
-def _print_local_summary(entries: Iterable[TestEntry]) -> None:
-    excluded = [entry for entry in entries if entry.excluded]
-    if excluded:
-        print("Covered exclusions:")
-        for entry in excluded:
-            print(f"  {entry.id}: {entry.reason}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -340,32 +907,15 @@ def main(argv: list[str] | None = None) -> int:
     aggregate_parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args(argv)
 
-    if args.command == "matrix":
-        try:
-            validate_executable_test_coverage(ROOT)
-            entries = build_entries()
-            print(json.dumps(matrix(entries), separators=(",", ":")))
-        except (MatrixError, OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
-            print(f"ERROR: {exc}", file=sys.stderr)
-            # ci.yml captures this command inside echo, which masks its exit status.
-            # Emit a blocking row so the next direct CLI invocation fails visibly.
-            print(
-                json.dumps(
-                    {"include": [{"id": POLICY_GATE_ID, "allowed_failure": False}]},
-                    separators=(",", ":"),
-                )
-            )
-            return 1
-        return 0
-
     try:
-        validate_executable_test_coverage(ROOT)
-        entries = build_entries()
-        if args.command == "list":
+        policy = load_policy(ROOT)
+        metadata = load_skill_metadata(ROOT)
+        entries = build_entries(ROOT, policy, metadata)
+        if args.command == "matrix":
+            print(json.dumps(matrix(entries), separators=(",", ":")))
+        elif args.command == "list":
             for entry in entries.values():
-                if not entry.excluded:
-                    print(entry.id)
-            _print_local_summary(entries.values())
+                print(entry.id)
         elif args.command == "allowed-failure":
             return 0 if _entry(entries, args.id).allowed_failure else 1
         elif args.command == "install":
@@ -373,9 +923,18 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "run":
             return run(_entry(entries, args.id), ROOT, args.coverage_dir)
         elif args.command == "aggregate":
-            return aggregate(entries, args.artifacts, args.output)
+            return aggregate(entries, policy, args.artifacts, args.output)
     except (MatrixError, OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
+        if args.command == "matrix":
+            # ci.yml captures this command inside echo, masking its exit status.
+            # A blocking fallback row makes the following direct invocation fail.
+            print(
+                json.dumps(
+                    {"include": [{"id": POLICY_GATE_ID, "allowed_failure": False}]},
+                    separators=(",", ":"),
+                )
+            )
         return 1
     return 0
 

--- a/scripts/tests/test_ci_test_matrix.py
+++ b/scripts/tests/test_ci_test_matrix.py
@@ -2,25 +2,34 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import date
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import yaml
 
 from scripts.ci_test_matrix import (
     POLICY_GATE_ID,
+    CoverageWaiver,
+    DatedException,
     MatrixError,
+    SkillMetadata,
     TestEntry,
+    TestPolicy,
     aggregate,
     build_entries,
     discover,
     executable_test_inventory,
     install,
+    load_policy,
     main,
     matrix,
     run,
     validate_executable_test_coverage,
 )
+
+TODAY = date(2026, 8, 10)
 
 
 def _test_file(root: Path, relative: str) -> None:
@@ -35,40 +44,127 @@ def _script_file(root: Path, skill_id: str, name: str = "run.py") -> None:
     path.write_text("def main():\n    return 0\n", encoding="utf-8")
 
 
-def test_executable_inventory_requires_canonical_test_files(tmp_path):
-    for skill_id in ("covered", "missing", "empty", "nested-only"):
+def _write_index(root: Path, skills: dict[str, dict[str, object]]) -> None:
+    payload = {
+        "skills": [
+            {"id": skill_id, "status": values.get("status", "production"), **values}
+            for skill_id, values in skills.items()
+        ]
+    }
+    (root / "skills-index.yaml").write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+
+def _base_policy() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "aggregate_coverage": {"target": 75, "waiver": None},
+        "coverage": {"default_target": 70, "tiers": {}, "waivers": {}},
+        "allowed_failures": {},
+        "matrix": {},
+    }
+
+
+def _write_policy(root: Path, payload: dict[str, object] | None = None) -> None:
+    path = root / "config/ci-test-policy.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload or _base_policy(), sort_keys=False), encoding="utf-8")
+
+
+def _policy(*, aggregate_floor: int | None = None, aggregate_target: int = 75) -> TestPolicy:
+    aggregate_waiver = (
+        None
+        if aggregate_floor is None
+        else CoverageWaiver(
+            floor=aggregate_floor,
+            target=aggregate_target,
+            expires_on=date(2026, 10, 31),
+            issue=293,
+            reason="ratchet",
+        )
+    )
+    return TestPolicy(
+        aggregate_target=aggregate_target,
+        aggregate_waiver=aggregate_waiver,
+        default_target=70,
+        tier_targets={},
+        coverage_waivers={},
+        allowed_failures={},
+        matrix_overrides={},
+    )
+
+
+def test_executable_inventory_requires_tests_for_every_status(tmp_path):
+    for skill_id in ("covered", "beta-missing", "empty", "nested-only"):
         _script_file(tmp_path, skill_id)
     _test_file(tmp_path, "skills/covered/scripts/tests/test_covered.py")
     (tmp_path / "skills/empty/scripts/tests").mkdir(parents=True)
     (tmp_path / "skills/empty/scripts/tests/test_directory.py").mkdir()
-    _test_file(
-        tmp_path,
-        "skills/nested-only/examples/skills/nested/scripts/tests/test_nested.py",
-    )
+    _test_file(tmp_path, "skills/nested-only/examples/scripts/tests/test_nested.py")
+    metadata = {
+        "covered": SkillMetadata("production"),
+        "beta-missing": SkillMetadata("beta"),
+        "empty": SkillMetadata("production"),
+        "nested-only": SkillMetadata("experimental"),
+    }
 
     assert executable_test_inventory(tmp_path) == {
+        "beta-missing": False,
         "covered": True,
         "empty": False,
-        "missing": False,
         "nested-only": False,
     }
     with pytest.raises(
         MatrixError,
-        match="skills with executable scripts lack canonical tests: empty, missing, nested-only",
+        match="skills with executable scripts lack canonical tests: beta-missing, empty, nested-only",
     ):
-        validate_executable_test_coverage(tmp_path)
+        validate_executable_test_coverage(tmp_path, metadata)
 
 
-def test_executable_inventory_accepts_tests_layout_and_ignores_init_only(tmp_path):
-    _script_file(tmp_path, "direct-tests")
-    _test_file(tmp_path, "skills/direct-tests/tests/test_direct.py")
-    _script_file(tmp_path, "init-only", "__init__.py")
+def test_knowledge_only_is_explicit_and_cannot_hide_executable_code(tmp_path):
+    _script_file(tmp_path, "executable")
+    _test_file(tmp_path, "skills/executable/scripts/tests/test_run.py")
+    (tmp_path / "skills/knowledge/scripts/tests").mkdir(parents=True)
 
-    assert executable_test_inventory(tmp_path) == {"direct-tests": True}
-    validate_executable_test_coverage(tmp_path)
+    with pytest.raises(MatrixError, match="must set knowledge_only"):
+        validate_executable_test_coverage(
+            tmp_path,
+            {
+                "executable": SkillMetadata("production"),
+                "knowledge": SkillMetadata("production"),
+            },
+        )
+
+    validate_executable_test_coverage(
+        tmp_path,
+        {
+            "executable": SkillMetadata("production"),
+            "knowledge": SkillMetadata("production", knowledge_only=True),
+        },
+    )
+
+    with pytest.raises(MatrixError, match="knowledge_only must identify script-free"):
+        validate_executable_test_coverage(
+            tmp_path,
+            {
+                "executable": SkillMetadata("production", knowledge_only=True),
+                "knowledge": SkillMetadata("production", knowledge_only=True),
+            },
+        )
 
 
-def test_executable_inventory_rejects_missing_or_unsafe_skills_directory(tmp_path):
+def test_nested_executable_requires_tests_and_cannot_be_knowledge_only(tmp_path):
+    _script_file(tmp_path, "nested", "pkg/run.py")
+    metadata = {"nested": SkillMetadata("production", knowledge_only=True)}
+
+    with pytest.raises(MatrixError, match="lack canonical tests: nested"):
+        validate_executable_test_coverage(tmp_path, metadata)
+
+    _test_file(tmp_path, "skills/nested/scripts/tests/test_run.py")
+    with pytest.raises(MatrixError, match="knowledge_only must identify script-free"):
+        validate_executable_test_coverage(tmp_path, metadata)
+
+
+def test_inventory_rejects_missing_or_unsafe_skills_directory(tmp_path):
     with pytest.raises(MatrixError, match="skills directory is missing"):
         executable_test_inventory(tmp_path)
 
@@ -77,25 +173,7 @@ def test_executable_inventory_rejects_missing_or_unsafe_skills_directory(tmp_pat
         executable_test_inventory(tmp_path)
 
 
-def test_cli_matrix_emits_blocking_policy_row_for_untested_script(monkeypatch, tmp_path, capsys):
-    _script_file(tmp_path, "untested")
-    monkeypatch.setattr("scripts.ci_test_matrix.ROOT", tmp_path)
-    monkeypatch.setattr("scripts.ci_test_matrix.POLICY", {})
-
-    assert main(["matrix"]) == 1
-    captured = capsys.readouterr()
-    assert json.loads(captured.out) == {
-        "include": [{"id": POLICY_GATE_ID, "allowed_failure": False}]
-    }
-    assert "skills with executable scripts lack canonical tests: untested" in captured.err
-
-    assert main(["install", POLICY_GATE_ID]) == 1
-    assert (
-        "skills with executable scripts lack canonical tests: untested" in capsys.readouterr().err
-    )
-
-
-def test_discover_supports_both_direct_skill_layouts_and_repo_tests(tmp_path):
+def test_discover_supports_both_skill_layouts_and_repo_tests(tmp_path):
     _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
     _test_file(tmp_path, "skills/beta/tests/test_beta.py")
     _test_file(tmp_path, "scripts/tests/test_repo.py")
@@ -107,53 +185,146 @@ def test_discover_supports_both_direct_skill_layouts_and_repo_tests(tmp_path):
     assert entries["beta"].test_paths == ("skills/beta/tests",)
 
 
-def test_discover_ignores_empty_and_nested_noncanonical_tests(tmp_path):
-    (tmp_path / "skills/empty/scripts/tests").mkdir(parents=True)
-    _test_file(tmp_path, "skills/outer/examples/skills/nested/scripts/tests/test_nested.py")
+def test_policy_rejects_expired_or_unlinked_allowed_failure(tmp_path):
+    policy = _base_policy()
+    policy["allowed_failures"] = {
+        "alpha": {"expires_on": "2026-08-09", "issue": 293, "reason": "known failure"}
+    }
+    _write_policy(tmp_path, policy)
+    with pytest.raises(MatrixError, match="expired on 2026-08-09"):
+        load_policy(tmp_path, today=TODAY)
 
-    assert discover(tmp_path) == {}
+    policy["allowed_failures"]["alpha"]["expires_on"] = "2026-08-11"
+    policy["allowed_failures"]["alpha"]["issue"] = 0
+    _write_policy(tmp_path, policy)
+    with pytest.raises(MatrixError, match="issue must be an integer"):
+        load_policy(tmp_path, today=TODAY)
 
 
-def test_new_skill_is_automatically_included_in_matrix(tmp_path):
-    _test_file(tmp_path, "skills/new-skill/scripts/tests/test_new.py")
+def test_policy_rejects_unknown_keys_and_target_mismatch(tmp_path):
+    policy = _base_policy()
+    policy["unexpected"] = True
+    _write_policy(tmp_path, policy)
+    with pytest.raises(MatrixError, match="unknown keys"):
+        load_policy(tmp_path, today=TODAY)
 
-    entries = build_entries(tmp_path, policy={})
+    policy = _base_policy()
+    policy["coverage"]["waivers"] = {
+        "alpha": {
+            "floor": 40,
+            "target": 85,
+            "expires_on": "2026-08-11",
+            "issue": 293,
+            "reason": "ratchet",
+        }
+    }
+    _write_policy(tmp_path, policy)
+    with pytest.raises(MatrixError, match="target mismatch"):
+        load_policy(tmp_path, today=TODAY)
 
-    assert matrix(entries) == {"include": [{"id": "new-skill", "allowed_failure": False}]}
+
+def test_policy_rejects_duplicate_yaml_keys(tmp_path):
+    _write_policy(tmp_path)
+    path = tmp_path / "config/ci-test-policy.yaml"
+    path.write_text(path.read_text(encoding="utf-8") + "matrix: {}\n", encoding="utf-8")
+
+    with pytest.raises(MatrixError, match="duplicate YAML key: 'matrix'"):
+        load_policy(tmp_path, today=TODAY)
 
 
-def test_exception_policy_requires_reason(tmp_path):
+def test_build_entries_applies_targets_waivers_and_dated_allowed_failure(tmp_path):
+    for skill_id in ("alpha", "core"):
+        _script_file(tmp_path, skill_id)
+        _test_file(tmp_path, f"skills/{skill_id}/scripts/tests/test_run.py")
+    _write_index(tmp_path, {"alpha": {"status": "beta"}, "core": {"status": "production"}})
+    policy = _base_policy()
+    policy["coverage"] = {
+        "default_target": 70,
+        "tiers": {"core": {"target": 85, "skills": ["core"]}},
+        "waivers": {
+            "alpha": {
+                "floor": 60,
+                "target": 70,
+                "expires_on": "2026-08-11",
+                "issue": 293,
+                "reason": "ratchet",
+            }
+        },
+    }
+    policy["allowed_failures"] = {
+        "alpha": {"expires_on": "2026-08-11", "issue": 999, "reason": "known failure"}
+    }
+    _write_policy(tmp_path, policy)
+
+    entries = build_entries(tmp_path, load_policy(tmp_path, today=TODAY))
+
+    assert entries["alpha"].coverage_target == 70
+    assert entries["alpha"].coverage_floor == 60
+    assert entries["alpha"].allowed_failure is True
+    assert entries["core"].coverage_target == entries["core"].coverage_floor == 85
+    assert matrix(entries) == {
+        "include": [
+            {"id": "alpha", "allowed_failure": True},
+            {"id": "core", "allowed_failure": False},
+        ]
+    }
+
+
+def test_unknown_matrix_id_unsafe_requirement_and_missing_path_fail_closed(tmp_path):
+    _script_file(tmp_path, "alpha")
     _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
+    _write_index(tmp_path, {"alpha": {}})
 
-    with pytest.raises(MatrixError, match="requires a reason"):
-        build_entries(tmp_path, {"alpha": {"excluded": True}})
+    policy = _base_policy()
+    policy["matrix"] = {"ghost": {"reason": "not real"}}
+    _write_policy(tmp_path, policy)
+    with pytest.raises(MatrixError, match="matrix references unknown"):
+        build_entries(tmp_path, load_policy(tmp_path, today=TODAY))
 
+    policy["matrix"] = {"alpha": {"reason": "bad dependency", "requirements": ["--index-url"]}}
+    _write_policy(tmp_path, policy)
+    with pytest.raises(MatrixError, match="unsafe requirement"):
+        build_entries(tmp_path, load_policy(tmp_path, today=TODAY))
 
-def test_unknown_policy_and_missing_override_path_fail_closed(tmp_path):
-    _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
-
-    with pytest.raises(MatrixError, match="undiscovered"):
-        build_entries(tmp_path, {"ghost": {"reason": "not real"}})
+    policy["matrix"] = {"alpha": {"reason": "missing path", "test_paths": ["missing.py"]}}
+    _write_policy(tmp_path, policy)
     with pytest.raises(MatrixError, match="invalid test path"):
-        build_entries(
-            tmp_path,
-            {"alpha": {"test_paths": ("missing.py",), "reason": "partial contract"}},
-        )
+        build_entries(tmp_path, load_policy(tmp_path, today=TODAY))
 
 
-def test_zero_runnable_rows_fail(tmp_path):
+@pytest.mark.parametrize(
+    "requirement",
+    [
+        "file:///tmp/pkg",
+        "../../pkg",
+        "git+https://example.invalid/repo.git",
+        "demo @ https://example.invalid/demo.whl",
+    ],
+)
+def test_matrix_rejects_url_vcs_and_local_requirements(tmp_path, requirement):
+    _script_file(tmp_path, "alpha")
     _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
+    _write_index(tmp_path, {"alpha": {}})
+    policy = _base_policy()
+    policy["matrix"] = {"alpha": {"reason": "unsafe source", "requirements": [requirement]}}
+    _write_policy(tmp_path, policy)
 
-    with pytest.raises(MatrixError, match="no runnable"):
-        build_entries(tmp_path, {"alpha": {"excluded": True, "reason": "known failure"}})
+    with pytest.raises(MatrixError, match="unsafe requirement"):
+        build_entries(tmp_path, load_policy(tmp_path, today=TODAY))
 
 
-def test_matrix_json_is_compact_and_contains_no_paths(tmp_path):
-    _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
-    payload = json.dumps(matrix(build_entries(tmp_path, {})), separators=(",", ":"))
+def test_cli_matrix_emits_blocking_policy_row_for_untested_beta(monkeypatch, tmp_path, capsys):
+    _script_file(tmp_path, "untested")
+    _write_index(tmp_path, {"untested": {"status": "beta"}})
+    _write_policy(tmp_path)
+    monkeypatch.setattr("scripts.ci_test_matrix.ROOT", tmp_path)
 
-    assert payload == '{"include":[{"id":"alpha","allowed_failure":false}]}'
-    assert "skills/" not in payload
+    assert main(["matrix"]) == 1
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "include": [{"id": POLICY_GATE_ID, "allowed_failure": False}]
+    }
+    assert "skills with executable scripts lack canonical tests: untested" in captured.err
 
 
 def test_install_uses_safe_argv_and_double_dash(monkeypatch):
@@ -170,100 +341,248 @@ def test_install_uses_safe_argv_and_double_dash(monkeypatch):
     assert calls == [([sys.executable, "-m", "pip", "install", "--", "safe-package>=1"], True)]
 
 
-def test_run_always_writes_manifest_with_test_result_and_coverage(monkeypatch, tmp_path):
+def test_run_writes_policy_bound_manifest_even_when_tests_fail(monkeypatch, tmp_path):
     def fake_run(command, cwd, env, check):
         Path(env["COVERAGE_FILE"]).write_text("coverage", encoding="utf-8")
         return SimpleNamespace(returncode=3)
 
     monkeypatch.setattr("scripts.ci_test_matrix.subprocess.run", fake_run)
-    entry = TestEntry("alpha", ("tests",), "scripts")
+    entry = TestEntry(
+        "alpha",
+        ("tests",),
+        "scripts",
+        coverage_target=70,
+        coverage_floor=60,
+        policy_signature="abc123",
+    )
 
     assert run(entry, tmp_path, tmp_path / "artifacts") == 3
     manifest = json.loads((tmp_path / "artifacts/manifest.alpha.json").read_text())
     assert manifest == {
         "allowed_failure": False,
         "coverage_created": True,
+        "coverage_floor": 60,
+        "coverage_target": 70,
         "id": "alpha",
+        "policy_signature": "abc123",
         "test_exit": 3,
     }
 
 
-def _artifact(tmp_path: Path, entry_id: str, **overrides) -> None:
+def _artifact(root: Path, entry: TestEntry, **overrides: object) -> None:
     payload = {
-        "id": entry_id,
-        "allowed_failure": False,
-        "test_exit": 0,
+        "id": entry.id,
+        "allowed_failure": entry.allowed_failure,
         "coverage_created": True,
+        "coverage_floor": entry.coverage_floor,
+        "coverage_target": entry.coverage_target,
+        "policy_signature": entry.policy_signature,
+        "test_exit": 0,
         **overrides,
     }
-    (tmp_path / f"manifest.{entry_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+    (root / f"manifest.{entry.id}.json").write_text(json.dumps(payload), encoding="utf-8")
     if payload["coverage_created"]:
-        (tmp_path / f"coverage.{entry_id}").write_text("data", encoding="utf-8")
+        (root / f"coverage.{entry.id}").write_text("data", encoding="utf-8")
 
 
-def test_aggregate_rejects_failed_blocking_manifest(tmp_path):
-    _artifact(tmp_path, "alpha", test_exit=1)
-    entries = {"alpha": TestEntry("alpha", ("tests",), "scripts")}
-
-    with pytest.raises(MatrixError, match="tests failed"):
-        aggregate(entries, tmp_path, tmp_path / "combined")
-
-
-def test_aggregate_rejects_manifest_policy_and_coverage_mismatch(tmp_path):
-    entries = {"alpha": TestEntry("alpha", ("tests",), "scripts")}
-    _artifact(tmp_path, "alpha", allowed_failure=True)
-    with pytest.raises(MatrixError, match="allowed-failure mismatch"):
-        aggregate(entries, tmp_path, tmp_path / "combined")
-
-    (tmp_path / "manifest.alpha.json").unlink()
-    (tmp_path / "coverage.alpha").unlink()
-    _artifact(tmp_path, "alpha", coverage_created=False)
-    (tmp_path / "coverage.alpha").write_text("unexpected", encoding="utf-8")
-    with pytest.raises(MatrixError, match="coverage manifest mismatch"):
-        aggregate(entries, tmp_path, tmp_path / "combined")
-
-
-def test_aggregate_warns_for_missing_allowed_row_and_combines_blocking_row(
-    monkeypatch, tmp_path, capsys
-):
-    _artifact(tmp_path, "alpha")
-    entries = {
-        "alpha": TestEntry("alpha", ("tests",), "scripts"),
-        "known": TestEntry("known", ("tests",), "scripts", allowed_failure=True),
-    }
-    calls = []
-
+def _fake_coverage_run(percentages: dict[str, float], calls: list[list[str]]):
     def fake_run(command, **kwargs):
         calls.append(command)
+        if "combine" in command:
+            Path(kwargs["env"]["COVERAGE_FILE"]).write_text("combined", encoding="utf-8")
+        elif "json" in command:
+            output = Path(command[command.index("-o") + 1])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(
+                json.dumps({"totals": {"percent_covered": percentages[output.name]}}),
+                encoding="utf-8",
+            )
         return SimpleNamespace(returncode=0)
 
-    monkeypatch.setattr("scripts.ci_test_matrix.subprocess.run", fake_run)
-
-    assert aggregate(entries, tmp_path, tmp_path / "combined") == 0
-    assert "allowed-failure row known" in capsys.readouterr().err
-    assert calls[0][3] == "combine"
-    assert str(tmp_path / "coverage.alpha") in calls[0]
-    assert calls[1][3:5] == ["report", "--fail-under=40"]
+    return fake_run
 
 
-def test_cli_unknown_id_is_nonzero(monkeypatch, tmp_path, capsys):
-    _test_file(tmp_path, "skills/alpha/scripts/tests/test_alpha.py")
-    monkeypatch.setattr("scripts.ci_test_matrix.ROOT", tmp_path)
-    monkeypatch.setattr("scripts.ci_test_matrix.POLICY", {})
+def _covered_entry() -> TestEntry:
+    waiver = CoverageWaiver(
+        floor=60,
+        target=70,
+        expires_on=date(2026, 10, 31),
+        issue=293,
+        reason="ratchet",
+    )
+    return TestEntry(
+        "alpha",
+        ("tests",),
+        "skills/alpha/scripts",
+        coverage_target=70,
+        coverage_floor=60,
+        coverage_waiver=waiver,
+        policy_signature="signed",
+    )
 
-    assert main(["run", "missing"]) == 1
-    assert "unknown test id" in capsys.readouterr().err
+
+def test_aggregate_writes_reports_before_returning_floor_failure(monkeypatch, tmp_path):
+    entry = _covered_entry()
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    _artifact(artifacts, entry)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "scripts.ci_test_matrix.subprocess.run",
+        _fake_coverage_run({"alpha.json": 59.5, "repository-coverage.json": 71.5}, calls),
+    )
+    output = tmp_path / "combined"
+
+    assert (
+        aggregate(
+            {"alpha": entry},
+            _policy(aggregate_floor=72),
+            artifacts,
+            output,
+            root=tmp_path,
+            today=TODAY,
+        )
+        == 1
+    )
+
+    summary = json.loads((output / "per-skill-coverage.json").read_text())
+    assert summary["aggregate"]["status"] == "floor_failed"
+    assert summary["skills"][0]["status"] == "floor_failed"
+    assert len(summary["violations"]) == 2
+    assert (output / "per-skill-coverage.md").is_file()
+    json_calls = [command for command in calls if "json" in command]
+    assert all("--omit=*/tests/*" in command for command in json_calls)
+    assert all("--fail-under=0" in command for command in json_calls)
 
 
-def test_pair_and_portfolio_quality_suites_are_blocking_rows():
-    entries = build_entries()
+def test_aggregate_reports_active_waivers_without_failing(monkeypatch, tmp_path):
+    entry = _covered_entry()
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    _artifact(artifacts, entry)
+    monkeypatch.setattr(
+        "scripts.ci_test_matrix.subprocess.run",
+        _fake_coverage_run({"alpha.json": 65.0, "repository-coverage.json": 73.0}, []),
+    )
+    output = tmp_path / "combined"
 
-    pair = entries["pair-trade-screener"]
-    portfolio = entries["portfolio-manager"]
-    assert pair.excluded is False
-    assert pair.allowed_failure is False
-    assert pair.requirements == ("statsmodels>=0.14,<0.15",)
-    assert pair.test_paths == ("skills/pair-trade-screener/scripts/tests",)
-    assert portfolio.excluded is False
-    assert portfolio.allowed_failure is False
-    assert portfolio.test_paths == ("skills/portfolio-manager/scripts/tests",)
+    assert (
+        aggregate(
+            {"alpha": entry},
+            _policy(aggregate_floor=72),
+            artifacts,
+            output,
+            root=tmp_path,
+            today=TODAY,
+        )
+        == 0
+    )
+    summary = json.loads((output / "per-skill-coverage.json").read_text())
+    assert summary["aggregate"]["status"] == "waiver_active"
+    assert summary["skills"][0]["status"] == "waiver_active"
+    assert summary["violations"] == []
+
+
+def _allowed_entry() -> TestEntry:
+    allowed = DatedException(
+        expires_on=date(2026, 9, 1), issue=999, reason="temporary known failure"
+    )
+    return TestEntry(
+        "known",
+        ("tests",),
+        "skills/known/scripts",
+        allowed_failure=True,
+        allowed_failure_policy=allowed,
+        coverage_target=70,
+        coverage_floor=70,
+        policy_signature="allowed-signed",
+    )
+
+
+def test_aggregate_skips_failed_allowed_row_and_marks_partial_report(monkeypatch, tmp_path):
+    normal = _covered_entry()
+    allowed = _allowed_entry()
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    _artifact(artifacts, normal)
+    _artifact(artifacts, allowed, test_exit=1)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "scripts.ci_test_matrix.subprocess.run",
+        _fake_coverage_run({"alpha.json": 75.0, "repository-coverage.json": 80.0}, calls),
+    )
+    output = tmp_path / "combined"
+
+    assert (
+        aggregate(
+            {"alpha": normal, "known": allowed},
+            _policy(),
+            artifacts,
+            output,
+            root=tmp_path,
+            today=TODAY,
+        )
+        == 0
+    )
+
+    summary = json.loads((output / "per-skill-coverage.json").read_text())
+    assert summary["skipped_allowed_failures"] == ["known"]
+    assert summary["aggregate"]["status"] == "partial_allowed_failure"
+    assert {row["id"]: row["status"] for row in summary["skills"]} == {
+        "alpha": "target_met",
+        "known": "allowed_failure",
+    }
+    combine = next(command for command in calls if "combine" in command)
+    assert str(artifacts / "coverage.known") not in combine
+
+
+def test_aggregate_only_missing_allowed_row_is_nonblocking_and_reported(monkeypatch, tmp_path):
+    allowed = _allowed_entry()
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    monkeypatch.setattr(
+        "scripts.ci_test_matrix.subprocess.run",
+        lambda *args, **kwargs: pytest.fail("coverage subprocess must not run"),
+    )
+    output = tmp_path / "combined"
+
+    assert (
+        aggregate({"known": allowed}, _policy(), artifacts, output, root=tmp_path, today=TODAY) == 0
+    )
+    summary = json.loads((output / "per-skill-coverage.json").read_text())
+    assert summary["aggregate"]["actual"] is None
+    assert summary["aggregate"]["status"] == "not_measured"
+    assert summary["skills"][0]["status"] == "allowed_failure"
+    assert (output / "per-skill-coverage.md").is_file()
+
+
+def test_aggregate_rejects_failed_or_stale_manifest(tmp_path):
+    entry = _covered_entry()
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    _artifact(artifacts, entry, test_exit=1)
+    with pytest.raises(MatrixError, match="tests failed"):
+        aggregate({"alpha": entry}, _policy(), artifacts, tmp_path / "out")
+
+    (artifacts / "manifest.alpha.json").unlink()
+    _artifact(artifacts, entry, policy_signature="stale")
+    with pytest.raises(MatrixError, match="policy-signature mismatch"):
+        aggregate({"alpha": entry}, _policy(), artifacts, tmp_path / "out")
+
+
+def test_current_policy_has_no_allowed_failures_and_enforces_all_tiers():
+    policy = load_policy(today=TODAY)
+    entries = build_entries(policy=policy)
+
+    assert policy.aggregate_target == 75
+    assert policy.aggregate_waiver is not None
+    assert policy.aggregate_waiver.floor == 73
+    assert policy.allowed_failures == {}
+    assert entries["theme-detector"].allowed_failure is False
+    assert entries["futures-position-sizer"].coverage_target == 85
+    assert entries["drawdown-circuit-breaker"].coverage_target == 85
+    assert entries["mt5-robot-tester"].coverage_target == 70
+    assert entries["options-strategy-advisor"].coverage_floor == 70
+    assert entries["signal-postmortem"].coverage_floor == 40
+    assert entries["pair-trade-screener"].requirements == ("statsmodels>=0.14,<0.15",)
+    assert entries["market-news-analyst"].coverage_target is None

--- a/scripts/tests/test_ci_test_matrix.py
+++ b/scripts/tests/test_ci_test_matrix.py
@@ -576,7 +576,7 @@ def test_current_policy_has_no_allowed_failures_and_enforces_all_tiers():
 
     assert policy.aggregate_target == 75
     assert policy.aggregate_waiver is not None
-    assert policy.aggregate_waiver.floor == 73
+    assert policy.aggregate_waiver.floor == 72
     assert policy.allowed_failures == {}
     assert entries["theme-detector"].allowed_failure is False
     assert entries["futures-position-sizer"].coverage_target == 85

--- a/scripts/tests/test_validate_skills_index.py
+++ b/scripts/tests/test_validate_skills_index.py
@@ -1180,6 +1180,42 @@ def test_consume_optional_artifact_passes(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_knowledge_only_marker_is_strictly_validated(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+
+    write_index(tmp_path, [minimal_skill("alpha", knowledge_only="yes")])
+    findings = validate(tmp_path)
+    assert any(f.code == "IDX014" and "boolean" in f.message for f in findings)
+
+    write_index(
+        tmp_path,
+        [minimal_skill("alpha", status="beta", verification=None, knowledge_only=True)],
+    )
+    findings = validate(tmp_path)
+    assert any(f.code == "IDX014" and "production" in f.message for f in findings)
+
+
+def test_knowledge_only_conflicts_with_executable_python(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    script = tmp_path / "skills/alpha/scripts/pkg/run.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("def main():\n    return 0\n", encoding="utf-8")
+    write_index(tmp_path, [minimal_skill("alpha", knowledge_only=True)])
+
+    findings = validate(tmp_path)
+
+    assert any(f.code == "IDX014" and "executable" in f.message for f in findings)
+
+
+def test_script_free_production_accepts_knowledge_only_marker(tmp_path: Path) -> None:
+    write_skill(tmp_path, "alpha")
+    write_index(tmp_path, [minimal_skill("alpha", knowledge_only=True)])
+
+    findings = validate(tmp_path)
+
+    assert not any(f.code == "IDX014" for f in findings)
+
+
 def test_production_missing_verification_warns_by_default(tmp_path: Path) -> None:
     write_skill(tmp_path, "alpha")
     skill = minimal_skill("alpha")

--- a/scripts/validate_skills_index.py
+++ b/scripts/validate_skills_index.py
@@ -6,7 +6,7 @@ Strictness levels:
   --strict-workflows   : also resolve workflow references and check internal-consistency
   --strict-metadata    : also enforce timeframe/difficulty/inputs/outputs completeness
 
-Emits stable error codes (IDX001-013, WF001-014). See
+Emits stable error codes (IDX001-014, WF001-014). See
 docs/dev/metadata-and-workflow-schema.md for the full catalog.
 """
 
@@ -246,6 +246,40 @@ def _validate_index_structure(
         status = entry.get("status")
         if not _valid_enum(status, VALID_STATUSES):
             findings.append(Finding("IDX006", "error", loc, f"invalid status {status!r}"))
+
+        if "knowledge_only" in entry:
+            knowledge_only = entry.get("knowledge_only")
+            if not isinstance(knowledge_only, bool):
+                findings.append(
+                    Finding("IDX014", "error", loc, "`knowledge_only` must be a boolean")
+                )
+            elif knowledge_only:
+                scripts_dir = project_root / "skills" / skill_id / "scripts"
+                executable_scripts = [
+                    path
+                    for path in scripts_dir.rglob("*.py")
+                    if path.is_file()
+                    and path.name != "__init__.py"
+                    and "tests" not in path.relative_to(scripts_dir).parts
+                ]
+                if status != "production":
+                    findings.append(
+                        Finding(
+                            "IDX014",
+                            "error",
+                            loc,
+                            "`knowledge_only: true` is only valid for production skills",
+                        )
+                    )
+                if executable_scripts:
+                    findings.append(
+                        Finding(
+                            "IDX014",
+                            "error",
+                            loc,
+                            "`knowledge_only: true` conflicts with executable Python scripts",
+                        )
+                    )
 
         verification_present = "verification" in entry
         if status == "production" and not verification_present:

--- a/skills-index.yaml
+++ b/skills-index.yaml
@@ -997,6 +997,7 @@ skills:
   display_name: Market News Analyst
   category: market-regime
   status: production
+  knowledge_only: true
   verification:
     instruction_contract: not_verified
     unit_tests: not_applicable
@@ -1337,6 +1338,7 @@ skills:
   display_name: Scenario Analyzer
   category: strategy-research
   status: production
+  knowledge_only: true
   verification:
     instruction_contract: not_verified
     unit_tests: not_applicable
@@ -1978,6 +1980,7 @@ skills:
   display_name: US Stock Analysis
   category: trade-planning
   status: production
+  knowledge_only: true
   verification:
     instruction_contract: not_verified
     unit_tests: not_applicable

--- a/uv.lock
+++ b/uv.lock
@@ -332,6 +332,7 @@ source = { editable = "." }
 dependencies = [
     { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -361,6 +362,7 @@ requires-dist = [
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.3.0" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "jsonschema", specifier = ">=4.25.1" },
+    { name = "packaging", specifier = ">=24.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },


### PR DESCRIPTION
## Summary

- invert test discovery so every executable skill must have canonical tests, while script-free production skills require an explicit `knowledge_only: true` marker
- move matrix overrides, dated allowed failures, per-skill coverage tiers, and ratchet waivers into strict versioned policy
- enforce 85% core / 70% other executable-skill targets and a 75% repository target, with current floors and expiry tracked in config
- publish per-skill and repository executable-code coverage reports even when a floor fails
- reject expired exceptions, duplicate YAML keys, unsafe requirement sources, stale IDs, missing/duplicate artifacts, and policy-signature mismatches

## Validation

- `python3.9 -m pytest scripts/tests/test_ci_test_matrix.py scripts/tests/test_validate_skills_index.py -q` — 106 passed
- full dynamic test matrix / pre-push suite — 73/73 rows passed
- repo-scripts row — 570 passed
- Linux CI executable-code baseline — 35,031 / 48,073 statements (72.870%), 69 skills, 42 target-met, 27 active waivers
- local Python 3.9 executable-code validation — 35,429 / 48,073 statements (73.698%), 69 skills, 43 target-met, 26 active waivers, 0 violations
- `ruff check skills/ scripts/` — passed with repository-pinned Ruff 0.9.6
- `ruff format --check skills/ scripts/` — 643 files formatted
- strict skills index metadata/workflows, skillsets, generated catalog/docs/workflow/skillset docs, navigator snapshot, targeted pre-commit, and `git diff --check` — passed

## Review loops

- plan review: 2 rounds; final approved
- implementation review: 3 rounds; final approved with no blocking findings

The first exact-head CI run passed all 73 test rows and exposed a Linux/local
aggregate delta (72.870% vs. 73.698%). The dated aggregate floor was aligned to
the lower measured cross-platform baseline (72%) and the evidence was recorded
in the policy documentation.

## Issue disposition

Refs #293

This PR intentionally leaves Issue #293 open. It establishes and enforces the ratchet, but 26 per-skill waivers and the repository aggregate waiver remain active until the documented coverage burn-down reaches the final 85% / 70% / 75% targets.
