### PR TITLE
test: retire position-sizer coverage waiver

### DIFF
--- a/config/ci-test-policy.yaml
+++ b/config/ci-test-policy.yaml
@@ -94,12 +94,6 @@ coverage:
       expires_on: "2026-10-31"
       issue: 293
       reason: Ratchet from the 2026-08-10 executable-code baseline.
-    position-sizer:
-      floor: 71
-      target: 85
-      expires_on: "2026-10-31"
-      issue: 293
-      reason: Ratchet core financial-math coverage toward the 85% target.
     signal-postmortem:
       floor: 40
       target: 70

--- a/scripts/tests/test_ci_test_matrix.py
+++ b/scripts/tests/test_ci_test_matrix.py
@@ -581,6 +581,9 @@ def test_current_policy_has_no_allowed_failures_and_enforces_all_tiers():
     assert entries["theme-detector"].allowed_failure is False
     assert entries["futures-position-sizer"].coverage_target == 85
     assert entries["drawdown-circuit-breaker"].coverage_target == 85
+    assert entries["position-sizer"].coverage_target == 85
+    assert entries["position-sizer"].coverage_floor == 85
+    assert entries["position-sizer"].coverage_waiver is None
     assert entries["mt5-robot-tester"].coverage_target == 70
     assert entries["options-strategy-advisor"].coverage_floor == 70
     assert entries["signal-postmortem"].coverage_floor == 40

--- a/skills/position-sizer/scripts/tests/test_position_sizer.py
+++ b/skills/position-sizer/scripts/tests/test_position_sizer.py
@@ -13,6 +13,7 @@ from position_sizer import (
     calculate_kelly,
     calculate_position,
     generate_markdown_report,
+    main,
     validate_parameters,
 )
 
@@ -572,6 +573,46 @@ class TestOutput:
         assert "## Parameters" in md
         assert "## Final Recommendation" in md
         assert "153" in md  # final shares
+
+    def test_main_writes_risk_pct_reports_in_process(self, monkeypatch, tmp_path, capsys):
+        """The CLI entry point writes both reports and prints its share summary."""
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "position_sizer.py",
+                "--account-size",
+                "100000",
+                "--entry",
+                "155",
+                "--stop",
+                "148.50",
+                "--risk-pct",
+                "1.0",
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+
+        main()
+
+        stdout = capsys.readouterr().out
+        assert "Final: 153 shares" in stdout
+        assert "JSON report:" in stdout
+        assert "Markdown report:" in stdout
+
+        json_reports = list(tmp_path.glob("position_sizer_*.json"))
+        markdown_reports = list(tmp_path.glob("position_sizer_*.md"))
+        assert len(json_reports) == 1
+        assert len(markdown_reports) == 1
+
+        payload = json.loads(json_reports[0].read_text(encoding="utf-8"))
+        assert payload["mode"] == "shares"
+        assert payload["final_recommended_shares"] == 153
+
+        markdown = markdown_reports[0].read_text(encoding="utf-8")
+        assert "# Position Sizing Report" in markdown
+        assert "**Shares:** 153" in markdown
 
     def test_cli_arguments(self):
         """Verify argparse works for standard cases."""


### PR DESCRIPTION
## Summary

- remove the `position-sizer` coverage waiver after adding CI-compatible in-process coverage for the CLI success path
- pin the production policy contract at target/floor 85 with no waiver
- keep the broader coverage burn-down tracked by Issue #293

## Validation

- `.venv/bin/python scripts/ci_test_matrix.py run position-sizer --coverage-dir ...` — 42 passed; pytest-cov 7 measured 226/253 executable statements (89.33%, reported as 89%)
- `python3.9 -m pytest skills/position-sizer/scripts/tests -q` — 42 passed
- `python3.9 -m pytest scripts/tests/test_ci_test_matrix.py -q` — 23 passed
- `ruff check` and `ruff format --check` on changed Python files — passed
- package, catalog, skill-doc, index/workflow, skillset, workflow-doc, skillset-doc, and navigator snapshot checks — passed
- `UV_CACHE_DIR=/private/tmp/issue293-uv-cache bash scripts/run_all_tests.sh` — 73/74 rows passed in the sandbox; the only two failures were unrelated localhost-bind permission errors in `mt5-robot-tester`, and both passed (2/2) when rerun outside the sandbox; repo-scripts 673 passed
- `pre-commit run --all-files` — repository gates passed; Ruff rewrote two unrelated clean-base example imports, which were restored
- changed-file pre-commit and commit hooks — passed
- `git diff --check` — passed

The first PR-head CI run passed 80/81 checks but exposed a pytest-cov 7 subprocess-coverage mismatch: `position-sizer` measured 71.54% instead of the older local 89.72% result. The added in-process CLI test closes that gap and the exact CI-compatible matrix row now measures 89.33%.

## Review loops

- Plan review: 2 rounds; both PASS with no findings
- Implementation review: 2 rounds; both PASS with no findings

## Issue

This removes one stale core-risk coverage waiver. The remaining skill waivers and aggregate waiver keep the umbrella acceptance criteria incomplete, so Issue #293 remains open.

Refs #293