### PR TITLE
test: add swing-opportunity-daily executable replay coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
       # 'Test repo-level scripts' step in the test job above.
 
   workflow-replay:
-    name: Workflow replay (Coverage 6/11)
+    name: Workflow replay (Coverage 7/11)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -82,7 +82,7 @@ cross-artifact arithmetic. All files also remain subject to standard hygiene hoo
 (whitespace, YAML syntax, `detect-secrets`, `no-absolute-paths`, and related
 checks).
 
-## Executable workflow replay (Issue #294, Coverage 6/11)
+## Executable workflow replay (Issue #294, Coverage 7/11)
 
 Six of the eleven canonical workflows are generated and checked by the
 executable replay harness:
@@ -93,6 +93,7 @@ executable replay harness:
 - `stockbee-20pct-study-daily`
 - `trade-memory-loop`
 - `monthly-performance-review`
+- `swing-opportunity-daily`
 
 ```bash
 python3 scripts/workflow_replay.py validate
@@ -121,7 +122,7 @@ carried by the postmortem bundle. The monthly-performance-review replay
 consolidates a monthly aggregate from the bundled closed-theses log and runs
 the signal-postmortem analyzer and Trade Performance Coach CLI against
 disposable fixtures, then publishes a decision log and rule-change backlog.
-The replays require explicit offline fixture inputs and remove API-key, token,
+The replay requires explicit offline fixture inputs and remove API-key, token,
 secret, password, and proxy variables from the subprocess environment. No replay command supplies `--symbols`,
 `--fmp-universe`, or `--api-key`. This is an `offline-input-required` policy,
 not an operating-system network sandbox.
@@ -162,7 +163,7 @@ goldens; committed goldens are never executor inputs. The monthly replay uses
 dedicated `replay-run/` and `replay-run-full-path/` golden trees, distinct from
 the teaching `sample-run/` and `sample-run-full-path/` fixtures covered by Issue
 #208. The coverage manifest
-freezes the other five current workflows as Coverage 6/11 deferrals linked to Issue
+freezes the other four current workflows as Coverage 7/11 deferrals linked to Issue
 #294. A newly added workflow cannot join that frozen deferral set and must ship
 both required-only and full-path replay specs. Issue #294 remains open until
 all eleven workflows and their applicable failure modes are executable.

--- a/examples/workflows/replay-coverage.yaml
+++ b/examples/workflows/replay-coverage.yaml
@@ -31,8 +31,13 @@ covered:
     variants:
       - required-only
       - full-path
+  swing-opportunity-daily:
+    spec: swing-opportunity-daily/replay.yaml
+    variants:
+      - required-only
+      - full-path
 
-# Frozen Coverage 6/11 baseline. The validator rejects adding another deferral, so a
+# Frozen Coverage 7/11 baseline. The validator rejects adding another deferral, so a
 # newly introduced workflow must ship both replay variants.
 deferred:
   kanchi-dividend-weekly:
@@ -47,6 +52,3 @@ deferred:
   stockbee-ep-daily:
     issue: 294
     reason: Circuit-breaker and EP handoff failure fixtures remain deferred.
-  swing-opportunity-daily:
-    issue: 294
-    reason: Existing examples need circuit-breaker halt replay migration.

--- a/examples/workflows/swing-opportunity-daily/replay-inputs/canslim.json
+++ b/examples/workflows/swing-opportunity-daily/replay-inputs/canslim.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "candidates": [
+    {
+      "symbol": "EXMPL",
+      "grade": "B",
+      "score": 78,
+      "current_quarter_eps_growth_pct": 32.0,
+      "annual_eps_growth_pct": 24.0,
+      "status": "CANDIDATE_NOT_SIGNAL"
+    }
+  ],
+  "warnings": [
+    "Fictional fundamentals; not sourced from a real filing."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-inputs/exhaustion-hammer.json
+++ b/examples/workflows/swing-opportunity-daily/replay-inputs/exhaustion-hammer.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "candidates": [],
+  "screen_status": "COMPLETE_NO_MATCHES",
+  "warnings": [
+    "An empty optional screen is preserved; no candidate is invented."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-inputs/exposure-decision.json
+++ b/examples/workflows/swing-opportunity-daily/replay-inputs/exposure-decision.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-29T12:00:00+00:00",
+  "exposure_ceiling_pct": 61,
+  "bias": "NEUTRAL",
+  "participation": "BROAD",
+  "recommendation": "NEW_ENTRY_ALLOWED",
+  "confidence": "MEDIUM",
+  "composite_score": 59.2,
+  "component_scores": {
+    "breadth_score": 70,
+    "uptrend_score": 74,
+    "top_risk_score": 65
+  },
+  "inputs_provided": ["top_risk", "breadth", "uptrend"],
+  "inputs_missing": ["regime", "institutional", "sector", "theme", "ftd"],
+  "rationale": "Broad participation indicates healthy market internals. Missing critical inputs (regime) reduce confidence. New positions allowed within the 61% ceiling."
+}

--- a/examples/workflows/swing-opportunity-daily/replay-inputs/journal-decision.yaml
+++ b/examples/workflows/swing-opportunity-daily/replay-inputs/journal-decision.yaml
@@ -1,0 +1,34 @@
+schema_version: "1.0"
+human_approved: true
+thesis_type: growth_momentum
+setup_type: fictional_vcp
+catalyst: null
+confidence: medium
+confidence_score: 0.7
+thesis_statement: EXMPL holds the fictional 50.00 pivot after a tightening VCP base.
+reason_required_only: Registered from the fictional VCP sample.
+reason_full_path: Registered from the fictional multi-screen sample.
+evidence_base: VCP contractions narrowed from 18% to 10% to 5%.
+evidence_screen_corroboration: Momentum, CANSLIM, and fictional-theme screens corroborated the candidate.
+evidence_manual: Manual weekly-chart review passed.
+kill_criteria:
+  - Close below the planned 47.50 stop invalidates the setup.
+entry_conditions:
+  - Entry must remain in the written plan.
+exit:
+  take_profit: 55.0
+  take_profit_rr: 2.0
+  stop_loss_pct: 5.0
+  time_stop_days: 10
+screening_grade: A
+screening_score: 88
+account_type: fictional_cash
+sizing_method: fixed_fractional
+market_context:
+  regime: NEW_ENTRY_ALLOWED
+  breadth_score: 70
+  top_detector_score: 35
+  sector: Fictional Technology
+monitoring:
+  review_interval_days: 1
+  next_review_date: "2026-06-30"

--- a/examples/workflows/swing-opportunity-daily/replay-inputs/momentum-burst.json
+++ b/examples/workflows/swing-opportunity-daily/replay-inputs/momentum-burst.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "candidates": [
+    {
+      "symbol": "EXMPL",
+      "setup": "MOMENTUM_BURST",
+      "score": 81,
+      "range_expansion_pct": 4.8,
+      "volume_ratio": 1.9,
+      "status": "CANDIDATE_NOT_SIGNAL"
+    }
+  ],
+  "warnings": [
+    "Fictional output; chart and risk validation remain required."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-inputs/sizing-parameters.json
+++ b/examples/workflows/swing-opportunity-daily/replay-inputs/sizing-parameters.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "1.0",
+  "account_size": 100000.0,
+  "risk_pct": 0.5
+}

--- a/examples/workflows/swing-opportunity-daily/replay-inputs/theme.json
+++ b/examples/workflows/swing-opportunity-daily/replay-inputs/theme.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "themes": [
+    {
+      "theme": "Fictional Cloud Efficiency",
+      "strength": "EMERGING",
+      "symbols": ["EXMPL"],
+      "evidence": [
+        "Hand-authored teaching evidence only."
+      ]
+    }
+  ],
+  "warnings": [
+    "Fictional theme; not a market claim."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-inputs/trade-plans.json
+++ b/examples/workflows/swing-opportunity-daily/replay-inputs/trade-plans.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "plans": [
+    {
+      "symbol": "EXMPL",
+      "side": "BUY",
+      "entry_type": "STOP_LIMIT",
+      "entry_price": 50.0,
+      "limit_price": 50.25,
+      "stop_price": 47.5,
+      "target_price": 55.0,
+      "shares": 200,
+      "position_value": 10000.0,
+      "planned_risk_dollars": 500.0,
+      "risk_reward_ratio": 2.0,
+      "order_status": "PROPOSED_NOT_SUBMITTED"
+    }
+  ],
+  "manual_execution_required": true
+}

--- a/examples/workflows/swing-opportunity-daily/replay-inputs/validated-setups.json
+++ b/examples/workflows/swing-opportunity-daily/replay-inputs/validated-setups.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "setups": [
+    {
+      "symbol": "EXMPL",
+      "weekly_trend": "STAGE_2",
+      "base_quality": "TIGHT",
+      "entry_price": 50.0,
+      "stop_price": 47.5,
+      "target_price": 55.0,
+      "risk_per_share": 2.5,
+      "manual_chart_review": "PASS",
+      "decision": "VALIDATED"
+    }
+  ],
+  "rejected": []
+}

--- a/examples/workflows/swing-opportunity-daily/replay-inputs/vcp-scan.json
+++ b/examples/workflows/swing-opportunity-daily/replay-inputs/vcp-scan.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.0",
+  "as_of": "2026-06-29",
+  "universe": "fictional_teaching_universe",
+  "candidates": [
+    {
+      "symbol": "EXMPL",
+      "pattern": "VCP",
+      "score": 88,
+      "pivot_price": 50.0,
+      "suggested_stop": 47.5,
+      "contractions_pct": [18.0, 10.0, 5.0],
+      "volume_dry_up": true,
+      "status": "CANDIDATE_NOT_SIGNAL"
+    }
+  ],
+  "warnings": [
+    "EXMPL is fictional; candidate generation is not a buy recommendation."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/01_circuit_breaker_decision.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/01_circuit_breaker_decision.json
@@ -1,0 +1,26 @@
+{
+  "account_size": 100000.0,
+  "as_of_date": "2026-06-29",
+  "config": {
+    "cooldown_hours": 24.0,
+    "losing_streak_n": 2,
+    "max_daily_loss_pct": 2.0,
+    "monthly_drawdown_pct": 8.0,
+    "weekly_drawdown_pct": 5.0
+  },
+  "data_quality": "EMPTY_STATE",
+  "generated_at": "2026-06-29T12:00:00+00:00",
+  "metrics": {
+    "consecutive_losses": 0,
+    "last_loss_exit_at": null,
+    "realized_pnl_mtd": 0.0,
+    "realized_pnl_today": 0.0,
+    "realized_pnl_wtd": 0.0,
+    "theses_scanned": 0
+  },
+  "rationale": "No account-level circuit breaker rules are active; new trade risk may proceed.",
+  "recommendation": "TRADING_ALLOWED",
+  "schema_version": "1.0",
+  "triggered_rules": [],
+  "warnings": []
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/02_vcp_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/02_vcp_candidates.json
@@ -1,0 +1,24 @@
+{
+  "as_of": "2026-06-29",
+  "candidates": [
+    {
+      "contractions_pct": [
+        18.0,
+        10.0,
+        5.0
+      ],
+      "pattern": "VCP",
+      "pivot_price": 50.0,
+      "score": 88,
+      "status": "CANDIDATE_NOT_SIGNAL",
+      "suggested_stop": 47.5,
+      "symbol": "EXMPL",
+      "volume_dry_up": true
+    }
+  ],
+  "schema_version": "1.0",
+  "universe": "fictional_teaching_universe",
+  "warnings": [
+    "EXMPL is fictional; candidate generation is not a buy recommendation."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/03_momentum_burst_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/03_momentum_burst_candidates.json
@@ -1,0 +1,17 @@
+{
+  "as_of": "2026-06-29",
+  "candidates": [
+    {
+      "range_expansion_pct": 4.8,
+      "score": 81,
+      "setup": "MOMENTUM_BURST",
+      "status": "CANDIDATE_NOT_SIGNAL",
+      "symbol": "EXMPL",
+      "volume_ratio": 1.9
+    }
+  ],
+  "schema_version": "1.0",
+  "warnings": [
+    "Fictional output; chart and risk validation remain required."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/04_exhaustion_hammer_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/04_exhaustion_hammer_candidates.json
@@ -1,0 +1,9 @@
+{
+  "as_of": "2026-06-29",
+  "candidates": [],
+  "schema_version": "1.0",
+  "screen_status": "COMPLETE_NO_MATCHES",
+  "warnings": [
+    "An empty optional screen is preserved; no candidate is invented."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/05_canslim_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/05_canslim_candidates.json
@@ -1,0 +1,17 @@
+{
+  "as_of": "2026-06-29",
+  "candidates": [
+    {
+      "annual_eps_growth_pct": 24.0,
+      "current_quarter_eps_growth_pct": 32.0,
+      "grade": "B",
+      "score": 78,
+      "status": "CANDIDATE_NOT_SIGNAL",
+      "symbol": "EXMPL"
+    }
+  ],
+  "schema_version": "1.0",
+  "warnings": [
+    "Fictional fundamentals; not sourced from a real filing."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/06_theme_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/06_theme_candidates.json
@@ -1,0 +1,19 @@
+{
+  "as_of": "2026-06-29",
+  "schema_version": "1.0",
+  "themes": [
+    {
+      "evidence": [
+        "Hand-authored teaching evidence only."
+      ],
+      "strength": "EMERGING",
+      "symbols": [
+        "EXMPL"
+      ],
+      "theme": "Fictional Cloud Efficiency"
+    }
+  ],
+  "warnings": [
+    "Fictional theme; not a market claim."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/07_validated_setups.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/07_validated_setups.json
@@ -1,0 +1,32 @@
+{
+  "as_of": "2026-06-29",
+  "inputs_missing": [],
+  "inputs_provided": [
+    "vcp_candidates",
+    "momentum_burst_candidates",
+    "exhaustion_hammer_candidates",
+    "canslim_candidates",
+    "theme_candidates"
+  ],
+  "rejected": [],
+  "schema_version": "1.0",
+  "setups": [
+    {
+      "base_quality": "TIGHT",
+      "decision": "VALIDATED",
+      "entry_price": 50.0,
+      "manual_chart_review": "PASS",
+      "risk_per_share": 2.5,
+      "source_artifacts": [
+        "vcp_candidates",
+        "momentum_burst_candidates",
+        "canslim_candidates",
+        "theme_candidates"
+      ],
+      "stop_price": 47.5,
+      "symbol": "EXMPL",
+      "target_price": 55.0,
+      "weekly_trend": "STAGE_2"
+    }
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/08_position_sizing.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/08_position_sizing.json
@@ -1,0 +1,27 @@
+{
+  "binding_constraint": null,
+  "calculations": {
+    "atr_based": null,
+    "fixed_fractional": {
+      "dollar_risk": 500.0,
+      "method": "fixed_fractional",
+      "risk_per_share": 2.5,
+      "shares": 200,
+      "stop_price": 47.5
+    },
+    "kelly": null
+  },
+  "constraints_applied": [],
+  "final_position_value": 10000.0,
+  "final_recommended_shares": 200,
+  "final_risk_dollars": 500.0,
+  "final_risk_pct": 0.5,
+  "mode": "shares",
+  "parameters": {
+    "account_size": 100000.0,
+    "entry_price": 50.0,
+    "risk_pct": 0.5,
+    "stop_price": 47.5
+  },
+  "schema_version": "1.0"
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/09_trade_plans.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/09_trade_plans.json
@@ -1,0 +1,21 @@
+{
+  "as_of": "2026-06-29",
+  "manual_execution_required": true,
+  "plans": [
+    {
+      "entry_price": 50.0,
+      "entry_type": "STOP_LIMIT",
+      "limit_price": 50.25,
+      "order_status": "PROPOSED_NOT_SUBMITTED",
+      "planned_risk_dollars": 500.0,
+      "position_value": 10000.0,
+      "risk_reward_ratio": 2.0,
+      "shares": 200,
+      "side": "BUY",
+      "stop_price": 47.5,
+      "symbol": "EXMPL",
+      "target_price": 55.0
+    }
+  ],
+  "schema_version": "1.0"
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/10_candidate_journal_entry.yaml
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/10_candidate_journal_entry.yaml
@@ -1,0 +1,82 @@
+thesis_id: th_exmpl_gro_20260629_cd34
+ticker: EXMPL
+created_at: '2026-06-29T12:00:00+00:00'
+updated_at: '2026-06-29T12:00:00+00:00'
+thesis_type: growth_momentum
+setup_type: fictional_vcp
+catalyst: null
+status: ENTRY_READY
+status_history:
+- status: IDEA
+  at: '2026-06-29T12:00:00+00:00'
+  reason: Registered from the fictional multi-screen sample.
+- status: ENTRY_READY
+  at: '2026-06-29T12:00:00+00:00'
+  reason: Weekly setup, position size, and optional trade plan were reviewed.
+thesis_statement: EXMPL holds the fictional 50.00 pivot after a tightening VCP base.
+mechanism_tag: behavior
+evidence:
+- VCP contractions narrowed from 18% to 10% to 5%.
+- Momentum, CANSLIM, and fictional-theme screens corroborated the candidate.
+- Manual weekly-chart review passed.
+kill_criteria:
+- Close below the planned 47.50 stop invalidates the setup.
+confidence: medium
+confidence_score: 0.7
+entry:
+  target_price: 50.0
+  conditions:
+  - Entry must remain in the written plan.
+  actual_price: null
+  actual_date: null
+exit:
+  stop_loss: 47.5
+  stop_loss_pct: 5.0
+  take_profit: 55.0
+  take_profit_rr: 2.0
+  time_stop_days: 10
+  actual_price: null
+  actual_date: null
+  exit_reason: null
+position:
+  shares: 200
+  shares_remaining: 200
+  position_value: 10000.0
+  risk_dollars: 500.0
+  risk_pct_of_account: 0.5
+  account_type: fictional_cash
+  sizing_method: fixed_fractional
+  raw_source:
+    skill: position-sizer
+    file: 08_position_sizing.json
+    fields:
+      final_recommended_shares: 200
+      final_risk_dollars: 500.0
+market_context:
+  regime: NEW_ENTRY_ALLOWED
+  breadth_score: 70
+  top_detector_score: 35
+  sector: Fictional Technology
+monitoring:
+  review_interval_days: 1
+  next_review_date: '2026-06-30'
+  last_review_date: null
+  review_status: OK
+  triggers_config: []
+  alerts: []
+origin:
+  skill: breakout-trade-planner
+  output_file: 09_trade_plans.json
+  screening_grade: A
+  screening_score: 88
+  raw_provenance:
+    fixture: fictional
+linked_reports: []
+outcome:
+  pnl_dollars: null
+  pnl_pct: null
+  holding_days: null
+  mae_pct: null
+  mfe_pct: null
+  mae_mfe_source: null
+  lessons_learned: null

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/11_pre_trade_discipline_decision.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/11_pre_trade_discipline_decision.json
@@ -1,0 +1,42 @@
+{
+  "artifact_paths": {
+    "json": "11_pre_trade_discipline_decision.json",
+    "markdown": "11_pre_trade_discipline_decision.md"
+  },
+  "as_of": "2026-06-29T08:00:00-04:00",
+  "candidate_results": [
+    {
+      "actionable": true,
+      "checklist_answers": {
+        "actual_risk_dollars": 500.0,
+        "entry_in_written_plan": true,
+        "notes": "Fictional 200-share plan; no order submitted.",
+        "planned_risk_dollars": 500.0,
+        "size_within_plan": true,
+        "stop_predefined": true
+      },
+      "decision": "GO",
+      "link_status": "skipped_no_state_dir",
+      "order_intent": "MANUAL_ORDER",
+      "reasons": [],
+      "symbol": "EXMPL",
+      "thesis_id": "th_exmpl_gro_20260629_cd34"
+    }
+  ],
+  "generated_at": "2026-06-29T12:00:00+00:00",
+  "inputs": {
+    "circuit_breaker_decision": "01_circuit_breaker_decision.json",
+    "market_regime_decision": "00_exposure_decision.json",
+    "state_dir": null
+  },
+  "metrics": {
+    "actionable_candidates": 1,
+    "candidates_total": 1,
+    "revenge_window_hours": 24.0,
+    "theses_scanned": 0
+  },
+  "overall_decision": "GO",
+  "rationale": "All actionable manual-order candidates passed the pre-trade discipline gate.",
+  "schema_version": "1.0",
+  "warnings": []
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/11_pre_trade_discipline_decision.md
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/11_pre_trade_discipline_decision.md
@@ -1,0 +1,13 @@
+# Pre-Trade Discipline Decision
+**As of:** 2026-06-29T08:00:00-04:00
+**Decision:** GO
+
+## Rationale
+
+All actionable manual-order candidates passed the pre-trade discipline gate.
+
+## Candidates
+
+| Symbol | Intent | Actionable | Decision | Reasons | Link |
+|--------|--------|------------|----------|---------|------|
+| EXMPL | MANUAL_ORDER | yes | GO | None | skipped_no_state_dir |

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/manifest.yaml
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/manifest.yaml
@@ -1,0 +1,89 @@
+workflow_id: swing-opportunity-daily
+sample_type: full-path
+status: completed
+completed_steps:
+- 1
+- 2
+- 3
+- 4
+- 5
+- 6
+- 7
+- 8
+- 9
+- 10
+- 11
+required_steps_not_executed: []
+illustrative: true
+generated_by: scripts/workflow_replay.py generate
+prompt: prompt.md
+network_policy: offline-input-required
+optional_steps_skipped: []
+artifacts:
+- step: 1
+  artifact_id: circuit_breaker_decision
+  skill: drawdown-circuit-breaker
+  execution_mode: native_cli
+  files:
+    canonical: 01_circuit_breaker_decision.json
+- step: 2
+  artifact_id: vcp_candidates
+  skill: vcp-screener
+  execution_mode: manual_contract
+  files:
+    canonical: 02_vcp_candidates.json
+- step: 3
+  artifact_id: momentum_burst_candidates
+  skill: stockbee-momentum-burst-screener
+  execution_mode: manual_contract
+  files:
+    canonical: 03_momentum_burst_candidates.json
+- step: 4
+  artifact_id: exhaustion_hammer_candidates
+  skill: stockbee-exhaustion-hammer-screener
+  execution_mode: manual_contract
+  files:
+    canonical: 04_exhaustion_hammer_candidates.json
+- step: 5
+  artifact_id: canslim_candidates
+  skill: canslim-screener
+  execution_mode: manual_contract
+  files:
+    canonical: 05_canslim_candidates.json
+- step: 6
+  artifact_id: theme_candidates
+  skill: theme-detector
+  execution_mode: manual_contract
+  files:
+    canonical: 06_theme_candidates.json
+- step: 7
+  artifact_id: validated_setups
+  skill: technical-analyst
+  execution_mode: manual_contract
+  files:
+    canonical: 07_validated_setups.json
+- step: 8
+  artifact_id: position_sizing
+  skill: position-sizer
+  execution_mode: native_cli
+  files:
+    canonical: 08_position_sizing.json
+- step: 9
+  artifact_id: trade_plans
+  skill: breakout-trade-planner
+  execution_mode: manual_contract
+  files:
+    canonical: 09_trade_plans.json
+- step: 10
+  artifact_id: candidate_journal_entry
+  skill: trader-memory-core
+  execution_mode: manual_contract
+  files:
+    canonical: 10_candidate_journal_entry.yaml
+- step: 11
+  artifact_id: pre_trade_discipline_decision
+  skill: pre-trade-discipline-gate
+  execution_mode: native_cli
+  files:
+    canonical: 11_pre_trade_discipline_decision.json
+    companion: 11_pre_trade_discipline_decision.md

--- a/examples/workflows/swing-opportunity-daily/replay-run-full-path/prompt.md
+++ b/examples/workflows/swing-opportunity-daily/replay-run-full-path/prompt.md
@@ -1,0 +1,5 @@
+# Prompt: full-path swing-opportunity-daily replay
+
+Replay this workflow with the bundled fictional input data. This is not investment advice and must not submit orders or call live APIs.
+
+Run the optional human-approved lessons step after reviewing the cohort evidence.

--- a/examples/workflows/swing-opportunity-daily/replay-run/01_circuit_breaker_decision.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run/01_circuit_breaker_decision.json
@@ -1,0 +1,26 @@
+{
+  "account_size": 100000.0,
+  "as_of_date": "2026-06-29",
+  "config": {
+    "cooldown_hours": 24.0,
+    "losing_streak_n": 2,
+    "max_daily_loss_pct": 2.0,
+    "monthly_drawdown_pct": 8.0,
+    "weekly_drawdown_pct": 5.0
+  },
+  "data_quality": "EMPTY_STATE",
+  "generated_at": "2026-06-29T12:00:00+00:00",
+  "metrics": {
+    "consecutive_losses": 0,
+    "last_loss_exit_at": null,
+    "realized_pnl_mtd": 0.0,
+    "realized_pnl_today": 0.0,
+    "realized_pnl_wtd": 0.0,
+    "theses_scanned": 0
+  },
+  "rationale": "No account-level circuit breaker rules are active; new trade risk may proceed.",
+  "recommendation": "TRADING_ALLOWED",
+  "schema_version": "1.0",
+  "triggered_rules": [],
+  "warnings": []
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run/02_vcp_candidates.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run/02_vcp_candidates.json
@@ -1,0 +1,24 @@
+{
+  "as_of": "2026-06-29",
+  "candidates": [
+    {
+      "contractions_pct": [
+        18.0,
+        10.0,
+        5.0
+      ],
+      "pattern": "VCP",
+      "pivot_price": 50.0,
+      "score": 88,
+      "status": "CANDIDATE_NOT_SIGNAL",
+      "suggested_stop": 47.5,
+      "symbol": "EXMPL",
+      "volume_dry_up": true
+    }
+  ],
+  "schema_version": "1.0",
+  "universe": "fictional_teaching_universe",
+  "warnings": [
+    "EXMPL is fictional; candidate generation is not a buy recommendation."
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run/07_validated_setups.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run/07_validated_setups.json
@@ -1,0 +1,30 @@
+{
+  "as_of": "2026-06-29",
+  "inputs_missing": [
+    "momentum_burst_candidates",
+    "exhaustion_hammer_candidates",
+    "canslim_candidates",
+    "theme_candidates"
+  ],
+  "inputs_provided": [
+    "vcp_candidates"
+  ],
+  "rejected": [],
+  "schema_version": "1.0",
+  "setups": [
+    {
+      "base_quality": "TIGHT",
+      "decision": "VALIDATED",
+      "entry_price": 50.0,
+      "manual_chart_review": "PASS",
+      "risk_per_share": 2.5,
+      "source_artifacts": [
+        "vcp_candidates"
+      ],
+      "stop_price": 47.5,
+      "symbol": "EXMPL",
+      "target_price": 55.0,
+      "weekly_trend": "STAGE_2"
+    }
+  ]
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run/08_position_sizing.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run/08_position_sizing.json
@@ -1,0 +1,27 @@
+{
+  "binding_constraint": null,
+  "calculations": {
+    "atr_based": null,
+    "fixed_fractional": {
+      "dollar_risk": 500.0,
+      "method": "fixed_fractional",
+      "risk_per_share": 2.5,
+      "shares": 200,
+      "stop_price": 47.5
+    },
+    "kelly": null
+  },
+  "constraints_applied": [],
+  "final_position_value": 10000.0,
+  "final_recommended_shares": 200,
+  "final_risk_dollars": 500.0,
+  "final_risk_pct": 0.5,
+  "mode": "shares",
+  "parameters": {
+    "account_size": 100000.0,
+    "entry_price": 50.0,
+    "risk_pct": 0.5,
+    "stop_price": 47.5
+  },
+  "schema_version": "1.0"
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run/10_candidate_journal_entry.yaml
+++ b/examples/workflows/swing-opportunity-daily/replay-run/10_candidate_journal_entry.yaml
@@ -1,0 +1,81 @@
+thesis_id: th_exmpl_gro_20260629_ab12
+ticker: EXMPL
+created_at: '2026-06-29T12:00:00+00:00'
+updated_at: '2026-06-29T12:00:00+00:00'
+thesis_type: growth_momentum
+setup_type: fictional_vcp
+catalyst: null
+status: ENTRY_READY
+status_history:
+- status: IDEA
+  at: '2026-06-29T12:00:00+00:00'
+  reason: Registered from the fictional VCP sample.
+- status: ENTRY_READY
+  at: '2026-06-29T12:00:00+00:00'
+  reason: Weekly setup and position size were reviewed.
+thesis_statement: EXMPL holds the fictional 50.00 pivot after a tightening VCP base.
+mechanism_tag: behavior
+evidence:
+- VCP contractions narrowed from 18% to 10% to 5%.
+- Manual weekly-chart review passed.
+kill_criteria:
+- Close below the planned 47.50 stop invalidates the setup.
+confidence: medium
+confidence_score: 0.7
+entry:
+  target_price: 50.0
+  conditions:
+  - Entry must remain in the written plan.
+  actual_price: null
+  actual_date: null
+exit:
+  stop_loss: 47.5
+  stop_loss_pct: 5.0
+  take_profit: 55.0
+  take_profit_rr: 2.0
+  time_stop_days: 10
+  actual_price: null
+  actual_date: null
+  exit_reason: null
+position:
+  shares: 200
+  shares_remaining: 200
+  position_value: 10000.0
+  risk_dollars: 500.0
+  risk_pct_of_account: 0.5
+  account_type: fictional_cash
+  sizing_method: fixed_fractional
+  raw_source:
+    skill: position-sizer
+    file: 08_position_sizing.json
+    fields:
+      final_recommended_shares: 200
+      final_risk_dollars: 500.0
+market_context:
+  regime: NEW_ENTRY_ALLOWED
+  breadth_score: 70
+  top_detector_score: 35
+  sector: Fictional Technology
+monitoring:
+  review_interval_days: 1
+  next_review_date: '2026-06-30'
+  last_review_date: null
+  review_status: OK
+  triggers_config: []
+  alerts: []
+origin:
+  skill: vcp-screener
+  output_file: 02_vcp_candidates.json
+  screening_grade: A
+  screening_score: 88
+  raw_provenance:
+    fixture: fictional
+linked_reports: []
+outcome:
+  pnl_dollars: null
+  pnl_pct: null
+  holding_days: null
+  mae_pct: null
+  mfe_pct: null
+  mae_mfe_source: null
+  lessons_learned: null

--- a/examples/workflows/swing-opportunity-daily/replay-run/11_pre_trade_discipline_decision.json
+++ b/examples/workflows/swing-opportunity-daily/replay-run/11_pre_trade_discipline_decision.json
@@ -1,0 +1,46 @@
+{
+  "artifact_paths": {
+    "json": "11_pre_trade_discipline_decision.json",
+    "markdown": "11_pre_trade_discipline_decision.md"
+  },
+  "as_of": "2026-06-29T08:00:00-04:00",
+  "candidate_results": [
+    {
+      "actionable": true,
+      "checklist_answers": {
+        "actual_risk_dollars": 500.0,
+        "entry_in_written_plan": false,
+        "notes": "Fictional 200-share plan; no order submitted.",
+        "planned_risk_dollars": 500.0,
+        "size_within_plan": false,
+        "stop_predefined": false
+      },
+      "decision": "NO_GO",
+      "link_status": "skipped_no_state_dir",
+      "order_intent": "MANUAL_ORDER",
+      "reasons": [
+        "entry is not confirmed in the written plan",
+        "stop is not predefined",
+        "size is not confirmed within plan"
+      ],
+      "symbol": "EXMPL",
+      "thesis_id": "th_exmpl_gro_20260629_ab12"
+    }
+  ],
+  "generated_at": "2026-06-29T12:00:00+00:00",
+  "inputs": {
+    "circuit_breaker_decision": "01_circuit_breaker_decision.json",
+    "market_regime_decision": "00_exposure_decision.json",
+    "state_dir": null
+  },
+  "metrics": {
+    "actionable_candidates": 1,
+    "candidates_total": 1,
+    "revenge_window_hours": 24.0,
+    "theses_scanned": 0
+  },
+  "overall_decision": "NO_GO",
+  "rationale": "At least one actionable candidate violated a discipline rule; do not place the manual order.",
+  "schema_version": "1.0",
+  "warnings": []
+}

--- a/examples/workflows/swing-opportunity-daily/replay-run/11_pre_trade_discipline_decision.md
+++ b/examples/workflows/swing-opportunity-daily/replay-run/11_pre_trade_discipline_decision.md
@@ -1,0 +1,13 @@
+# Pre-Trade Discipline Decision
+**As of:** 2026-06-29T08:00:00-04:00
+**Decision:** NO_GO
+
+## Rationale
+
+At least one actionable candidate violated a discipline rule; do not place the manual order.
+
+## Candidates
+
+| Symbol | Intent | Actionable | Decision | Reasons | Link |
+|--------|--------|------------|----------|---------|------|
+| EXMPL | MANUAL_ORDER | yes | NO_GO | entry is not confirmed in the written plan<br>stop is not predefined<br>size is not confirmed within plan | skipped_no_state_dir |

--- a/examples/workflows/swing-opportunity-daily/replay-run/manifest.yaml
+++ b/examples/workflows/swing-opportunity-daily/replay-run/manifest.yaml
@@ -1,0 +1,69 @@
+workflow_id: swing-opportunity-daily
+sample_type: required-only
+status: completed
+completed_steps:
+- 1
+- 2
+- 7
+- 8
+- 10
+- 11
+required_steps_not_executed: []
+illustrative: true
+generated_by: scripts/workflow_replay.py generate
+prompt: prompt.md
+network_policy: offline-input-required
+optional_steps_skipped:
+- step: 3
+  skill: stockbee-momentum-burst-screener
+  reason: required-only executable replay
+- step: 4
+  skill: stockbee-exhaustion-hammer-screener
+  reason: required-only executable replay
+- step: 5
+  skill: canslim-screener
+  reason: required-only executable replay
+- step: 6
+  skill: theme-detector
+  reason: required-only executable replay
+- step: 9
+  skill: breakout-trade-planner
+  reason: required-only executable replay
+artifacts:
+- step: 1
+  artifact_id: circuit_breaker_decision
+  skill: drawdown-circuit-breaker
+  execution_mode: native_cli
+  files:
+    canonical: 01_circuit_breaker_decision.json
+- step: 2
+  artifact_id: vcp_candidates
+  skill: vcp-screener
+  execution_mode: manual_contract
+  files:
+    canonical: 02_vcp_candidates.json
+- step: 7
+  artifact_id: validated_setups
+  skill: technical-analyst
+  execution_mode: manual_contract
+  files:
+    canonical: 07_validated_setups.json
+- step: 8
+  artifact_id: position_sizing
+  skill: position-sizer
+  execution_mode: native_cli
+  files:
+    canonical: 08_position_sizing.json
+- step: 10
+  artifact_id: candidate_journal_entry
+  skill: trader-memory-core
+  execution_mode: manual_contract
+  files:
+    canonical: 10_candidate_journal_entry.yaml
+- step: 11
+  artifact_id: pre_trade_discipline_decision
+  skill: pre-trade-discipline-gate
+  execution_mode: native_cli
+  files:
+    canonical: 11_pre_trade_discipline_decision.json
+    companion: 11_pre_trade_discipline_decision.md

--- a/examples/workflows/swing-opportunity-daily/replay-run/prompt.md
+++ b/examples/workflows/swing-opportunity-daily/replay-run/prompt.md
@@ -1,0 +1,5 @@
+# Prompt: required-only swing-opportunity-daily replay
+
+Replay this workflow with the bundled fictional input data. This is not investment advice and must not submit orders or call live APIs.
+
+Skip every optional step.

--- a/examples/workflows/swing-opportunity-daily/replay.yaml
+++ b/examples/workflows/swing-opportunity-daily/replay.yaml
@@ -1,0 +1,129 @@
+schema_version: 1
+workflow_id: swing-opportunity-daily
+fixed_timestamp: "2026-06-29T12:00:00+00:00"
+
+inputs:
+  exposure_decision: replay-inputs/exposure-decision.json
+  vcp_scan: replay-inputs/vcp-scan.json
+  momentum_burst: replay-inputs/momentum-burst.json
+  exhaustion_hammer: replay-inputs/exhaustion-hammer.json
+  canslim: replay-inputs/canslim.json
+  theme: replay-inputs/theme.json
+  validated_setups: replay-inputs/validated-setups.json
+  sizing_parameters: replay-inputs/sizing-parameters.json
+  journal: replay-inputs/journal-decision.yaml
+
+steps:
+  - step: 1
+    executor: swing_circuit_breaker
+    executor_mode: native_cli
+    gate_policy: continue
+    output_files:
+      circuit_breaker_decision:
+        canonical: 01_circuit_breaker_decision.json
+
+  - step: 2
+    executor: swing_vcp_screen
+    executor_mode: manual_contract
+    gate_policy: continue
+    output_files:
+      vcp_candidates:
+        canonical: 02_vcp_candidates.json
+
+  - step: 3
+    executor: swing_momentum_burst
+    executor_mode: manual_contract
+    gate_policy: continue
+    output_files:
+      momentum_burst_candidates:
+        canonical: 03_momentum_burst_candidates.json
+
+  - step: 4
+    executor: swing_exhaustion_hammer
+    executor_mode: manual_contract
+    gate_policy: continue
+    output_files:
+      exhaustion_hammer_candidates:
+        canonical: 04_exhaustion_hammer_candidates.json
+
+  - step: 5
+    executor: swing_canslim
+    executor_mode: manual_contract
+    gate_policy: continue
+    output_files:
+      canslim_candidates:
+        canonical: 05_canslim_candidates.json
+
+  - step: 6
+    executor: swing_theme
+    executor_mode: manual_contract
+    gate_policy: continue
+    output_files:
+      theme_candidates:
+        canonical: 06_theme_candidates.json
+
+  - step: 7
+    executor: swing_validate_setups
+    executor_mode: manual_contract
+    gate_policy: continue
+    output_files:
+      validated_setups:
+        canonical: 07_validated_setups.json
+
+  - step: 8
+    executor: swing_position_size
+    executor_mode: native_cli
+    gate_policy: continue
+    output_files:
+      position_sizing:
+        canonical: 08_position_sizing.json
+
+  - step: 9
+    executor: swing_build_plan
+    executor_mode: manual_contract
+    gate_policy: continue
+    output_files:
+      trade_plans:
+        canonical: 09_trade_plans.json
+
+  - step: 10
+    executor: swing_journal
+    executor_mode: manual_contract
+    gate_policy: continue
+    output_files:
+      candidate_journal_entry:
+        canonical: 10_candidate_journal_entry.yaml
+
+  - step: 11
+    executor: swing_discipline
+    executor_mode: native_cli
+    gate_policy: continue
+    output_files:
+      pre_trade_discipline_decision:
+        canonical: 11_pre_trade_discipline_decision.json
+        companion: 11_pre_trade_discipline_decision.md
+
+variants:
+  required-only:
+    enabled_steps:
+      - 1
+      - 2
+      - 7
+      - 8
+      - 10
+      - 11
+    golden_dir: replay-run
+  full-path:
+    enabled_steps:
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+    golden_dir: replay-run-full-path

--- a/scripts/tests/test_workflow_replay.py
+++ b/scripts/tests/test_workflow_replay.py
@@ -42,16 +42,18 @@ def test_coverage_is_complete_and_six_of_eleven_deferrals_are_frozen() -> None:
         "monthly-performance-review",
         "stockbee-20pct-study-daily",
         "stockbee-fluency-loop",
+        "swing-opportunity-daily",
         "trade-memory-loop",
     ]
     assert set(summary["deferred"]) == FROZEN_DEFERRED_WORKFLOWS
-    assert len(summary["deferred"]) == 5
+    assert len(summary["deferred"]) == 4
     assert summary["variants"] == {
         "core-portfolio-weekly": ["required-only", "full-path"],
         "market-regime-daily": ["required-only", "full-path"],
         "monthly-performance-review": ["required-only", "full-path"],
         "stockbee-20pct-study-daily": ["required-only", "full-path"],
         "stockbee-fluency-loop": ["required-only", "full-path"],
+        "swing-opportunity-daily": ["required-only", "full-path"],
         "trade-memory-loop": ["required-only", "full-path"],
     }
 
@@ -65,10 +67,10 @@ def test_new_workflow_cannot_be_silently_deferred() -> None:
 
     coverage["deferred"]["new-workflow"] = {
         "issue": 294,
-        "reason": "Do not allow new coverage 6/11 deferrals.",
+        "reason": "Do not allow new coverage 7/11 deferrals.",
     }
     errors = coverage_errors(workflow_ids, coverage)
-    assert any("frozen coverage 6/11 deferred set" in error for error in errors)
+    assert any("frozen coverage 7/11 deferred set" in error for error in errors)
 
 
 def test_pilot_spec_matches_workflow_and_requires_offline_prices() -> None:
@@ -556,7 +558,7 @@ def test_check_writes_structured_report_when_executor_fails(
 
     assert any("injected execution failure" in difference for difference in differences)
     report = json.loads(report_path.read_text(encoding="utf-8"))
-    assert report["coverage"] == {"covered": 6, "total": 11}
+    assert report["coverage"] == {"covered": 7, "total": 11}
     assert report["rows"][0]["status"] == "error"
     assert report["rows"][0]["completed_steps"] == [1]
 

--- a/scripts/tests/test_workflow_replay_swing.py
+++ b/scripts/tests/test_workflow_replay_swing.py
@@ -1,0 +1,320 @@
+"""Executable replay coverage for swing-opportunity-daily (Issue #294)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import workflow_replay as replay_module  # noqa: E402
+from workflow_replay import (  # noqa: E402
+    ReplayError,
+    compare_trees,
+    execute_replay,
+    load_yaml,
+)
+
+SPEC = ROOT / "examples" / "workflows" / "swing-opportunity-daily" / "replay.yaml"
+COVERAGE = ROOT / "examples" / "workflows" / "replay-coverage.yaml"
+
+
+def test_swing_spec_runs_three_native_cli_steps_and_manual_screens() -> None:
+    summary = replay_module.validate_spec(ROOT, SPEC)
+
+    assert summary["workflow_id"] == "swing-opportunity-daily"
+    assert summary["native_steps"] == [1, 8, 11]
+    assert summary["manual_contract_steps"] == [2, 3, 4, 5, 6, 7, 9, 10]
+
+
+def test_required_only_replays_core_steps_and_skips_optional(tmp_path: Path) -> None:
+    output = tmp_path / "required"
+    report = execute_replay(ROOT, SPEC, "required-only", output)
+
+    assert report["status"] == "completed"
+    assert report["network_policy"] == "offline-input-required"
+    assert [step["executor_mode"] for step in report["steps"]] == [
+        "native_cli",
+        "manual_contract",
+        "manual_contract",
+        "native_cli",
+        "manual_contract",
+        "native_cli",
+    ]
+    assert [step["gate_policy"] for step in report["steps"]] == ["continue"] * 6
+
+    circuit = json.loads((output / "01_circuit_breaker_decision.json").read_text())
+    vcp = json.loads((output / "02_vcp_candidates.json").read_text())
+    validated = json.loads((output / "07_validated_setups.json").read_text())
+    sizing = json.loads((output / "08_position_sizing.json").read_text())
+    journal = load_yaml(output / "10_candidate_journal_entry.yaml")
+    discipline = json.loads((output / "11_pre_trade_discipline_decision.json").read_text())
+
+    assert circuit["recommendation"] == "TRADING_ALLOWED"
+    assert vcp["candidates"][0]["symbol"] == "EXMPL"
+    assert validated["inputs_provided"] == ["vcp_candidates"]
+    assert validated["inputs_missing"] == [
+        "momentum_burst_candidates",
+        "exhaustion_hammer_candidates",
+        "canslim_candidates",
+        "theme_candidates",
+    ]
+    assert sizing["final_recommended_shares"] == 200
+    assert journal["thesis_id"] == "th_exmpl_gro_20260629_ab12"
+    assert journal["origin"]["skill"] == "vcp-screener"
+    assert journal["evidence"] == [
+        "VCP contractions narrowed from 18% to 10% to 5%.",
+        "Manual weekly-chart review passed.",
+    ]
+    assert discipline["overall_decision"] == "NO_GO"
+    assert discipline["candidate_results"][0]["thesis_id"] == "th_exmpl_gro_20260629_ab12"
+    assert discipline["candidate_results"][0]["link_status"] == "skipped_no_state_dir"
+    assert not (output / "09_trade_plans.json").exists()
+
+    manifest = load_yaml(output / "manifest.yaml")
+    assert manifest["completed_steps"] == [1, 2, 7, 8, 10, 11]
+    assert manifest["optional_steps_skipped"] == [
+        {
+            "step": 3,
+            "skill": "stockbee-momentum-burst-screener",
+            "reason": "required-only executable replay",
+        },
+        {
+            "step": 4,
+            "skill": "stockbee-exhaustion-hammer-screener",
+            "reason": "required-only executable replay",
+        },
+        {"step": 5, "skill": "canslim-screener", "reason": "required-only executable replay"},
+        {"step": 6, "skill": "theme-detector", "reason": "required-only executable replay"},
+        {"step": 9, "skill": "breakout-trade-planner", "reason": "required-only executable replay"},
+    ]
+
+
+def test_full_path_builds_trade_plan_and_corroborating_evidence(tmp_path: Path) -> None:
+    output = tmp_path / "full"
+    report = execute_replay(ROOT, SPEC, "full-path", output)
+
+    assert report["status"] == "completed"
+    plan = json.loads((output / "09_trade_plans.json").read_text())
+    journal = load_yaml(output / "10_candidate_journal_entry.yaml")
+
+    assert plan["plans"][0]["limit_price"] == 50.25
+    assert plan["plans"][0]["risk_reward_ratio"] == 2.0
+    assert plan["plans"][0]["order_status"] == "PROPOSED_NOT_SUBMITTED"
+    assert journal["thesis_id"] == "th_exmpl_gro_20260629_cd34"
+    assert journal["origin"]["skill"] == "breakout-trade-planner"
+    assert journal["evidence"] == [
+        "VCP contractions narrowed from 18% to 10% to 5%.",
+        "Momentum, CANSLIM, and fictional-theme screens corroborated the candidate.",
+        "Manual weekly-chart review passed.",
+    ]
+
+
+def test_invalid_offline_input_fails_without_partial_publication(
+    tmp_path: Path,
+) -> None:
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir()
+    invalid = input_dir / "invalid-sizing.json"
+    invalid.write_text("{not json\n", encoding="utf-8")
+    output = tmp_path / "published"
+    output.mkdir()
+    sentinel = output / "existing.txt"
+    sentinel.write_bytes(b"unchanged\n")
+
+    with pytest.raises(ReplayError) as exc_info:
+        execute_replay(
+            ROOT,
+            SPEC,
+            "required-only",
+            output,
+            input_overrides={"sizing_parameters": invalid},
+        )
+
+    assert exc_info.value.completed_steps == []
+    assert sentinel.read_bytes() == b"unchanged\n"
+    assert {path.name for path in output.iterdir()} == {"existing.txt"}
+
+
+def test_mismatched_validated_setup_cross_check_halts(tmp_path: Path) -> None:
+    validated = json.loads((SPEC.parent / "replay-inputs/validated-setups.json").read_text())
+    validated["setups"][0]["entry_price"] = 51.0
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir()
+    override = input_dir / "validated-setups.json"
+    override.write_text(json.dumps(validated), encoding="utf-8")
+
+    with pytest.raises(ReplayError, match="validated setup entry"):
+        execute_replay(
+            ROOT,
+            SPEC,
+            "required-only",
+            tmp_path / "published",
+            input_overrides={"validated_setups": override},
+        )
+
+    assert not (tmp_path / "published").exists()
+
+
+def test_vcp_candidate_symbol_mismatch_halts_validate_setups(tmp_path: Path) -> None:
+    vcp = json.loads((SPEC.parent / "replay-inputs/vcp-scan.json").read_text())
+    vcp["candidates"][0]["symbol"] = "OTHER"
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir()
+    override = input_dir / "vcp-scan.json"
+    override.write_text(json.dumps(vcp), encoding="utf-8")
+
+    with pytest.raises(ReplayError, match="does not match any VCP candidate"):
+        execute_replay(
+            ROOT,
+            SPEC,
+            "required-only",
+            tmp_path / "published",
+            input_overrides={"vcp_scan": override},
+        )
+
+    assert not (tmp_path / "published").exists()
+
+
+def test_trade_plan_price_mismatch_halts_discipline_fail_closed(tmp_path: Path) -> None:
+    def tamper_after_plan(step: int, artifacts: dict[str, dict]) -> None:
+        if step == 9:
+            path = Path(artifacts["trade_plans"]["files"]["canonical"])
+            plan = json.loads(path.read_text())
+            plan["plans"][0]["entry_price"] = 99.0
+            path.write_text(json.dumps(plan), encoding="utf-8")
+
+    with pytest.raises(ReplayError, match="trade plan.*inconsistent"):
+        execute_replay(
+            ROOT,
+            SPEC,
+            "full-path",
+            tmp_path / "published",
+            after_step=tamper_after_plan,
+        )
+
+    assert not (tmp_path / "published").exists()
+
+
+def test_required_only_discipline_fails_closed_without_plan(tmp_path: Path) -> None:
+    output = tmp_path / "required"
+    execute_replay(ROOT, SPEC, "required-only", output)
+    discipline = json.loads((output / "11_pre_trade_discipline_decision.json").read_text())
+
+    assert discipline["overall_decision"] == "NO_GO"
+    checklist = discipline["candidate_results"][0]["checklist_answers"]
+    assert checklist["entry_in_written_plan"] is False
+    assert checklist["stop_predefined"] is False
+    assert checklist["size_within_plan"] is False
+
+
+def test_corrupt_state_handoff_stops_before_downstream_and_preserves_output(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "published"
+    output.mkdir()
+    sentinel = output / "existing.txt"
+    sentinel.write_bytes(b"unchanged\n")
+
+    def corrupt_after_scan(step: int, artifacts: dict[str, dict]) -> None:
+        if step == 7:
+            state = Path(artifacts["validated_setups"]["files"]["canonical"])
+            state.write_text("{not json\n", encoding="utf-8")
+
+    with pytest.raises(ReplayError) as exc_info:
+        execute_replay(
+            ROOT,
+            SPEC,
+            "required-only",
+            output,
+            after_step=corrupt_after_scan,
+        )
+
+    assert exc_info.value.completed_steps == [1, 2, 7]
+    assert sentinel.read_bytes() == b"unchanged\n"
+    assert {path.name for path in output.iterdir()} == {"existing.txt"}
+
+
+def test_native_commands_use_only_offline_inputs_and_scrub_sensitive_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[list[str], dict[str, str]]] = []
+    real_run = replay_module.subprocess.run
+    monkeypatch.setenv("REPLAY_API_KEY", "secret-value")
+    monkeypatch.setenv("REPLAY_PROXY", "http://proxy.invalid")
+
+    def capture_run(command, *args, **kwargs):
+        captured.append((list(command), dict(kwargs["env"])))
+        return real_run(command, *args, **kwargs)
+
+    monkeypatch.setattr(replay_module.subprocess, "run", capture_run)
+    execute_replay(ROOT, SPEC, "required-only", tmp_path / "published")
+
+    assert [command[1].split("/")[-1] for command, _env in captured] == [
+        "check_circuit_breaker.py",
+        "position_sizer.py",
+        "check_pre_trade_discipline.py",
+    ]
+    for command, env in captured:
+        assert not {"--symbols", "--fmp-universe", "--api-key"} & set(command)
+        assert "REPLAY_API_KEY" not in env
+        assert "REPLAY_PROXY" not in env
+
+
+@pytest.mark.parametrize(
+    ("variant", "golden_dir"),
+    (("required-only", "replay-run"), ("full-path", "replay-run-full-path")),
+)
+def test_swing_goldens_are_byte_reproducible(
+    variant: str,
+    golden_dir: str,
+    tmp_path: Path,
+) -> None:
+    generated = tmp_path / "generated"
+    execute_replay(ROOT, SPEC, variant, generated)
+    assert compare_trees(generated, SPEC.parent / golden_dir) == []
+
+    altered = tmp_path / "altered"
+    shutil.copytree(SPEC.parent / golden_dir, altered)
+    candidate = next(altered.glob("0*_*.json"))
+    candidate.write_text("{}\n", encoding="utf-8")
+    assert compare_trees(generated, altered)
+
+
+@pytest.mark.parametrize(
+    "output_dir",
+    [
+        ROOT,
+        SPEC,
+        SPEC.parent,
+        SPEC.parent / "replay-inputs",
+        SPEC.parent / "sample-run",
+        SPEC.parent / "sample-run-full-path",
+        SPEC.parent / "replay-run",
+        SPEC.parent / "replay-run-full-path",
+    ],
+)
+def test_runtime_output_cannot_overlap_repo_sources_or_goldens(
+    output_dir: Path,
+    tmp_path: Path,
+) -> None:
+    protected_files = [
+        SPEC,
+        SPEC.parent / "replay-inputs/exposure-decision.json",
+        SPEC.parent / "sample-run/manifest.yaml",
+        SPEC.parent / "sample-run-full-path/manifest.yaml",
+        SPEC.parent / "replay-run/manifest.yaml",
+        SPEC.parent / "replay-run-full-path/manifest.yaml",
+    ]
+    before = {path: path.read_bytes() for path in protected_files}
+
+    with pytest.raises(ReplayError, match="output_dir (?:overlaps protected|must be a directory)"):
+        execute_replay(ROOT, SPEC, "required-only", output_dir)
+
+    assert {path: path.read_bytes() for path in protected_files} == before

--- a/scripts/tests/test_workflow_replay_trade_memory.py
+++ b/scripts/tests/test_workflow_replay_trade_memory.py
@@ -51,9 +51,10 @@ def test_coverage_includes_trade_memory_at_six_of_eleven() -> None:
         "monthly-performance-review",
         "stockbee-20pct-study-daily",
         "stockbee-fluency-loop",
+        "swing-opportunity-daily",
         "trade-memory-loop",
     ]
-    assert len(summary["deferred"]) == 5
+    assert len(summary["deferred"]) == 4
     assert "trade-memory-loop" not in summary["deferred"]
 
 
@@ -453,6 +454,8 @@ def test_generate_stages_all_covered_goldens_without_publishing(
         "stockbee-20pct-study-daily:full-path",
         "stockbee-fluency-loop:required-only",
         "stockbee-fluency-loop:full-path",
+        "swing-opportunity-daily:required-only",
+        "swing-opportunity-daily:full-path",
         "trade-memory-loop:required-only",
         "trade-memory-loop:full-path",
     ]
@@ -467,6 +470,8 @@ def test_generate_stages_all_covered_goldens_without_publishing(
         "sample-run-full-path",
         "sample-run",
         "sample-run-full-path",
+        "replay-run",
+        "replay-run-full-path",
         "sample-run",
         "sample-run-full-path",
     ]

--- a/scripts/workflow_replay.py
+++ b/scripts/workflow_replay.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Deterministic workflow contract replay harness (Issue #294, coverage 6/11).
+"""Deterministic workflow contract replay harness (Issue #294, coverage 7/11).
 
 The harness executes real offline CLIs for the Stockbee fluency, 20% study,
-trade-memory, market-regime, monthly-performance-review, and core-portfolio
-workflows. Human decisions and fixture-backed native API evidence are reported
+trade-memory, market-regime, monthly-performance-review, core-portfolio, and
+swing-opportunity-daily workflows. Human decisions and fixture-backed native API evidence are reported
 separately from full skill execution. Golden outputs are comparison targets only
 and are never used as replay inputs.
 """
@@ -41,7 +41,7 @@ CORE_PORTFOLIO_SCHEMA = (
 )
 VARIANTS = ("required-only", "full-path")
 
-# Coverage 6/11 leaves five workflows deferred. This frozen baseline prevents a newly
+# Coverage 7/11 leaves four workflows deferred. This frozen baseline prevents a newly
 # introduced workflow from being waved through as another deferral.
 FROZEN_DEFERRED_WORKFLOWS = frozenset(
     {
@@ -49,7 +49,6 @@ FROZEN_DEFERRED_WORKFLOWS = frozenset(
         "multi-asset-opportunity-daily",
         "shapiro-contrarian",
         "stockbee-ep-daily",
-        "swing-opportunity-daily",
     }
 )
 
@@ -242,7 +241,7 @@ def coverage_errors(workflow_ids: set[str], coverage: Mapping[str, Any]) -> list
 
     if set(deferred) != FROZEN_DEFERRED_WORKFLOWS:
         errors.append(
-            "deferred workflows must match the frozen coverage 6/11 deferred set; "
+            "deferred workflows must match the frozen coverage 7/11 deferred set; "
             f"expected {sorted(FROZEN_DEFERRED_WORKFLOWS)}, got {sorted(deferred)}"
         )
     for workflow_id, entry in deferred.items():
@@ -502,6 +501,16 @@ def validate_spec(repo_root: Path, spec_path: Path) -> dict[str, Any]:
         "monthly_backtest": {"backtest_params"},
         "monthly_skill_review": {"skill_review_target"},
         "monthly_decision_log": {"rule_change_decision"},
+        "swing_circuit_breaker": {"sizing_parameters"},
+        "swing_vcp_screen": {"vcp_scan"},
+        "swing_momentum_burst": {"momentum_burst"},
+        "swing_exhaustion_hammer": {"exhaustion_hammer"},
+        "swing_canslim": {"canslim"},
+        "swing_theme": {"theme"},
+        "swing_validate_setups": {"validated_setups"},
+        "swing_position_size": {"sizing_parameters"},
+        "swing_journal": {"journal"},
+        "swing_discipline": {"exposure_decision"},
     }
     for number, replay_step in spec_steps.items():
         required_inputs = executor_required_inputs.get(replay_step["executor"], set())
@@ -3303,6 +3312,644 @@ def _monthly_decision_log(
     return artifacts
 
 
+_SWING_SCREEN_IDS = [
+    "vcp_candidates",
+    "momentum_burst_candidates",
+    "exhaustion_hammer_candidates",
+    "canslim_candidates",
+    "theme_candidates",
+]
+_SWING_CANDIDATE_LIST_KEY = {
+    "vcp_candidates": "candidates",
+    "momentum_burst_candidates": "candidates",
+    "exhaustion_hammer_candidates": "candidates",
+    "canslim_candidates": "candidates",
+    "theme_candidates": "themes",
+}
+_SWING_SCREEN_DISPLAY = {
+    "vcp_candidates": "VCP",
+    "momentum_burst_candidates": "Momentum",
+    "exhaustion_hammer_candidates": "Exhaustion Hammer",
+    "canslim_candidates": "CANSLIM",
+    "theme_candidates": "fictional-theme",
+}
+_SWING_SCREEN_INPUT_KEY = {
+    "vcp_candidates": "vcp_scan",
+    "momentum_burst_candidates": "momentum_burst",
+    "exhaustion_hammer_candidates": "exhaustion_hammer",
+    "canslim_candidates": "canslim",
+    "theme_candidates": "theme",
+}
+_SWING_SCREEN_CANONICAL = {
+    "vcp_candidates": "02_vcp_candidates.json",
+    "momentum_burst_candidates": "03_momentum_burst_candidates.json",
+    "exhaustion_hammer_candidates": "04_exhaustion_hammer_candidates.json",
+    "canslim_candidates": "05_canslim_candidates.json",
+    "theme_candidates": "06_theme_candidates.json",
+}
+_SWING_SETUP_CANONICAL = "07_validated_setups.json"
+
+
+def _swing_screen_symbols(payload: Mapping[str, Any] | None, screen_id: str) -> set[str]:
+    if not isinstance(payload, dict):
+        return set()
+    list_key = _SWING_CANDIDATE_LIST_KEY[screen_id]
+    value = payload.get(list_key)
+    if not isinstance(value, list):
+        return set()
+    if screen_id == "theme_candidates":
+        symbols: set[str] = set()
+        for entry in value:
+            if isinstance(entry, dict):
+                symbols.update(s for s in entry.get("symbols", []) if isinstance(s, str))
+        return symbols
+    return {c.get("symbol") for c in value if isinstance(c, dict) and c.get("symbol")}
+
+
+def _swing_payload_contains_symbol(
+    payload: Mapping[str, Any] | None, screen_id: str, symbol: str
+) -> bool:
+    return symbol in _swing_screen_symbols(payload, screen_id)
+
+
+def _swing_payloads_from_stage(stage: Path) -> dict[str, Mapping[str, Any]]:
+    payloads: dict[str, Mapping[str, Any]] = {}
+    for screen_id in _SWING_SCREEN_IDS:
+        path = stage / _SWING_SCREEN_CANONICAL[screen_id]
+        if path.exists():
+            payloads[screen_id] = _load_json(path, f"{screen_id} stage")
+    validated_path = stage / _SWING_SETUP_CANONICAL
+    if validated_path.exists():
+        payloads["validated_setups"] = _load_json(validated_path, "validated setups stage")
+    return payloads
+
+
+def _swing_corroboration_line(contributing: list[str]) -> str | None:
+    names = [_SWING_SCREEN_DISPLAY[sid] for sid in contributing]
+    if not names:
+        return None
+    if len(names) == 1:
+        return f"{names[0]} screen corroborated the candidate."
+    if len(names) == 2:
+        return f"{names[0]} and {names[1]} screens corroborated the candidate."
+    return f"{', '.join(names[:-1])}, and {names[-1]} screens corroborated the candidate."
+
+
+def _swing_circuit_breaker(
+    repo_root: Path,
+    spec: Mapping[str, Any],
+    step: Mapping[str, Any],
+    inputs: Mapping[str, Path],
+    consumed: Mapping[str, dict[str, Any]],
+    work: Path,
+    stage: Path,
+) -> dict[str, dict[str, Any]]:
+    sizing = _load_json(inputs["sizing_parameters"], "sizing parameters")
+    _require_finite_number(sizing.get("account_size"), "circuit breaker account_size")
+    state_dir = work / "empty_state"
+    state_dir.mkdir(parents=True)
+    reports = work / "reports"
+    reports.mkdir(parents=True)
+    _run_cli(
+        [
+            sys.executable,
+            str(
+                repo_root
+                / "skills"
+                / "drawdown-circuit-breaker"
+                / "scripts"
+                / "check_circuit_breaker.py"
+            ),
+            "--state-dir",
+            str(state_dir),
+            "--account-size",
+            str(int(sizing["account_size"])),
+            "--as-of",
+            spec["fixed_timestamp"][:10],
+            "--output-dir",
+            str(reports),
+            "--json-only",
+        ],
+        repo_root,
+    )
+    artifacts = _artifact_paths(stage, step["output_files"])
+    _normalize_json_file(
+        _latest_report(reports, "circuit_breaker_decision_*.json"),
+        Path(artifacts["circuit_breaker_decision"]["files"]["canonical"]),
+        spec["fixed_timestamp"],
+        {str(state_dir): "$STATE/empty_state", str(reports): "$WORK/reports"},
+    )
+    return artifacts
+
+
+def _swing_screen_executor(artifact_id: str):
+    input_key = _SWING_SCREEN_INPUT_KEY[artifact_id]
+    list_key = _SWING_CANDIDATE_LIST_KEY[artifact_id]
+
+    def _executor(
+        repo_root: Path,
+        spec: Mapping[str, Any],
+        step: Mapping[str, Any],
+        inputs: Mapping[str, Path],
+        consumed: Mapping[str, dict[str, Any]],
+        work: Path,
+        stage: Path,
+    ) -> dict[str, dict[str, Any]]:
+        if consumed:
+            raise ReplayError(f"{artifact_id} must not consume upstream artifacts")
+        fixture = _load_json(inputs[input_key], f"{artifact_id} fixture")
+        if not isinstance(fixture, dict):
+            raise ReplayError(f"{artifact_id} fixture must be a mapping")
+        if not isinstance(fixture.get(list_key), list):
+            raise ReplayError(f"{artifact_id} fixture {list_key!r} must be a list")
+        artifacts = _artifact_paths(stage, step["output_files"])
+        _write_json(Path(artifacts[artifact_id]["files"]["canonical"]), fixture)
+        return artifacts
+
+    return _executor
+
+
+def _swing_validate_setups(
+    repo_root: Path,
+    spec: Mapping[str, Any],
+    step: Mapping[str, Any],
+    inputs: Mapping[str, Path],
+    consumed: Mapping[str, dict[str, Any]],
+    work: Path,
+    stage: Path,
+) -> dict[str, dict[str, Any]]:
+    fixture = _load_json(inputs["validated_setups"], "validated setups fixture")
+    if not isinstance(fixture, dict) or not isinstance(fixture.get("setups"), list):
+        raise ReplayError("validated setups fixture must contain a setups list")
+    if "vcp_candidates" not in consumed:
+        raise ReplayError("validated setups requires the VCP screen to have been run")
+    provided = [sid for sid in _SWING_SCREEN_IDS if sid in consumed]
+    missing = [sid for sid in _SWING_SCREEN_IDS if sid not in consumed]
+    setups = []
+    for item in fixture["setups"]:
+        item = dict(item)
+        symbol = item.get("symbol")
+        if not symbol:
+            raise ReplayError("validated setup is missing a symbol")
+        vcp_path = Path(consumed["vcp_candidates"]["files"]["canonical"])
+        vcp = _load_json(vcp_path, "vcp handoff")
+        vcp_candidates = vcp.get("candidates")
+        if not isinstance(vcp_candidates, list) or not vcp_candidates:
+            raise ReplayError("VCP screen produced no candidates")
+        by_symbol = {
+            cand.get("symbol"): cand
+            for cand in vcp_candidates
+            if isinstance(cand, dict) and cand.get("symbol")
+        }
+        cand = by_symbol.get(symbol)
+        if cand is None:
+            raise ReplayError(
+                f"validated setup symbol {symbol!r} does not match any VCP candidate "
+                f"({sorted(by_symbol) or 'none'})"
+            )
+        pivot = cand.get("pivot_price")
+        stop = cand.get("suggested_stop")
+        if item.get("entry_price") != pivot:
+            raise ReplayError(
+                f"validated setup entry {item.get('entry_price')} != VCP pivot {pivot} for {symbol}"
+            )
+        if item.get("stop_price") != stop:
+            raise ReplayError(
+                f"validated setup stop {item.get('stop_price')} != VCP suggested stop {stop} "
+                f"for {symbol}"
+            )
+        item["source_artifacts"] = [
+            sid
+            for sid in provided
+            if _swing_payload_contains_symbol(
+                _load_json(Path(consumed[sid]["files"]["canonical"]), f"{sid} handoff"),
+                sid,
+                symbol,
+            )
+        ]
+        setups.append(item)
+    payload = {
+        "schema_version": fixture.get("schema_version"),
+        "as_of": fixture.get("as_of"),
+        "inputs_provided": provided,
+        "inputs_missing": missing,
+        "setups": setups,
+        "rejected": fixture.get("rejected", []),
+    }
+    artifacts = _artifact_paths(stage, step["output_files"])
+    _write_json(Path(artifacts["validated_setups"]["files"]["canonical"]), payload)
+    return artifacts
+
+
+def _swing_position_size(
+    repo_root: Path,
+    spec: Mapping[str, Any],
+    step: Mapping[str, Any],
+    inputs: Mapping[str, Path],
+    consumed: Mapping[str, dict[str, Any]],
+    work: Path,
+    stage: Path,
+) -> dict[str, dict[str, Any]]:
+    validated = _load_json(
+        Path(consumed["validated_setups"]["files"]["canonical"]), "validated setups handoff"
+    )
+    setup = validated["setups"][0]
+    sizing = _load_json(inputs["sizing_parameters"], "sizing parameters")
+    reports = work / "reports"
+    reports.mkdir(parents=True)
+    _run_cli(
+        [
+            sys.executable,
+            str(repo_root / "skills" / "position-sizer" / "scripts" / "position_sizer.py"),
+            "--account-size",
+            str(sizing["account_size"]),
+            "--entry",
+            str(setup["entry_price"]),
+            "--stop",
+            str(setup["stop_price"]),
+            "--risk-pct",
+            str(sizing["risk_pct"]),
+            "--output-dir",
+            str(reports),
+        ],
+        repo_root,
+    )
+    artifacts = _artifact_paths(stage, step["output_files"])
+    _normalize_json_file(
+        _latest_report(reports, "position_sizer_*.json"),
+        Path(artifacts["position_sizing"]["files"]["canonical"]),
+        spec["fixed_timestamp"],
+        {},
+    )
+    return artifacts
+
+
+def _swing_build_plan(
+    repo_root: Path,
+    spec: Mapping[str, Any],
+    step: Mapping[str, Any],
+    inputs: Mapping[str, Path],
+    consumed: Mapping[str, dict[str, Any]],
+    work: Path,
+    stage: Path,
+) -> dict[str, dict[str, Any]]:
+    if set(consumed) != {"validated_setups", "position_sizing"}:
+        raise ReplayError(f"swing build_plan received unexpected artifacts: {sorted(consumed)}")
+    validated = _load_json(
+        Path(consumed["validated_setups"]["files"]["canonical"]), "validated setups handoff"
+    )
+    sizing = _load_json(
+        Path(consumed["position_sizing"]["files"]["canonical"]), "position sizing handoff"
+    )
+    setup = validated["setups"][0]
+    entry = setup["entry_price"]
+    stop = setup["stop_price"]
+    target = setup["target_price"]
+    shares = int(sizing["final_recommended_shares"])
+    payload = {
+        "schema_version": "1.0",
+        "as_of": validated["as_of"],
+        "plans": [
+            {
+                "symbol": setup["symbol"],
+                "side": "BUY",
+                "entry_type": "STOP_LIMIT",
+                "entry_price": entry,
+                "limit_price": round(entry * 1.005, 2),
+                "stop_price": stop,
+                "target_price": target,
+                "shares": shares,
+                "position_value": sizing["final_position_value"],
+                "planned_risk_dollars": sizing["final_risk_dollars"],
+                "risk_reward_ratio": round((target - entry) / (entry - stop), 4),
+                "order_status": "PROPOSED_NOT_SUBMITTED",
+            }
+        ],
+        "manual_execution_required": True,
+    }
+    artifacts = _artifact_paths(stage, step["output_files"])
+    _write_json(Path(artifacts["trade_plans"]["files"]["canonical"]), payload)
+    return artifacts
+
+
+def _swing_journal(
+    repo_root: Path,
+    spec: Mapping[str, Any],
+    step: Mapping[str, Any],
+    inputs: Mapping[str, Path],
+    consumed: Mapping[str, dict[str, Any]],
+    work: Path,
+    stage: Path,
+) -> dict[str, dict[str, Any]]:
+    decision = load_yaml(inputs["journal"])
+    fixed_ts = spec["fixed_timestamp"]
+    has_trade_plans = "trade_plans" in consumed
+    sizing = _load_json(
+        Path(consumed["position_sizing"]["files"]["canonical"]), "position sizing handoff"
+    )
+    shares = int(sizing["final_recommended_shares"])
+    entry_price = sizing["parameters"]["entry_price"]
+    stop_price = sizing["parameters"]["stop_price"]
+
+    stage_payloads = _swing_payloads_from_stage(stage)
+    validated = stage_payloads.get("validated_setups")
+    if not validated or not isinstance(validated.get("setups"), list):
+        raise ReplayError("journal requires the validated setups artifact")
+    setup_list = validated["setups"]
+    if len(setup_list) != 1:
+        raise ReplayError(
+            f"journal must be tied to exactly one validated setup; found {len(setup_list)}"
+        )
+    setup = setup_list[0]
+    symbol = setup.get("symbol")
+    if not symbol:
+        raise ReplayError("journal validated setup is missing a symbol")
+    if setup.get("entry_price") != entry_price:
+        raise ReplayError(
+            f"journal setup entry {setup.get('entry_price')} != position sizing entry "
+            f"{entry_price} for {symbol}"
+        )
+    if setup.get("stop_price") != stop_price:
+        raise ReplayError(
+            f"journal setup stop {setup.get('stop_price')} != position sizing stop "
+            f"{stop_price} for {symbol}"
+        )
+
+    contributing = [
+        sid
+        for sid in _SWING_SCREEN_IDS
+        if sid in stage_payloads
+        and _swing_payload_contains_symbol(stage_payloads[sid], sid, symbol)
+    ]
+    non_vcp = [sid for sid in contributing if sid != "vcp_candidates"]
+    corroboration = _swing_corroboration_line(non_vcp)
+    evidence = [decision["evidence_base"]]
+    if corroboration:
+        evidence.append(corroboration)
+    evidence.append(decision["evidence_manual"])
+
+    if has_trade_plans:
+        origin_skill = "breakout-trade-planner"
+        origin_file = "09_trade_plans.json"
+        idea_reason = decision["reason_full_path"]
+        entry_ready_reason = "Weekly setup, position size, and optional trade plan were reviewed."
+        thesis_suffix = "_cd34"
+    else:
+        origin_skill = "vcp-screener"
+        origin_file = "02_vcp_candidates.json"
+        idea_reason = decision["reason_required_only"]
+        entry_ready_reason = "Weekly setup and position size were reviewed."
+        thesis_suffix = "_ab12"
+    thesis_id = f"th_{symbol.lower()}_gro_20260629{thesis_suffix}"
+
+    payload = {
+        "thesis_id": thesis_id,
+        "ticker": symbol,
+        "created_at": fixed_ts,
+        "updated_at": fixed_ts,
+        "thesis_type": decision["thesis_type"],
+        "setup_type": decision["setup_type"],
+        "catalyst": decision.get("catalyst"),
+        "status": "ENTRY_READY",
+        "status_history": [
+            {"status": "IDEA", "at": fixed_ts, "reason": idea_reason},
+            {"status": "ENTRY_READY", "at": fixed_ts, "reason": entry_ready_reason},
+        ],
+        "thesis_statement": (
+            f"{symbol} holds the fictional {entry_price:.2f} pivot after a tightening VCP base."
+        ),
+        "mechanism_tag": "behavior",
+        "evidence": evidence,
+        "kill_criteria": [f"Close below the planned {stop_price:.2f} stop invalidates the setup."],
+        "confidence": decision["confidence"],
+        "confidence_score": decision["confidence_score"],
+        "entry": {
+            "target_price": entry_price,
+            "conditions": decision["entry_conditions"],
+            "actual_price": None,
+            "actual_date": None,
+        },
+        "exit": {
+            "stop_loss": stop_price,
+            "stop_loss_pct": decision["exit"]["stop_loss_pct"],
+            "take_profit": decision["exit"]["take_profit"],
+            "take_profit_rr": decision["exit"]["take_profit_rr"],
+            "time_stop_days": decision["exit"]["time_stop_days"],
+            "actual_price": None,
+            "actual_date": None,
+            "exit_reason": None,
+        },
+        "position": {
+            "shares": shares,
+            "shares_remaining": shares,
+            "position_value": sizing["final_position_value"],
+            "risk_dollars": sizing["final_risk_dollars"],
+            "risk_pct_of_account": sizing["final_risk_pct"],
+            "account_type": decision["account_type"],
+            "sizing_method": decision["sizing_method"],
+            "raw_source": {
+                "skill": "position-sizer",
+                "file": "08_position_sizing.json",
+                "fields": {
+                    "final_recommended_shares": shares,
+                    "final_risk_dollars": sizing["final_risk_dollars"],
+                },
+            },
+        },
+        "market_context": decision["market_context"],
+        "monitoring": {
+            "review_interval_days": decision["monitoring"]["review_interval_days"],
+            "next_review_date": decision["monitoring"]["next_review_date"],
+            "last_review_date": None,
+            "review_status": "OK",
+            "triggers_config": [],
+            "alerts": [],
+        },
+        "origin": {
+            "skill": origin_skill,
+            "output_file": origin_file,
+            "screening_grade": decision["screening_grade"],
+            "screening_score": decision["screening_score"],
+            "raw_provenance": {"fixture": "fictional"},
+        },
+        "linked_reports": [],
+        "outcome": {
+            "pnl_dollars": None,
+            "pnl_pct": None,
+            "holding_days": None,
+            "mae_pct": None,
+            "mfe_pct": None,
+            "mae_mfe_source": None,
+            "lessons_learned": None,
+        },
+    }
+    artifacts = _artifact_paths(stage, step["output_files"])
+    _write_yaml(Path(artifacts["candidate_journal_entry"]["files"]["canonical"]), payload)
+    return artifacts
+
+
+def _swing_discipline(
+    repo_root: Path,
+    spec: Mapping[str, Any],
+    step: Mapping[str, Any],
+    inputs: Mapping[str, Path],
+    consumed: Mapping[str, dict[str, Any]],
+    work: Path,
+    stage: Path,
+) -> dict[str, dict[str, Any]]:
+    expected = {"candidate_journal_entry", "position_sizing", "circuit_breaker_decision"}
+    if "trade_plans" in consumed:
+        expected.add("trade_plans")
+    if set(consumed) != expected:
+        raise ReplayError(f"swing discipline received unexpected artifacts: {sorted(consumed)}")
+    journal = load_yaml(Path(consumed["candidate_journal_entry"]["files"]["canonical"]))
+    sizing = _load_json(
+        Path(consumed["position_sizing"]["files"]["canonical"]), "position sizing handoff"
+    )
+    regime_path = inputs["exposure_decision"].resolve()
+    cb_path = Path(consumed["circuit_breaker_decision"]["files"]["canonical"]).resolve()
+
+    symbol = journal["ticker"]
+    planned_risk = sizing["final_risk_dollars"]
+    _require_finite_number(planned_risk, "discipline planned_risk_dollars")
+    journal_shares = journal.get("position", {}).get("shares")
+    if journal_shares != sizing["final_recommended_shares"]:
+        raise ReplayError(
+            f"journal shares {journal_shares} != position sizing "
+            f"{sizing['final_recommended_shares']} for {symbol}"
+        )
+    if journal.get("position", {}).get("risk_dollars") != planned_risk:
+        raise ReplayError(
+            f"journal risk_dollars {journal.get('position', {}).get('risk_dollars')} != "
+            f"position sizing {planned_risk} for {symbol}"
+        )
+    if journal.get("entry", {}).get("target_price") != sizing["parameters"]["entry_price"]:
+        raise ReplayError(f"journal entry != position sizing entry for {symbol}")
+    if journal.get("exit", {}).get("stop_loss") != sizing["parameters"]["stop_price"]:
+        raise ReplayError(f"journal stop != position sizing stop for {symbol}")
+
+    has_trade_plans = "trade_plans" in consumed
+    plan_checks = {
+        "entry_in_written_plan": False,
+        "stop_predefined": False,
+        "size_within_plan": False,
+    }
+    if has_trade_plans:
+        plans_path = Path(consumed["trade_plans"]["files"]["canonical"]).resolve()
+        plans = _load_json(plans_path, "trade plans handoff")
+        plan_list = plans.get("plans")
+        if not isinstance(plan_list, list) or not plan_list:
+            raise ReplayError("trade plan handoff has no plans")
+        if len(plan_list) != 1:
+            raise ReplayError(f"discipline expects exactly one trade plan; found {len(plan_list)}")
+        plan = plan_list[0]
+        checks = [
+            ("symbol", plan.get("symbol"), symbol),
+            ("entry_price", plan.get("entry_price"), sizing["parameters"]["entry_price"]),
+            ("stop_price", plan.get("stop_price"), sizing["parameters"]["stop_price"]),
+            ("shares", plan.get("shares"), sizing["final_recommended_shares"]),
+            ("position_value", plan.get("position_value"), sizing["final_position_value"]),
+            (
+                "planned_risk_dollars",
+                plan.get("planned_risk_dollars"),
+                sizing["final_risk_dollars"],
+            ),
+        ]
+        mismatches = [
+            (field, got, expected_val) for field, got, expected_val in checks if got != expected_val
+        ]
+        if mismatches:
+            detail = ", ".join(
+                f"{field}={got!r} != {expected_val!r}" for field, got, expected_val in mismatches
+            )
+            raise ReplayError(f"trade plan for {symbol} inconsistent with sizing/journal: {detail}")
+        plan_checks["entry_in_written_plan"] = True
+        plan_checks["stop_predefined"] = True
+        plan_checks["size_within_plan"] = True
+
+    answers_path = work / "answers.json"
+    _write_json(
+        answers_path,
+        {
+            "candidates": [
+                {
+                    "symbol": symbol,
+                    "thesis_id": journal["thesis_id"],
+                    "order_intent": "MANUAL_ORDER",
+                    "entry_in_written_plan": plan_checks["entry_in_written_plan"],
+                    "stop_predefined": plan_checks["stop_predefined"],
+                    "size_within_plan": plan_checks["size_within_plan"],
+                    "planned_risk_dollars": planned_risk,
+                    "actual_risk_dollars": planned_risk,
+                    "notes": f"Fictional {journal_shares}-share plan; no order submitted.",
+                }
+            ]
+        },
+    )
+
+    reports = work / "reports"
+    reports.mkdir(parents=True)
+    journal_dir = work / "journal"
+    journal_dir.mkdir(parents=True)
+    _run_cli(
+        [
+            sys.executable,
+            str(
+                repo_root
+                / "skills"
+                / "pre-trade-discipline-gate"
+                / "scripts"
+                / "check_pre_trade_discipline.py"
+            ),
+            "--answers-file",
+            str(answers_path),
+            "--as-of",
+            spec["fixed_timestamp"],
+            "--market-regime-decision",
+            str(regime_path),
+            "--circuit-breaker-decision",
+            str(cb_path),
+            "--output-dir",
+            str(reports),
+            "--journal-dir",
+            str(journal_dir),
+        ],
+        repo_root,
+    )
+
+    artifacts = _artifact_paths(stage, step["output_files"])
+    source = _latest_report(reports, "pre_trade_discipline_decision_*.json")
+    payload = _canonicalize(
+        _load_json(source, "pre-trade discipline decision"),
+        spec["fixed_timestamp"],
+        {
+            str(regime_path): "00_exposure_decision.json",
+            str(cb_path): "01_circuit_breaker_decision.json",
+            str(reports): "$WORK/reports",
+            str(journal_dir): "$WORK/journal",
+        },
+    )
+    payload["artifact_paths"] = {
+        "json": "11_pre_trade_discipline_decision.json",
+        "markdown": "11_pre_trade_discipline_decision.md",
+    }
+    _write_json(Path(artifacts["pre_trade_discipline_decision"]["files"]["canonical"]), payload)
+    markdown_sources = sorted(reports.glob("pre_trade_discipline_decision_*.md"))
+    if not markdown_sources:
+        raise ReplayError("pre-trade discipline markdown report was not produced")
+    Path(artifacts["pre_trade_discipline_decision"]["files"]["companion"]).write_text(
+        markdown_sources[-1].read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return artifacts
+
+
+_swing_vcp_screen = _swing_screen_executor("vcp_candidates")
+_swing_momentum_burst = _swing_screen_executor("momentum_burst_candidates")
+_swing_exhaustion_hammer = _swing_screen_executor("exhaustion_hammer_candidates")
+_swing_canslim = _swing_screen_executor("canslim_candidates")
+_swing_theme = _swing_screen_executor("theme_candidates")
+
+
 EXECUTORS: dict[str, ExecutorRegistration] = {
     "stockbee_fluency_ingest": ExecutorRegistration("native_cli", _stockbee_ingest),
     "stockbee_fluency_update": ExecutorRegistration("native_cli", _stockbee_update),
@@ -3357,6 +4004,17 @@ EXECUTORS: dict[str, ExecutorRegistration] = {
     "monthly_backtest": ExecutorRegistration("native_cli", _monthly_backtest),
     "monthly_skill_review": ExecutorRegistration("native_cli", _monthly_skill_review),
     "monthly_decision_log": ExecutorRegistration("manual_contract", _monthly_decision_log),
+    "swing_theme": ExecutorRegistration("manual_contract", _swing_theme),
+    "swing_validate_setups": ExecutorRegistration("manual_contract", _swing_validate_setups),
+    "swing_position_size": ExecutorRegistration("native_cli", _swing_position_size),
+    "swing_build_plan": ExecutorRegistration("manual_contract", _swing_build_plan),
+    "swing_journal": ExecutorRegistration("manual_contract", _swing_journal),
+    "swing_discipline": ExecutorRegistration("native_cli", _swing_discipline),
+    "swing_circuit_breaker": ExecutorRegistration("native_cli", _swing_circuit_breaker),
+    "swing_vcp_screen": ExecutorRegistration("manual_contract", _swing_vcp_screen),
+    "swing_momentum_burst": ExecutorRegistration("manual_contract", _swing_momentum_burst),
+    "swing_exhaustion_hammer": ExecutorRegistration("manual_contract", _swing_exhaustion_hammer),
+    "swing_canslim": ExecutorRegistration("manual_contract", _swing_canslim),
 }
 
 


### PR DESCRIPTION
## Summary

Adds swing-opportunity-daily to the executable replay harness as the **7th covered workflow (7/11)**.

## Changes

- Native-cli/mixed executors for circuit breaker, position sizing, trade plan building, journaling, and pre-trade discipline gate
- Manual-contract screens (vcp, momentum, exhaustion, canslim, theme)
- Replay spec + offline fixtures + regenerated replay-run goldens
- **Fail-closed** symbol-matched setup/journal/discipline validation; honest NO_GO when no written plan exists
- Coverage bookkeeping 6/11 -> 7/11 across CI / README / replay-coverage

## Review

Addressed all prior review findings (P1-1, P1-2, P1-3, P2-1). Python 3.9.5: 204 tests pass, golden match confirmed, no monthly diff. Re-verified swing goldens reproduce byte-identically under CI Python 3.9.5.

Fix references: reviews/swing-replay-review-20260912.md, reviews/swing-replay-rereview-20260912.md